### PR TITLE
Enhance recommendations, bookmarks, and discovery

### DIFF
--- a/lib/app/app_startup.dart
+++ b/lib/app/app_startup.dart
@@ -1,7 +1,25 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// Placeholder for future startup tasks such as loading persisted settings,
-/// onboarding status checks, and initializing analytics.
+import '../features/onboarding/controller/onboarding_controller.dart';
+import '../features/policy/controller/policy_list_controller.dart';
+import '../features/profile/providers/user_preferences_provider.dart';
+
+/// Loads persisted onboarding and preference data so that routing and filters
+/// are hydrated before the rest of the app renders.
 final appStartupProvider = FutureProvider<void>((ref) async {
-  // TODO: implement startup initialization logic.
+  final snapshot = await UserPreferencesStorage.load();
+  ref.read(userRegionProvider.notifier).state = snapshot.region;
+  ref.read(userInterestsProvider.notifier).state = snapshot.interests;
+  ref.read(userAgeProvider.notifier).state = snapshot.age;
+
+  final onboardingNotifier = ref.read(onboardingStateProvider.notifier);
+  onboardingNotifier.state =
+      onboardingNotifier.state.copyWith(completed: snapshot.onboardingCompleted);
+
+  if (snapshot.region != null ||
+      snapshot.interests.isNotEmpty ||
+      snapshot.age != null) {
+    ref.read(policyFilterUseProfileProvider.notifier).state = true;
+    ref.read(policyFilterStateProvider.notifier).state = PolicyFilter.initial();
+  }
 });

--- a/lib/core/network/api_interceptor.dart
+++ b/lib/core/network/api_interceptor.dart
@@ -1,19 +1,36 @@
+import 'dart:developer';
+
 import 'package:dio/dio.dart';
 
+typedef TokenProvider = String? Function();
+
 class ApiInterceptor extends Interceptor {
+  ApiInterceptor({this.tokenProvider});
+
+  final TokenProvider? tokenProvider;
+
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    // TODO: attach auth headers or logging if needed.
+    final token = tokenProvider?.call();
+    if (token != null && token.isNotEmpty) {
+      options.headers['Authorization'] = 'Bearer $token';
+    }
+    log('➡️ ${options.method} ${options.uri}', name: 'ApiInterceptor');
     super.onRequest(options, handler);
   }
 
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) {
+    final code = err.response?.statusCode;
+    log('❌ ${code ?? 'ERR'} ${err.requestOptions.uri}: ${err.message}',
+        name: 'ApiInterceptor');
     super.onError(err, handler);
   }
 
   @override
   void onResponse(Response response, ResponseInterceptorHandler handler) {
+    log('✅ ${response.statusCode} ${response.requestOptions.uri}',
+        name: 'ApiInterceptor');
     super.onResponse(response, handler);
   }
 }

--- a/lib/features/bookmark/controller/bookmark_controller.dart
+++ b/lib/features/bookmark/controller/bookmark_controller.dart
@@ -1,30 +1,44 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../data/bookmark_local_datasource.dart';
+import '../data/bookmark_models.dart';
 import '../../policy/data/models/policy.dart';
 
-final bookmarkControllerProvider = AsyncNotifierProvider<BookmarkController, List<Policy>>(
+final bookmarkControllerProvider =
+    AsyncNotifierProvider<BookmarkController, List<BookmarkEntry>>(
   BookmarkController.new,
 );
 
-class BookmarkController extends AsyncNotifier<List<Policy>> {
+class BookmarkController extends AsyncNotifier<List<BookmarkEntry>> {
   late BookmarkLocalDataSource _dataSource;
 
   @override
-  Future<List<Policy>> build() async {
+  Future<List<BookmarkEntry>> build() async {
     _dataSource = await BookmarkLocalDataSource.create();
-    return _dataSource.getBookmarks();
+    return _dataSource.getBookmarkEntries();
   }
 
-  Future<void> toggle(Policy policy) async {
-    final updated = await _dataSource.toggleBookmark(policy);
+  Future<void> toggle(
+    Policy policy, {
+    BookmarkFolder folder = BookmarkFolder.favorite,
+  }) async {
+    final updated = await _dataSource.toggleBookmark(policy, folder: folder);
+    state = AsyncValue.data(updated);
+  }
+
+  Future<void> moveToFolder(String policyId, BookmarkFolder folder) async {
+    final updated = await _dataSource.updateFolder(policyId, folder);
     state = AsyncValue.data(updated);
   }
 
   bool isBookmarked(String policyId) {
     final cached = state.value;
     if (cached != null) {
-      return cached.any((policy) => policy.id == policyId);
+      return cached.any((entry) => entry.policy.id == policyId);
     }
     return _dataSource.isBookmarked(policyId);
+  }
+
+  BookmarkFolder? folderOf(String policyId) {
+    return _dataSource.folderOf(policyId);
   }
 }

--- a/lib/features/bookmark/data/bookmark_local_datasource.dart
+++ b/lib/features/bookmark/data/bookmark_local_datasource.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../policy/data/models/policy.dart';
+import 'bookmark_models.dart';
 
 class BookmarkLocalDataSource {
   BookmarkLocalDataSource._(this._prefs);
@@ -16,31 +17,66 @@ class BookmarkLocalDataSource {
     return BookmarkLocalDataSource._(prefs);
   }
 
-  List<Policy> getBookmarks() {
+  List<BookmarkEntry> getBookmarkEntries() {
     final raw = _prefs.getStringList(_storageKey) ?? const [];
     return raw
-        .map((item) => Policy.fromJson(jsonDecode(item) as Map<String, dynamic>))
+        .map((item) => BookmarkEntry.fromJson(
+              Map<String, dynamic>.from(jsonDecode(item) as Map<String, dynamic>),
+            ))
         .toList();
   }
 
-  Future<List<Policy>> toggleBookmark(Policy policy) async {
-    final current = getBookmarks();
-    final index = current.indexWhere((element) => element.id == policy.id);
+  Future<List<BookmarkEntry>> toggleBookmark(
+    Policy policy, {
+    BookmarkFolder folder = BookmarkFolder.favorite,
+  }) async {
+    final current = getBookmarkEntries();
+    final index = current.indexWhere((element) => element.policy.id == policy.id);
     if (index >= 0) {
       current.removeAt(index);
     } else {
-      current.add(policy);
+      current.add(
+        BookmarkEntry(
+          policy: policy,
+          folder: folder,
+          savedAt: DateTime.now(),
+        ),
+      );
     }
-    final encoded = current.map((p) => jsonEncode(p.toJson())).toList();
-    await _prefs.setStringList(_storageKey, encoded);
+    await _save(current);
+    return current;
+  }
+
+  Future<List<BookmarkEntry>> updateFolder(
+    String policyId,
+    BookmarkFolder folder,
+  ) async {
+    final current = getBookmarkEntries();
+    final index = current.indexWhere((element) => element.policy.id == policyId);
+    if (index >= 0) {
+      current[index] = current[index].copyWith(folder: folder);
+      await _save(current);
+    }
     return current;
   }
 
   bool isBookmarked(String policyId) {
-    final raw = _prefs.getStringList(_storageKey) ?? const [];
-    return raw.any((item) {
-      final decoded = jsonDecode(item) as Map<String, dynamic>;
-      return decoded['id'] == policyId;
-    });
+    final current = getBookmarkEntries();
+    return current.any((entry) => entry.policy.id == policyId);
+  }
+
+  BookmarkFolder? folderOf(String policyId) {
+    final current = getBookmarkEntries();
+    for (final entry in current) {
+      if (entry.policy.id == policyId) {
+        return entry.folder;
+      }
+    }
+    return null;
+  }
+
+  Future<void> _save(List<BookmarkEntry> entries) async {
+    final encoded = entries.map((entry) => jsonEncode(entry.toJson())).toList();
+    await _prefs.setStringList(_storageKey, encoded);
   }
 }

--- a/lib/features/bookmark/data/bookmark_models.dart
+++ b/lib/features/bookmark/data/bookmark_models.dart
@@ -1,0 +1,69 @@
+import '../../policy/data/models/policy.dart';
+
+enum BookmarkFolder { favorite, planning, pending }
+
+enum BookmarkSortOption { recent, region, category }
+
+extension BookmarkFolderLabel on BookmarkFolder {
+  String get label {
+    switch (this) {
+      case BookmarkFolder.favorite:
+        return '관심';
+      case BookmarkFolder.planning:
+        return '지원예정';
+      case BookmarkFolder.pending:
+        return '보류';
+    }
+  }
+}
+
+class BookmarkEntry {
+  final Policy policy;
+  final BookmarkFolder folder;
+  final DateTime savedAt;
+
+  const BookmarkEntry({
+    required this.policy,
+    required this.folder,
+    required this.savedAt,
+  });
+
+  BookmarkEntry copyWith({
+    BookmarkFolder? folder,
+    DateTime? savedAt,
+  }) {
+    return BookmarkEntry(
+      policy: policy,
+      folder: folder ?? this.folder,
+      savedAt: savedAt ?? this.savedAt,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'policy': policy.toJson(),
+      'folder': folder.name,
+      'savedAt': savedAt.toIso8601String(),
+    };
+  }
+
+  factory BookmarkEntry.fromJson(Map<String, dynamic> json) {
+    if (json.containsKey('policy')) {
+      return BookmarkEntry(
+        policy: Policy.fromJson(
+          Map<String, dynamic>.from(json['policy'] as Map<String, dynamic>),
+        ),
+        folder: BookmarkFolder.values
+            .firstWhere((folder) => folder.name == json['folder'], orElse: () => BookmarkFolder.favorite),
+        savedAt: DateTime.tryParse(json['savedAt'] as String? ?? '') ?? DateTime.now(),
+      );
+    }
+
+    // Legacy format: the entire JSON represents a Policy only.
+    return BookmarkEntry(
+      policy: Policy.fromJson(json),
+      folder: BookmarkFolder.favorite,
+      savedAt: DateTime.now(),
+    );
+  }
+}

--- a/lib/features/bookmark/presentation/bookmark_page.dart
+++ b/lib/features/bookmark/presentation/bookmark_page.dart
@@ -1,29 +1,235 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../controller/bookmark_controller.dart';
-import '../../policy/presentation/widgets/policy_card.dart';
+import 'package:go_router/go_router.dart';
 
-class BookmarkPage extends ConsumerWidget {
+import '../controller/bookmark_controller.dart';
+import '../data/bookmark_models.dart';
+
+class BookmarkPage extends ConsumerStatefulWidget {
   const BookmarkPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<BookmarkPage> createState() => _BookmarkPageState();
+}
+
+class _BookmarkPageState extends ConsumerState<BookmarkPage> {
+  BookmarkFolder? _folderFilter;
+  BookmarkSortOption _sort = BookmarkSortOption.recent;
+
+  @override
+  Widget build(BuildContext context) {
     final bookmarks = ref.watch(bookmarkControllerProvider);
     return Scaffold(
       appBar: AppBar(title: const Text('북마크')),
       body: bookmarks.when(
-        data: (items) => items.isEmpty
-            ? const Center(child: Text('북마크한 정책이 없습니다.'))
-            : ListView.builder(
-                itemCount: items.length,
-                itemBuilder: (context, index) {
-                  final policy = items[index];
-                  return PolicyCard(policy: policy);
-                },
+        data: (entries) {
+          final filtered = _applyFilters(entries);
+          return Column(
+            children: [
+              _FolderFilter(
+                selected: _folderFilter,
+                onSelected: (folder) => setState(() => _folderFilter = folder),
               ),
+              _SortSelector(
+                current: _sort,
+                onChanged: (sort) => setState(() => _sort = sort),
+              ),
+              const Divider(),
+              if (filtered.isEmpty)
+                const Expanded(
+                  child: Center(child: Text('선택한 조건에 맞는 북마크가 없습니다.')),
+                )
+              else
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: filtered.length,
+                    itemBuilder: (context, index) {
+                      final entry = filtered[index];
+                      return _BookmarkTile(
+                        entry: entry,
+                        onMove: (folder) => ref
+                            .read(bookmarkControllerProvider.notifier)
+                            .moveToFolder(entry.policy.id, folder),
+                        onRemove: () => ref
+                            .read(bookmarkControllerProvider.notifier)
+                            .toggle(entry.policy),
+                      );
+                    },
+                  ),
+                ),
+            ],
+          );
+        },
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (error, _) => Center(child: Text('북마크를 불러오지 못했습니다: $error')),
       ),
     );
   }
+
+  List<BookmarkEntry> _applyFilters(List<BookmarkEntry> entries) {
+    final filtered = _folderFilter == null
+        ? List<BookmarkEntry>.from(entries)
+        : entries
+            .where((entry) => entry.folder == _folderFilter)
+            .toList();
+    switch (_sort) {
+      case BookmarkSortOption.recent:
+        filtered.sort((a, b) => b.savedAt.compareTo(a.savedAt));
+        break;
+      case BookmarkSortOption.region:
+        filtered.sort((a, b) => a.policy.regionName.compareTo(b.policy.regionName));
+        break;
+      case BookmarkSortOption.category:
+        filtered.sort((a, b) {
+          final aCategory = a.policy.categories.isNotEmpty ? a.policy.categories.first : '';
+          final bCategory = b.policy.categories.isNotEmpty ? b.policy.categories.first : '';
+          return aCategory.compareTo(bCategory);
+        });
+        break;
+    }
+    return filtered;
+  }
 }
+
+class _FolderFilter extends StatelessWidget {
+  const _FolderFilter({required this.selected, required this.onSelected});
+
+  final BookmarkFolder? selected;
+  final ValueChanged<BookmarkFolder?> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Wrap(
+        spacing: 8,
+        children: [
+          ChoiceChip(
+            label: const Text('전체'),
+            selected: selected == null,
+            onSelected: (_) => onSelected(null),
+          ),
+          ...BookmarkFolder.values.map(
+            (folder) => ChoiceChip(
+              label: Text(folder.label),
+              selected: selected == folder,
+              onSelected: (_) => onSelected(folder),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SortSelector extends StatelessWidget {
+  const _SortSelector({required this.current, required this.onChanged});
+
+  final BookmarkSortOption current;
+  final ValueChanged<BookmarkSortOption> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text('정렬', style: Theme.of(context).textTheme.labelLarge),
+          DropdownButton<BookmarkSortOption>(
+            value: current,
+            items: const [
+              DropdownMenuItem(
+                value: BookmarkSortOption.recent,
+                child: Text('최근 저장 순'),
+              ),
+              DropdownMenuItem(
+                value: BookmarkSortOption.region,
+                child: Text('지역 순'),
+              ),
+              DropdownMenuItem(
+                value: BookmarkSortOption.category,
+                child: Text('카테고리 순'),
+              ),
+            ],
+            onChanged: (value) {
+              if (value != null) {
+                onChanged(value);
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BookmarkTile extends StatelessWidget {
+  const _BookmarkTile({
+    required this.entry,
+    required this.onMove,
+    required this.onRemove,
+  });
+
+  final BookmarkEntry entry;
+  final ValueChanged<BookmarkFolder> onMove;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: ListTile(
+        title: Text(entry.policy.title),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(entry.policy.summary, maxLines: 2, overflow: TextOverflow.ellipsis),
+            const SizedBox(height: 4),
+            Text('${entry.folder.label} • ${entry.policy.regionName}',
+                style: Theme.of(context).textTheme.bodySmall),
+          ],
+        ),
+        trailing: PopupMenuButton<_BookmarkAction>(
+          onSelected: (action) {
+            if (action == _BookmarkAction.remove) {
+              onRemove();
+            } else {
+              onMove(_actionToFolder(action));
+            }
+          },
+          itemBuilder: (context) => [
+            ...BookmarkFolder.values.map(
+              (folder) => PopupMenuItem<_BookmarkAction>(
+                value: _BookmarkAction.values
+                    .firstWhere((action) => action.name == folder.name),
+                child: Text('${folder.label} 폴더로 이동'),
+              ),
+            ),
+            const PopupMenuDivider(),
+            const PopupMenuItem<_BookmarkAction>(
+              value: _BookmarkAction.remove,
+              child: Text('삭제'),
+            ),
+          ],
+        ),
+        onTap: () => context.push('/home/policy/${entry.policy.id}'),
+      ),
+    );
+  }
+
+  BookmarkFolder _actionToFolder(_BookmarkAction action) {
+    switch (action) {
+      case _BookmarkAction.favorite:
+        return BookmarkFolder.favorite;
+      case _BookmarkAction.planning:
+        return BookmarkFolder.planning;
+      case _BookmarkAction.pending:
+        return BookmarkFolder.pending;
+      case _BookmarkAction.remove:
+        return entry.folder;
+    }
+  }
+}
+
+enum _BookmarkAction { favorite, planning, pending, remove }

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -1,12 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import '../policy/presentation/policy_list_page.dart';
 
-class HomePage extends StatelessWidget {
+import '../policy/controller/policy_list_controller.dart';
+import '../policy/controller/policy_engagement_controller.dart';
+import '../policy/data/models/policy.dart';
+import '../policy/presentation/widgets/policy_card.dart';
+import '../profile/providers/user_preferences_provider.dart';
+
+class HomePage extends ConsumerWidget {
   const HomePage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final policies = ref.watch(policyListControllerProvider);
+    final recent = ref.watch(policyEngagementControllerProvider);
+    final userRegion = ref.watch(userRegionProvider);
+    final userInterests = ref.watch(userInterestsProvider);
+    final recentPolicies = recent.maybeWhen(
+      data: (state) => state.recentPolicies,
+      orElse: () => const <Policy>[],
+    );
     return Scaffold(
       appBar: AppBar(
         title: const Text('추천 정책'),
@@ -25,7 +39,48 @@ class HomePage extends StatelessWidget {
           ),
         ],
       ),
-      body: const PolicyListPage(),
+      body: policies.when(
+        data: (items) => RefreshIndicator(
+          onRefresh: () async {
+            await ref.refresh(policyListControllerProvider.future);
+          },
+          child: ListView(
+            padding: const EdgeInsets.only(bottom: 24),
+            children: [
+              _PolicySection(
+                title: '맞춤 추천',
+                description: '관심 분야와 행동을 기반으로 선별했어요.',
+                policies: items.take(5).toList(),
+              ),
+              if (userRegion != null)
+                _PolicySection(
+                  title: '우리 지역 최신 정책',
+                  description: '선택한 지역의 최신 소식을 모았어요.',
+                  policies: _regionLatest(items, userRegion),
+                ),
+              _PolicySection(
+                title: '마감 임박',
+                description: '마감 전에 놓치지 마세요!',
+                policies: _closingSoon(items),
+              ),
+              if (userInterests.isNotEmpty)
+                _PolicySection(
+                  title: '관심사 추천',
+                  description: '관심 분야에서 새로 올라온 정책입니다.',
+                  policies: _interestPolicies(items, userInterests),
+                ),
+              if (recentPolicies.isNotEmpty)
+                _PolicySection(
+                  title: '최근 본 정책',
+                  description: '다시 확인할 수 있도록 모아두었습니다.',
+                  policies: recentPolicies,
+                ),
+            ],
+          ),
+        ),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(child: Text('정책을 불러오지 못했습니다: $error')),
+      ),
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: 0,
         onTap: (index) {
@@ -49,6 +104,87 @@ class HomePage extends StatelessWidget {
           BottomNavigationBarItem(icon: Icon(Icons.search), label: '검색'),
           BottomNavigationBarItem(icon: Icon(Icons.bookmark_border), label: '북마크'),
           BottomNavigationBarItem(icon: Icon(Icons.map), label: '지도'),
+        ],
+      ),
+    );
+  }
+
+  static List<Policy> _regionLatest(List<Policy> policies, String region) {
+    final filtered = policies.where((policy) => policy.regionCode == region).toList();
+    filtered.sort((a, b) {
+      final aDate = a.startDate ?? a.endDate ?? DateTime.fromMillisecondsSinceEpoch(0);
+      final bDate = b.startDate ?? b.endDate ?? DateTime.fromMillisecondsSinceEpoch(0);
+      return bDate.compareTo(aDate);
+    });
+    return filtered.take(5).toList();
+  }
+
+  static List<Policy> _closingSoon(List<Policy> policies) {
+    final now = DateTime.now();
+    final closings = policies
+        .where((policy) => policy.endDate != null && policy.endDate!.isAfter(now))
+        .toList();
+    closings.sort((a, b) => a.endDate!.compareTo(b.endDate!));
+    return closings.take(5).toList();
+  }
+
+  static List<Policy> _interestPolicies(
+    List<Policy> policies,
+    List<String> interests,
+  ) {
+    return policies
+        .where((policy) => policy.categories.any(interests.contains))
+        .take(5)
+        .toList();
+  }
+}
+
+class _PolicySection extends StatelessWidget {
+  const _PolicySection({
+    required this.title,
+    required this.description,
+    required this.policies,
+  });
+
+  final String title;
+  final String description;
+  final List<Policy> policies;
+
+  @override
+  Widget build(BuildContext context) {
+    if (policies.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title, style: Theme.of(context).textTheme.titleLarge),
+                const SizedBox(height: 4),
+                Text(description, style: Theme.of(context).textTheme.bodySmall),
+              ],
+            ),
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            height: 260,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              itemBuilder: (context, index) => SizedBox(
+                width: 320,
+                child: PolicyCard(policy: policies[index]),
+              ),
+              separatorBuilder: (_, __) => const SizedBox(width: 12),
+              itemCount: policies.length,
+            ),
+          ),
         ],
       ),
     );

--- a/lib/features/onboarding/presentation/onboarding_page.dart
+++ b/lib/features/onboarding/presentation/onboarding_page.dart
@@ -1,29 +1,64 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class OnboardingPage extends StatefulWidget {
+import '../../region/providers/providers.dart';
+import '../../policy/controller/policy_metadata_providers.dart';
+import '../../profile/providers/user_preferences_provider.dart';
+import '../../policy/controller/policy_list_controller.dart';
+import '../../policy/data/models/region.dart';
+import '../../policy/data/models/category.dart';
+import '../controller/onboarding_controller.dart';
+
+class OnboardingPage extends ConsumerStatefulWidget {
   const OnboardingPage({super.key});
 
   @override
-  State<OnboardingPage> createState() => _OnboardingPageState();
+  ConsumerState<OnboardingPage> createState() => _OnboardingPageState();
 }
 
-class _OnboardingPageState extends State<OnboardingPage> {
+class _OnboardingPageState extends ConsumerState<OnboardingPage> {
   int _step = 0;
   String? _selectedRegion;
-  final Set<String> _interests = {};
+  final Set<String> _interests = <String>{};
 
   void _next() {
     if (_step < 2) {
       setState(() => _step += 1);
     } else {
-      // TODO: persist onboarding data.
-      context.go('/home');
+      _completeOnboarding();
     }
+  }
+
+  Future<void> _completeOnboarding() async {
+    final region = _selectedRegion;
+    if (region == null) {
+      return;
+    }
+    final interests = List<String>.unmodifiable(_interests);
+    ref.read(userRegionProvider.notifier).state = region;
+    ref.read(userInterestsProvider.notifier).state = interests;
+    await UserPreferencesStorage.save(
+      region: region,
+      interests: interests,
+      onboardingCompleted: true,
+    );
+    ref.read(policyFilterUseProfileProvider.notifier).state = true;
+    ref.read(policyFilterStateProvider.notifier).state =
+        PolicyFilter.initial();
+    final onboardingNotifier = ref.read(onboardingStateProvider.notifier);
+    onboardingNotifier.state =
+        onboardingNotifier.state.copyWith(completed: true);
+    if (!mounted) {
+      return;
+    }
+    context.go('/home');
   }
 
   @override
   Widget build(BuildContext context) {
+    final regions = ref.watch(regionListProvider);
+    final categories = ref.watch(categoryListProvider);
     return Scaffold(
       appBar: AppBar(title: Text('온보딩 ${_step + 1}/3')),
       body: Padding(
@@ -33,16 +68,20 @@ class _OnboardingPageState extends State<OnboardingPage> {
           children: [
             _IntroStep(onNext: _next),
             _RegionStep(
+              regions: regions,
               selected: _selectedRegion,
               onSelected: (value) => setState(() => _selectedRegion = value),
             ),
             _InterestStep(
+              categories: categories,
               interests: _interests,
               onToggle: (value) {
                 setState(() {
-                  _interests.contains(value)
-                      ? _interests.remove(value)
-                      : _interests.add(value);
+                  if (_interests.contains(value)) {
+                    _interests.remove(value);
+                  } else {
+                    _interests.add(value);
+                  }
                 });
               },
             ),
@@ -53,7 +92,8 @@ class _OnboardingPageState extends State<OnboardingPage> {
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: ElevatedButton(
-            onPressed: (_step == 1 && _selectedRegion == null) ? null : _next,
+            onPressed:
+                (_step == 1 && _selectedRegion == null) ? null : _next,
             child: Text(_step < 2 ? '다음' : '완료'),
           ),
         ),
@@ -85,7 +125,13 @@ class _IntroStep extends StatelessWidget {
 }
 
 class _RegionStep extends StatelessWidget {
-  const _RegionStep({required this.selected, required this.onSelected});
+  const _RegionStep({
+    required this.regions,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  final AsyncValue<List<Region>> regions;
   final String? selected;
   final ValueChanged<String> onSelected;
 
@@ -94,22 +140,29 @@ class _RegionStep extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text('지역을 선택하세요 (Unity 연동 예정)', style: TextStyle(fontSize: 20)),
+        const Text('지역을 선택하세요 (Unity 연동 예정)',
+            style: TextStyle(fontSize: 20)),
         const SizedBox(height: 16),
-        Wrap(
-          spacing: 12,
-          children: [
-            '경산시',
-            '포항시',
-            '경주시',
-          ].map((r) {
-            final isSelected = r == selected;
-            return ChoiceChip(
-              label: Text(r),
-              selected: isSelected,
-              onSelected: (_) => onSelected(r),
+        regions.when(
+          data: (items) {
+            if (items.isEmpty) {
+              return const Text('선택 가능한 지역 정보가 없습니다.');
+            }
+            return Wrap(
+              spacing: 12,
+              runSpacing: 8,
+              children: items.map((region) {
+                final isSelected = region.code == selected;
+                return ChoiceChip(
+                  label: Text(region.name),
+                  selected: isSelected,
+                  onSelected: (_) => onSelected(region.code),
+                );
+              }).toList(),
             );
-          }).toList(),
+          },
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (error, _) => Text('지역 정보를 불러오지 못했습니다: $error'),
         ),
         const Spacer(),
         const Text('Unity 지도에서 REGION_SELECTED 메시지를 수신해 연동합니다.'),
@@ -119,36 +172,43 @@ class _RegionStep extends StatelessWidget {
 }
 
 class _InterestStep extends StatelessWidget {
-  const _InterestStep({required this.interests, required this.onToggle});
+  const _InterestStep({
+    required this.categories,
+    required this.interests,
+    required this.onToggle,
+  });
+
+  final AsyncValue<List<Category>> categories;
   final Set<String> interests;
   final ValueChanged<String> onToggle;
 
   @override
   Widget build(BuildContext context) {
-    final items = [
-      '일자리·취업',
-      '창업',
-      '주거',
-      '생활·복지',
-      '교육·역량',
-      '문화·여가',
-      '기타',
-    ];
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const Text('관심 분야를 선택하세요', style: TextStyle(fontSize: 20)),
         const SizedBox(height: 16),
-        Wrap(
-          spacing: 12,
-          runSpacing: 8,
-          children: items
-              .map((e) => FilterChip(
-                    label: Text(e),
-                    selected: interests.contains(e),
-                    onSelected: (_) => onToggle(e),
-                  ))
-              .toList(),
+        categories.when(
+          data: (items) {
+            if (items.isEmpty) {
+              return const Text('선택 가능한 관심 분야가 없습니다.');
+            }
+            return Wrap(
+              spacing: 12,
+              runSpacing: 8,
+              children: items.map((category) {
+                final selected = interests.contains(category.code);
+                return FilterChip(
+                  label: Text(category.name),
+                  selected: selected,
+                  onSelected: (_) => onToggle(category.code),
+                );
+              }).toList(),
+            );
+          },
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (error, _) => Text('관심 분야 정보를 불러오지 못했습니다: $error'),
         ),
       ],
     );

--- a/lib/features/onboarding/presentation/splash_page.dart
+++ b/lib/features/onboarding/presentation/splash_page.dart
@@ -1,14 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class SplashPage extends StatelessWidget {
+import '../controller/onboarding_controller.dart';
+
+class SplashPage extends ConsumerWidget {
   const SplashPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final onboardingState = ref.watch(onboardingStateProvider);
     Future.microtask(() {
-      // TODO: replace with onboarding completion check.
-      context.go('/onboarding');
+      if (!context.mounted) return;
+      final nextRoute = onboardingState.completed ? '/home' : '/onboarding';
+      context.go(nextRoute);
     });
     return const Scaffold(
       body: Center(child: CircularProgressIndicator()),

--- a/lib/features/policy/controller/policy_detail_controller.dart
+++ b/lib/features/policy/controller/policy_detail_controller.dart
@@ -17,3 +17,16 @@ class PolicyDetailController extends AutoDisposeFamilyAsyncNotifier<Policy, Stri
     return _repository.getPolicyDetail(arg);
   }
 }
+
+final relatedPoliciesProvider = FutureProvider.autoDispose.family<List<Policy>, Policy>(
+  (ref, policy) async {
+    final repository = ref.watch(policyRepositoryProvider);
+    final candidates = await repository.getPolicies(
+      region: policy.regionCode,
+      categories: policy.categories.isEmpty ? null : policy.categories,
+      size: 20,
+    );
+    final filtered = candidates.where((item) => item.id != policy.id).toList();
+    return filtered.take(6).toList();
+  },
+);

--- a/lib/features/policy/controller/policy_engagement_controller.dart
+++ b/lib/features/policy/controller/policy_engagement_controller.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/models/policy.dart';
+import '../data/user_engagement_storage.dart';
+
+class PolicyEngagementState {
+  final Map<String, int> clickCounts;
+  final List<Policy> recentPolicies;
+
+  const PolicyEngagementState({
+    this.clickCounts = const {},
+    this.recentPolicies = const [],
+  });
+
+  PolicyEngagementState copyWith({
+    Map<String, int>? clickCounts,
+    List<Policy>? recentPolicies,
+  }) {
+    return PolicyEngagementState(
+      clickCounts: clickCounts ?? this.clickCounts,
+      recentPolicies: recentPolicies ?? this.recentPolicies,
+    );
+  }
+
+  Set<String> get recentPolicyIds => recentPolicies.map((policy) => policy.id).toSet();
+}
+
+final policyEngagementControllerProvider =
+    AsyncNotifierProvider<PolicyEngagementController, PolicyEngagementState>(
+  PolicyEngagementController.new,
+);
+
+class PolicyEngagementController extends AsyncNotifier<PolicyEngagementState> {
+  late PolicyEngagementStorage _storage;
+
+  @override
+  Future<PolicyEngagementState> build() async {
+    _storage = await PolicyEngagementStorage.create();
+    return PolicyEngagementState(
+      clickCounts: _storage.loadClickCounts(),
+      recentPolicies: _storage.loadRecentPolicies(),
+    );
+  }
+
+  Future<void> recordClick(Policy policy) async {
+    final current = state.value ?? await future;
+    final updated = Map<String, int>.from(current.clickCounts);
+    updated.update(policy.id, (value) => value + 1, ifAbsent: () => 1);
+    await _storage.saveClickCounts(updated);
+    state = AsyncValue.data(current.copyWith(clickCounts: updated));
+  }
+
+  Future<void> recordView(Policy policy) async {
+    final current = state.value ?? await future;
+    final recent = List<Policy>.from(current.recentPolicies);
+    recent.removeWhere((element) => element.id == policy.id);
+    recent.insert(0, policy);
+    if (recent.length > PolicyEngagementStorage.recentLimit) {
+      recent.removeRange(PolicyEngagementStorage.recentLimit, recent.length);
+    }
+    await _storage.saveRecentPolicies(recent);
+    state = AsyncValue.data(current.copyWith(recentPolicies: recent));
+  }
+}

--- a/lib/features/policy/controller/policy_list_controller.dart
+++ b/lib/features/policy/controller/policy_list_controller.dart
@@ -2,6 +2,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../data/policy_repository.dart';
 import '../data/models/policy.dart';
 import '../../../providers/global_providers.dart';
+import '../../profile/providers/user_preferences_provider.dart';
+import '../../bookmark/controller/bookmark_controller.dart';
+import 'policy_engagement_controller.dart';
 
 class PolicyFilter {
   final String? region;
@@ -33,8 +36,34 @@ class PolicyFilter {
   factory PolicyFilter.initial() => const PolicyFilter();
 }
 
-final filterStateProvider = StateProvider<PolicyFilter>((ref) {
+final policyFilterStateProvider = StateProvider<PolicyFilter>((ref) {
   return PolicyFilter.initial();
+});
+
+/// Indicates whether global filters should fall back to the user's profile.
+final policyFilterUseProfileProvider = StateProvider<bool>((ref) => true);
+
+/// Combines explicit filter overrides with the user's onboarding profile.
+final policyFilterProvider = Provider<PolicyFilter>((ref) {
+  final overrides = ref.watch(policyFilterStateProvider);
+  final useProfile = ref.watch(policyFilterUseProfileProvider);
+  final userRegion = ref.watch(userRegionProvider);
+  final userAge = ref.watch(userAgeProvider);
+  final userInterests = ref.watch(userInterestsProvider);
+
+  if (!useProfile) {
+    return overrides;
+  }
+
+  final resolvedCategories = overrides.categories.isNotEmpty
+      ? overrides.categories
+      : userInterests;
+
+  return overrides.copyWith(
+    region: overrides.region ?? userRegion,
+    age: overrides.age ?? userAge,
+    categories: resolvedCategories,
+  );
 });
 
 final policyListControllerProvider =
@@ -47,7 +76,9 @@ class PolicyListController extends AutoDisposeAsyncNotifier<List<Policy>> {
   @override
   Future<List<Policy>> build() async {
     _repository = ref.watch(policyRepositoryProvider);
-    final filter = ref.watch(filterStateProvider);
+    final filter = ref.watch(policyFilterProvider);
+    final engagement = ref.watch(policyEngagementControllerProvider);
+    final bookmarked = ref.watch(bookmarkControllerProvider);
     final categories = filter.categories.isEmpty ? null : filter.categories;
     final status = (filter.status == null || filter.status!.isEmpty)
         ? null
@@ -58,12 +89,43 @@ class PolicyListController extends AutoDisposeAsyncNotifier<List<Policy>> {
       categories: categories,
       status: status,
     );
-    return _sortedByScore(policies, filter.categories);
+    final engagementState = engagement.maybeWhen(
+      data: (value) => value,
+      orElse: () => const PolicyEngagementState(),
+    );
+    final bookmarkedIds = bookmarked.maybeWhen(
+      data: (entries) => entries.map((entry) => entry.policy.id).toSet(),
+      orElse: () => <String>{},
+    );
+    return _sortedByScore(
+      policies,
+      filter,
+      engagementState,
+      bookmarkedIds,
+    );
   }
 
-  List<Policy> _sortedByScore(List<Policy> policies, List<String> interests) {
+  List<Policy> _sortedByScore(
+    List<Policy> policies,
+    PolicyFilter filter,
+    PolicyEngagementState engagementState,
+    Set<String> bookmarkedIds,
+  ) {
+    final interests = filter.categories;
     final scored = policies
-        .map((p) => MapEntry(p, computePolicyScore(p, interests)))
+        .map(
+          (p) => MapEntry(
+            p,
+            computePolicyScore(
+              p,
+              interests,
+              preferredRegion: filter.region,
+              recentPolicyIds: engagementState.recentPolicyIds,
+              bookmarkedIds: bookmarkedIds,
+              clickCounts: engagementState.clickCounts,
+            ),
+          ),
+        )
         .toList();
     scored.sort((a, b) => b.value.compareTo(a.value));
     return scored.map((e) => e.key).toList();

--- a/lib/features/policy/data/models/policy.dart
+++ b/lib/features/policy/data/models/policy.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'region.dart';
 import 'category.dart';
 
@@ -98,22 +100,46 @@ class Policy {
 }
 
 /// Helper to compute recommendation score based on user interests and policy metadata.
-double computePolicyScore(Policy policy, List<String> userInterests) {
+double computePolicyScore(
+  Policy policy,
+  List<String> userInterests, {
+  String? preferredRegion,
+  Set<String>? recentPolicyIds,
+  Set<String>? bookmarkedIds,
+  Map<String, int>? clickCounts,
+}) {
   double score = policy.priority.toDouble();
   final overlap = policy.categories.where(userInterests.contains).length;
-  score += overlap * 10;
+  score += overlap * 12;
+
+  if (preferredRegion != null && policy.regionCode == preferredRegion) {
+    score += 18;
+  }
 
   if (policy.endDate != null) {
     final daysLeft = policy.endDate!.difference(DateTime.now()).inDays;
     if (daysLeft >= 0 && daysLeft <= 7) {
-      score += 20;
+      score += 25;
     } else if (daysLeft <= 30) {
-      score += 10;
+      score += 12;
     }
   }
 
   if (policy.isNew) {
     score += 15;
+  }
+
+  if (recentPolicyIds?.contains(policy.id) ?? false) {
+    score += 8;
+  }
+
+  if (bookmarkedIds?.contains(policy.id) ?? false) {
+    score += 30;
+  }
+
+  if (clickCounts != null && clickCounts.containsKey(policy.id)) {
+    final clicks = clickCounts[policy.id] ?? 0;
+    score += min(clicks, 5) * 3;
   }
 
   return score;

--- a/lib/features/policy/data/user_engagement_storage.dart
+++ b/lib/features/policy/data/user_engagement_storage.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'models/policy.dart';
+
+class PolicyEngagementStorage {
+  PolicyEngagementStorage._(this._prefs);
+
+  static const _clickCountsKey = 'policy_click_counts';
+  static const _recentPoliciesKey = 'recent_policies';
+  static const recentLimit = 10;
+
+  final SharedPreferences _prefs;
+
+  static Future<PolicyEngagementStorage> create() async {
+    final prefs = await SharedPreferences.getInstance();
+    return PolicyEngagementStorage._(prefs);
+  }
+
+  Map<String, int> loadClickCounts() {
+    final raw = _prefs.getString(_clickCountsKey);
+    if (raw == null || raw.isEmpty) {
+      return <String, int>{};
+    }
+    final decoded = jsonDecode(raw) as Map<String, dynamic>;
+    return decoded.map((key, value) => MapEntry(key, value as int));
+  }
+
+  Future<void> saveClickCounts(Map<String, int> counts) async {
+    await _prefs.setString(_clickCountsKey, jsonEncode(counts));
+  }
+
+  List<Policy> loadRecentPolicies() {
+    final raw = _prefs.getStringList(_recentPoliciesKey) ?? const [];
+    return raw
+        .map((item) => Policy.fromJson(jsonDecode(item) as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<void> saveRecentPolicies(List<Policy> policies) async {
+    final encoded = policies.map((policy) => jsonEncode(policy.toJson())).toList();
+    await _prefs.setStringList(_recentPoliciesKey, encoded);
+  }
+}

--- a/lib/features/policy/presentation/policy_detail_page.dart
+++ b/lib/features/policy/presentation/policy_detail_page.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 import '../../bookmark/controller/bookmark_controller.dart';
+import '../../bookmark/data/bookmark_models.dart';
 import '../controller/policy_detail_controller.dart';
 import '../controller/policy_list_controller.dart';
+import '../controller/policy_engagement_controller.dart';
+import 'widgets/policy_card.dart';
 
 class PolicyDetailPage extends ConsumerWidget {
   const PolicyDetailPage({super.key, required this.policyId});
@@ -18,11 +22,14 @@ class PolicyDetailPage extends ConsumerWidget {
       appBar: AppBar(title: const Text('정책 상세')),
       body: policyAsync.when(
         data: (policy) {
+          ref.read(policyEngagementControllerProvider.notifier).recordView(policy);
           final bookmarkController = ref.read(bookmarkControllerProvider.notifier);
-          final isBookmarked = ref.watch(bookmarkControllerProvider).maybeWhen(
-                data: (items) => items.any((item) => item.id == policy.id),
+          final bookmarks = ref.watch(bookmarkControllerProvider);
+          final isBookmarked = bookmarks.maybeWhen(
+                data: (items) => items.any((item) => item.policy.id == policy.id),
                 orElse: () => false,
               );
+          final related = ref.watch(relatedPoliciesProvider(policy));
           return Padding(
             padding: const EdgeInsets.all(16),
             child: ListView(
@@ -56,6 +63,13 @@ class PolicyDetailPage extends ConsumerWidget {
                       : () => launchUrlString(policy.applicationUrl, mode: LaunchMode.externalApplication),
                   child: const Text('신청 페이지 열기'),
                 ),
+                TextButton.icon(
+                  onPressed: policy.applicationUrl.isEmpty
+                      ? null
+                      : () => _sharePolicy(context, policy.applicationUrl),
+                  icon: const Icon(Icons.share),
+                  label: const Text('링크 공유'),
+                ),
                 const SizedBox(height: 12),
                 Text('문의처: ${policy.contact}'),
                 if (policy.endDate != null)
@@ -66,12 +80,14 @@ class PolicyDetailPage extends ConsumerWidget {
                 const SizedBox(height: 24),
                 ElevatedButton.icon(
                   onPressed: () async {
-                    await bookmarkController.toggle(policy);
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text(isBookmarked ? '북마크에서 제거되었습니다.' : '북마크에 추가되었습니다.'),
-                      ),
-                    );
+                    if (isBookmarked) {
+                      await bookmarkController.toggle(policy);
+                      _showSnack(context, '북마크에서 제거되었습니다.');
+                    } else {
+                      final folder = await _pickFolder(context) ?? BookmarkFolder.favorite;
+                      await bookmarkController.toggle(policy, folder: folder);
+                      _showSnack(context, '${folder.label} 폴더에 추가되었습니다.');
+                    }
                   },
                   icon: Icon(isBookmarked ? Icons.bookmark : Icons.bookmark_border),
                   label: Text(isBookmarked ? '북마크 해제' : '북마크 추가'),
@@ -79,8 +95,14 @@ class PolicyDetailPage extends ConsumerWidget {
                 const SizedBox(height: 8),
                 OutlinedButton.icon(
                   onPressed: () {
-                    ref.read(filterStateProvider.notifier).state =
-                        ref.read(filterStateProvider.notifier).state.copyWith(region: policy.regionCode);
+                    ref
+                        .read(policyFilterUseProfileProvider.notifier)
+                        .state = false;
+                    ref.read(policyFilterStateProvider.notifier).state =
+                        ref
+                            .read(policyFilterStateProvider.notifier)
+                            .state
+                            .copyWith(region: policy.regionCode);
                     context.push(
                       '/home/unity-map',
                       extra: {
@@ -92,6 +114,27 @@ class PolicyDetailPage extends ConsumerWidget {
                   icon: const Icon(Icons.map),
                   label: const Text('지도에서 위치 보기'),
                 ),
+                const SizedBox(height: 24),
+                Text('연관 정책 추천', style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 8),
+                SizedBox(
+                  height: 250,
+                  child: related.when(
+                    data: (items) => items.isEmpty
+                        ? const Center(child: Text('연관 정책이 없습니다.'))
+                        : ListView.separated(
+                            scrollDirection: Axis.horizontal,
+                            itemBuilder: (context, index) => SizedBox(
+                              width: 320,
+                              child: PolicyCard(policy: items[index]),
+                            ),
+                            separatorBuilder: (_, __) => const SizedBox(width: 12),
+                            itemCount: items.length,
+                          ),
+                    loading: () => const Center(child: CircularProgressIndicator()),
+                    error: (e, _) => Center(child: Text('연관 정책을 불러오지 못했습니다: $e')),
+                  ),
+                ),
               ],
             ),
           );
@@ -99,6 +142,38 @@ class PolicyDetailPage extends ConsumerWidget {
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => Center(child: Text('불러오지 못했습니다: $e')),
       ),
+    );
+  }
+
+  Future<BookmarkFolder?> _pickFolder(BuildContext context) {
+    return showModalBottomSheet<BookmarkFolder>(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: BookmarkFolder.values
+                .map(
+                  (folder) => ListTile(
+                    title: Text(folder.label),
+                    onTap: () => Navigator.of(context).pop(folder),
+                  ),
+                )
+                .toList(),
+          ),
+        );
+      },
+    );
+  }
+
+  void _sharePolicy(BuildContext context, String url) {
+    Clipboard.setData(ClipboardData(text: url));
+    _showSnack(context, '링크가 복사되었습니다. 원하는 채팅 앱에 붙여넣어 공유하세요.');
+  }
+
+  void _showSnack(BuildContext context, String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
     );
   }
 }

--- a/lib/features/policy/presentation/policy_list_page.dart
+++ b/lib/features/policy/presentation/policy_list_page.dart
@@ -11,7 +11,7 @@ class PolicyListPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final policiesAsync = ref.watch(policyListControllerProvider);
-    final filter = ref.watch(filterStateProvider);
+    final filter = ref.watch(policyFilterProvider);
     return RefreshIndicator(
       onRefresh: () => ref.refresh(policyListControllerProvider.future),
       child: CustomScrollView(
@@ -90,7 +90,9 @@ class _FilterSection extends ConsumerWidget {
                 Text('필터', style: Theme.of(context).textTheme.titleMedium),
                 TextButton(
                   onPressed: () {
-                    ref.read(filterStateProvider.notifier).state =
+                    ref.read(policyFilterUseProfileProvider.notifier).state =
+                        true;
+                    ref.read(policyFilterStateProvider.notifier).state =
                         PolicyFilter.initial();
                   },
                   child: const Text('초기화'),
@@ -117,7 +119,9 @@ class _FilterSection extends ConsumerWidget {
                     ),
                   ],
                   onChanged: (value) {
-                    final notifier = ref.read(filterStateProvider.notifier);
+                    ref.read(policyFilterUseProfileProvider.notifier).state =
+                        false;
+                    final notifier = ref.read(policyFilterStateProvider.notifier);
                     notifier.state = notifier.state.copyWith(region: value);
                   },
                 );
@@ -140,7 +144,8 @@ class _FilterSection extends ConsumerWidget {
                 ),
               ],
               onChanged: (value) {
-                final notifier = ref.read(filterStateProvider.notifier);
+                ref.read(policyFilterUseProfileProvider.notifier).state = false;
+                final notifier = ref.read(policyFilterStateProvider.notifier);
                 notifier.state = notifier.state.copyWith(status: value);
               },
             ),
@@ -157,7 +162,10 @@ class _FilterSection extends ConsumerWidget {
                     label: Text(category.name),
                     selected: selected,
                     onSelected: (value) {
-                      final notifier = ref.read(filterStateProvider.notifier);
+                      ref
+                          .read(policyFilterUseProfileProvider.notifier)
+                          .state = false;
+                      final notifier = ref.read(policyFilterStateProvider.notifier);
                       final current = [...notifier.state.categories];
                       if (value) {
                         if (!current.contains(category.code)) {

--- a/lib/features/policy/presentation/widgets/policy_card.dart
+++ b/lib/features/policy/presentation/widgets/policy_card.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../bookmark/controller/bookmark_controller.dart';
+import '../../../bookmark/data/bookmark_models.dart';
+import '../../controller/policy_engagement_controller.dart';
 import '../../data/models/policy.dart';
 
 class PolicyCard extends ConsumerWidget {
@@ -13,7 +15,7 @@ class PolicyCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final bookmarks = ref.watch(bookmarkControllerProvider);
     final isBookmarked = bookmarks.maybeWhen(
-      data: (items) => items.any((item) => item.id == policy.id),
+      data: (items) => items.any((item) => item.policy.id == policy.id),
       orElse: () => false,
     );
 
@@ -35,9 +37,7 @@ class PolicyCard extends ConsumerWidget {
             IconButton(
               icon: Icon(isBookmarked ? Icons.bookmark : Icons.bookmark_border),
               tooltip: isBookmarked ? '북마크 해제' : '북마크 추가',
-              onPressed: () {
-                ref.read(bookmarkControllerProvider.notifier).toggle(policy);
-              },
+              onPressed: () => _handleBookmarkTap(context, ref, isBookmarked),
             ),
             if (policy.isNew)
               const Chip(
@@ -51,8 +51,54 @@ class PolicyCard extends ConsumerWidget {
               ),
           ],
         ),
-        onTap: () => context.push('/home/policy/${policy.id}'),
+        onTap: () {
+          ref.read(policyEngagementControllerProvider.notifier).recordClick(policy);
+          context.push('/home/policy/${policy.id}');
+        },
       ),
+    );
+  }
+
+  Future<void> _handleBookmarkTap(
+    BuildContext context,
+    WidgetRef ref,
+    bool isBookmarked,
+  ) async {
+    final controller = ref.read(bookmarkControllerProvider.notifier);
+    if (isBookmarked) {
+      await controller.toggle(policy);
+      _showSnack(context, '북마크에서 제거했습니다.');
+      return;
+    }
+    final folder = await _pickFolder(context) ?? BookmarkFolder.favorite;
+    await controller.toggle(policy, folder: folder);
+    _showSnack(context, '${folder.label} 폴더에 저장했습니다.');
+  }
+
+  Future<BookmarkFolder?> _pickFolder(BuildContext context) {
+    return showModalBottomSheet<BookmarkFolder>(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: BookmarkFolder.values
+                .map(
+                  (folder) => ListTile(
+                    title: Text(folder.label),
+                    onTap: () => Navigator.of(context).pop(folder),
+                  ),
+                )
+                .toList(),
+          ),
+        );
+      },
+    );
+  }
+
+  void _showSnack(BuildContext context, String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
     );
   }
 }

--- a/lib/features/profile/providers/user_preferences_provider.dart
+++ b/lib/features/profile/providers/user_preferences_provider.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Stores the region code selected by the user during onboarding/profile edits.
+final userRegionProvider = StateProvider<String?>((ref) => null);
+
+/// Stores the interest category codes selected by the user.
+final userInterestsProvider = StateProvider<List<String>>((ref) => const []);
+
+/// Stores the preferred age (if provided) to drive policy filtering.
+final userAgeProvider = StateProvider<int?>((ref) => null);
+
+class UserPreferencesSnapshot {
+  final String? region;
+  final List<String> interests;
+  final int? age;
+  final bool onboardingCompleted;
+
+  const UserPreferencesSnapshot({
+    this.region,
+    this.interests = const [],
+    this.age,
+    this.onboardingCompleted = false,
+  });
+}
+
+class UserPreferencesStorage {
+  static const _regionKey = 'user_region';
+  static const _interestsKey = 'user_interests';
+  static const _ageKey = 'user_age';
+  static const _onboardingKey = 'onboarding_completed';
+
+  static Future<UserPreferencesSnapshot> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    return UserPreferencesSnapshot(
+      region: prefs.getString(_regionKey),
+      interests:
+          List.unmodifiable(prefs.getStringList(_interestsKey) ?? const []),
+      age: prefs.getInt(_ageKey),
+      onboardingCompleted: prefs.getBool(_onboardingKey) ?? false,
+    );
+  }
+
+  static Future<void> save({
+    String? region,
+    List<String>? interests,
+    int? age,
+    bool? onboardingCompleted,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (region != null) {
+      await prefs.setString(_regionKey, region);
+    }
+    if (interests != null) {
+      await prefs.setStringList(_interestsKey, List<String>.from(interests));
+    }
+    if (age != null) {
+      await prefs.setInt(_ageKey, age);
+    }
+    if (onboardingCompleted != null) {
+      await prefs.setBool(_onboardingKey, onboardingCompleted);
+    }
+  }
+}

--- a/lib/features/search/controller/policy_search_controller.dart
+++ b/lib/features/search/controller/policy_search_controller.dart
@@ -2,7 +2,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../policy/data/policy_repository.dart';
 import '../../policy/data/models/policy.dart';
 import '../../policy/controller/policy_list_controller.dart';
+import '../../policy/controller/policy_engagement_controller.dart';
+import '../../bookmark/controller/bookmark_controller.dart';
+import '../../policy/controller/policy_metadata_providers.dart';
 import '../../../providers/global_providers.dart';
+import '../../policy/data/models/category.dart';
 
 class PolicySearchParams {
   final String? query;
@@ -34,40 +38,129 @@ class PolicySearchController extends AutoDisposeAsyncNotifier<List<Policy>> {
   @override
   Future<List<Policy>> build() async {
     _repository = ref.watch(policyRepositoryProvider);
-    final globalFilter = ref.watch(filterStateProvider);
+    final globalFilter = ref.watch(policyFilterProvider);
+    final engagement = ref.watch(policyEngagementControllerProvider);
+    final bookmarked = ref.watch(bookmarkControllerProvider);
+    final categoriesMeta = await ref.watch(categoryListProvider.future);
     final region = _params.region ?? globalFilter.region;
-    final categories =
-        _params.categories.isNotEmpty ? _params.categories : globalFilter.categories;
+    final tagMatches = _extractTags(_params.query, categoriesMeta);
+    final categories = _resolveCategories(globalFilter.categories, tagMatches);
+    final overrides =
+        _params.categories.isNotEmpty ? _params.categories : categories.toList();
+    final effectiveCategories = overrides.toSet()..addAll(tagMatches);
     final status = _params.status ?? globalFilter.status;
 
     final results = await _repository.getPolicies(
       region: region,
-      categories: categories.isEmpty ? null : categories,
+      categories: effectiveCategories.isEmpty ? null : effectiveCategories.toList(),
       status: (status == null || status.isEmpty) ? null : status,
     );
-    final filtered = _applyTextQuery(results, _params.query);
-    final interests = categories.isNotEmpty ? categories : globalFilter.categories;
-    return _sortByRecommendation(filtered, interests);
+    final filtered = _applyTextQuery(results, _params.query, tagMatches);
+    final engagementState = engagement.maybeWhen(
+      data: (value) => value,
+      orElse: () => const PolicyEngagementState(),
+    );
+    final bookmarkedIds = bookmarked.maybeWhen(
+      data: (entries) => entries.map((entry) => entry.policy.id).toSet(),
+      orElse: () => <String>{},
+    );
+    final interestSeed = effectiveCategories.isNotEmpty
+        ? effectiveCategories.toList()
+        : globalFilter.categories;
+    return _sortByRecommendation(
+      filtered,
+      interestSeed,
+      region,
+      engagementState,
+      bookmarkedIds,
+    );
   }
 
-  List<Policy> _applyTextQuery(List<Policy> policies, String? query) {
+  List<Policy> _applyTextQuery(
+    List<Policy> policies,
+    String? query,
+    List<String> tagMatches,
+  ) {
     if (query == null || query.trim().isEmpty) {
       return policies;
     }
-    final lowerQuery = query.toLowerCase();
-    return policies
-        .where((policy) =>
-            policy.title.toLowerCase().contains(lowerQuery) ||
-            policy.summary.toLowerCase().contains(lowerQuery) ||
-            policy.description.toLowerCase().contains(lowerQuery))
+    final cleanedKeywords = _normalizeQuery(query)
+        .split(RegExp(r'\s+'))
+        .where((keyword) => keyword.isNotEmpty && !keyword.startsWith('#'))
+        .map((keyword) => keyword.toLowerCase())
         .toList();
+    return policies.where((policy) {
+      final textBank =
+          '${policy.title} ${policy.summary} ${policy.description}'.toLowerCase();
+      final matchesKeyword = cleanedKeywords.isEmpty
+          ? true
+          : cleanedKeywords.any((keyword) => textBank.contains(keyword));
+      final matchesTags = tagMatches.isEmpty
+          ? true
+          : tagMatches.every((tag) => policy.categories.contains(tag));
+      return matchesKeyword && matchesTags;
+    }).toList();
   }
 
-  List<Policy> _sortByRecommendation(List<Policy> policies, List<String> interests) {
+  List<Policy> _sortByRecommendation(
+    List<Policy> policies,
+    List<String> interests,
+    String? region,
+    PolicyEngagementState engagementState,
+    Set<String> bookmarkedIds,
+  ) {
     final scored = policies
-        .map((policy) => MapEntry(policy, computePolicyScore(policy, interests)))
+        .map(
+          (policy) => MapEntry(
+            policy,
+            computePolicyScore(
+              policy,
+              interests,
+              preferredRegion: region,
+              recentPolicyIds: engagementState.recentPolicyIds,
+              bookmarkedIds: bookmarkedIds,
+              clickCounts: engagementState.clickCounts,
+            ),
+          ),
+        )
         .toList();
     scored.sort((a, b) => b.value.compareTo(a.value));
     return scored.map((entry) => entry.key).toList();
+  }
+
+  List<String> _extractTags(String? query, List<Category> categories) {
+    if (query == null) {
+      return const [];
+    }
+    final normalized = _normalizeQuery(query);
+    final tagCandidates =
+        RegExp(r'#([가-힣a-zA-Z0-9_-]+)').allMatches(normalized).map((match) => match.group(1)!).toList();
+    if (tagCandidates.isEmpty) {
+      return const [];
+    }
+    final resolved = <String>[];
+    for (final candidate in tagCandidates) {
+      final lower = candidate.toLowerCase();
+      final match = categories.firstWhere(
+        (category) =>
+            category.code.toLowerCase() == lower ||
+            category.name.toLowerCase() == lower,
+        orElse: () => Category(code: '', name: ''),
+      );
+      if (match.code.isNotEmpty) {
+        resolved.add(match.code);
+      }
+    }
+    return resolved;
+  }
+
+  Set<String> _resolveCategories(List<String> base, List<String> tagMatches) {
+    final resolved = base.toSet();
+    resolved.addAll(tagMatches);
+    return resolved;
+  }
+
+  String _normalizeQuery(String query) {
+    return query.replaceAll(RegExp(r'\s+'), ' ').trim();
   }
 }

--- a/lib/features/search/controller/search_history_controller.dart
+++ b/lib/features/search/controller/search_history_controller.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/search_history_storage.dart';
+
+final searchHistoryControllerProvider =
+    AsyncNotifierProvider<SearchHistoryController, List<String>>(
+  SearchHistoryController.new,
+);
+
+class SearchHistoryController extends AsyncNotifier<List<String>> {
+  late SearchHistoryStorage _storage;
+
+  @override
+  Future<List<String>> build() async {
+    _storage = await SearchHistoryStorage.create();
+    return _storage.load();
+  }
+
+  Future<void> addTerm(String term) async {
+    if (term.isEmpty) return;
+    final current = List<String>.from(state.value ?? await future);
+    current.removeWhere((element) => element.toLowerCase() == term.toLowerCase());
+    current.insert(0, term);
+    if (current.length > SearchHistoryStorage.limit) {
+      current.removeRange(SearchHistoryStorage.limit, current.length);
+    }
+    await _storage.save(current);
+    state = AsyncValue.data(current);
+  }
+
+  Future<void> removeTerm(String term) async {
+    final current = List<String>.from(state.value ?? await future);
+    current.remove(term);
+    await _storage.save(current);
+    state = AsyncValue.data(current);
+  }
+
+  Future<void> clear() async {
+    await _storage.save(const []);
+    state = const AsyncValue.data([]);
+  }
+}

--- a/lib/features/search/data/search_history_storage.dart
+++ b/lib/features/search/data/search_history_storage.dart
@@ -1,0 +1,23 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SearchHistoryStorage {
+  SearchHistoryStorage._(this._prefs);
+
+  static const storageKey = 'recent_search_terms';
+  static const limit = 8;
+
+  final SharedPreferences _prefs;
+
+  static Future<SearchHistoryStorage> create() async {
+    final prefs = await SharedPreferences.getInstance();
+    return SearchHistoryStorage._(prefs);
+  }
+
+  List<String> load() {
+    return _prefs.getStringList(storageKey) ?? const [];
+  }
+
+  Future<void> save(List<String> terms) async {
+    await _prefs.setStringList(storageKey, terms);
+  }
+}

--- a/lib/features/search/presentation/policy_search_page.dart
+++ b/lib/features/search/presentation/policy_search_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../policy/controller/policy_list_controller.dart';
 import '../controller/policy_search_controller.dart';
+import '../controller/search_history_controller.dart';
 import '../../policy/controller/policy_metadata_providers.dart';
 import '../../region/providers/providers.dart';
 import '../../policy/presentation/widgets/policy_card.dart';
@@ -22,7 +23,7 @@ class _PolicySearchPageState extends ConsumerState<PolicySearchPage> {
   @override
   void initState() {
     super.initState();
-    final filter = ref.read(filterStateProvider);
+    final filter = ref.read(policyFilterProvider);
     _selectedRegion = filter.region;
     _selectedStatus = filter.status;
     _selectedCategories.addAll(filter.categories);
@@ -42,7 +43,9 @@ class _PolicySearchPageState extends ConsumerState<PolicySearchPage> {
       status: _selectedStatus,
     );
     ref.read(policySearchControllerProvider.notifier).setParams(params);
-    final notifier = ref.read(filterStateProvider.notifier);
+    ref.read(searchHistoryControllerProvider.notifier).addTerm(params.query ?? '');
+    ref.read(policyFilterUseProfileProvider.notifier).state = false;
+    final notifier = ref.read(policyFilterStateProvider.notifier);
     notifier.state = notifier.state.copyWith(
       region: _selectedRegion,
       categories: _selectedCategories.toList(),
@@ -56,6 +59,7 @@ class _PolicySearchPageState extends ConsumerState<PolicySearchPage> {
     final results = ref.watch(policySearchControllerProvider);
     final regions = ref.watch(regionListProvider);
     final categories = ref.watch(categoryListProvider);
+    final recentSearches = ref.watch(searchHistoryControllerProvider);
     final statusOptions = const {
       'OPEN': '모집중',
       'CLOSED': '마감',
@@ -82,6 +86,19 @@ class _PolicySearchPageState extends ConsumerState<PolicySearchPage> {
               ),
               onSubmitted: (_) => _submitSearch(),
             ),
+          ),
+          recentSearches.when(
+            data: (items) => _RecentSearchSection(
+              items: items,
+              onSelect: (term) {
+                setState(() => _controller.text = term);
+                _submitSearch();
+              },
+              onRemove: (term) =>
+                  ref.read(searchHistoryControllerProvider.notifier).removeTerm(term),
+            ),
+            loading: () => const SizedBox.shrink(),
+            error: (_, __) => const SizedBox.shrink(),
           ),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 12),
@@ -133,25 +150,45 @@ class _PolicySearchPageState extends ConsumerState<PolicySearchPage> {
                 Text('관심 분야', style: Theme.of(context).textTheme.labelLarge),
                 const SizedBox(height: 8),
                 categories.when(
-                  data: (items) => Wrap(
-                    spacing: 8,
-                    runSpacing: 8,
-                    children: items.map((category) {
-                      final selected = _selectedCategories.contains(category.code);
-                      return FilterChip(
-                        label: Text(category.name),
-                        selected: selected,
-                        onSelected: (value) {
-                          setState(() {
-                            if (value) {
-                              _selectedCategories.add(category.code);
-                            } else {
-                              _selectedCategories.remove(category.code);
-                            }
-                          });
-                        },
-                      );
-                    }).toList(),
+                  data: (items) => Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: items.map((category) {
+                          final selected = _selectedCategories.contains(category.code);
+                          return FilterChip(
+                            label: Text(category.name),
+                            selected: selected,
+                            onSelected: (value) {
+                              setState(() {
+                                if (value) {
+                                  _selectedCategories.add(category.code);
+                                } else {
+                                  _selectedCategories.remove(category.code);
+                                }
+                              });
+                            },
+                          );
+                        }).toList(),
+                      ),
+                      const SizedBox(height: 12),
+                      Text('추천 검색어', style: Theme.of(context).textTheme.labelMedium),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 8,
+                        children: items.take(6).map((category) {
+                          return ActionChip(
+                            label: Text('#${category.name}'),
+                            onPressed: () {
+                              setState(() => _controller.text = '#${category.name}');
+                              _submitSearch();
+                            },
+                          );
+                        }).toList(),
+                      ),
+                    ],
                   ),
                   loading: () => const LinearProgressIndicator(),
                   error: (e, _) => Text('카테고리를 불러오지 못했습니다: $e'),
@@ -165,7 +202,10 @@ class _PolicySearchPageState extends ConsumerState<PolicySearchPage> {
                         _selectedStatus = null;
                         _selectedCategories.clear();
                       });
-                      final notifier = ref.read(filterStateProvider.notifier);
+                      ref
+                          .read(policyFilterUseProfileProvider.notifier)
+                          .state = true;
+                      final notifier = ref.read(policyFilterStateProvider.notifier);
                       notifier.state = PolicyFilter.initial();
                     },
                     child: const Text('필터 초기화'),
@@ -196,6 +236,45 @@ class _PolicySearchPageState extends ConsumerState<PolicySearchPage> {
               loading: () => const Center(child: CircularProgressIndicator()),
               error: (e, _) => Center(child: Text('검색 실패: $e')),
             ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RecentSearchSection extends StatelessWidget {
+  const _RecentSearchSection({
+    required this.items,
+    required this.onSelect,
+    required this.onRemove,
+  });
+
+  final List<String> items;
+  final ValueChanged<String> onSelect;
+  final ValueChanged<String> onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('최근 검색어', style: Theme.of(context).textTheme.labelLarge),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            children: items.map((term) {
+              return InputChip(
+                label: Text(term),
+                onPressed: () => onSelect(term),
+                onDeleted: () => onRemove(term),
+              );
+            }).toList(),
           ),
         ],
       ),

--- a/lib/features/unity/controller/unity_controller.dart
+++ b/lib/features/unity/controller/unity_controller.dart
@@ -90,7 +90,8 @@ class UnityController extends Notifier<UnityState> {
       selectedRegionName: regionName,
     );
     if (regionCode != null) {
-      final notifier = ref.read(filterStateProvider.notifier);
+      ref.read(policyFilterUseProfileProvider.notifier).state = false;
+      final notifier = ref.read(policyFilterStateProvider.notifier);
       notifier.state = notifier.state.copyWith(region: regionCode);
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'app/app_router.dart';
+import 'app/app_startup.dart';
 import 'app/app_theme.dart';
 
 void main() {
@@ -13,13 +14,33 @@ class YouthRoadApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final startup = ref.watch(appStartupProvider);
     final router = ref.watch(routerProvider);
-    return MaterialApp.router(
-      title: 'Gyeongbuk Youth Policy',
-      theme: buildAppTheme(),
-      routerDelegate: router.routerDelegate,
-      routeInformationParser: router.routeInformationParser,
-      routeInformationProvider: router.routeInformationProvider,
+    final theme = buildAppTheme();
+    return startup.when(
+      data: (_) => MaterialApp.router(
+        title: 'Gyeongbuk Youth Policy',
+        theme: theme,
+        routerDelegate: router.routerDelegate,
+        routeInformationParser: router.routeInformationParser,
+        routeInformationProvider: router.routeInformationProvider,
+      ),
+      loading: () => MaterialApp(
+        title: 'Gyeongbuk Youth Policy',
+        theme: theme,
+        home: const Scaffold(
+          body: Center(child: CircularProgressIndicator()),
+        ),
+      ),
+      error: (error, _) => MaterialApp(
+        title: 'Gyeongbuk Youth Policy',
+        theme: theme,
+        home: Scaffold(
+          body: Center(
+            child: Text('앱을 시작할 수 없습니다. 다시 시도해주세요.'),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/ui/screens/setting/setting_screen.dart
+++ b/lib/ui/screens/setting/setting_screen.dart
@@ -1,27 +1,60 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../widgets/app_appbar.dart';
 
-class SettingScreen extends StatelessWidget {
+class SettingScreen extends StatefulWidget {
   const SettingScreen({super.key});
+
+  @override
+  State<SettingScreen> createState() => _SettingScreenState();
+}
+
+class _SettingScreenState extends State<SettingScreen> {
+  static const _notificationsKey = 'settings_notifications_enabled';
+
+  bool _notificationsEnabled = true;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPreferences();
+  }
+
+  Future<void> _loadPreferences() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _notificationsEnabled = prefs.getBool(_notificationsKey) ?? true;
+      _loading = false;
+    });
+  }
+
+  void _toggleNotification(bool value) async {
+    setState(() => _notificationsEnabled = value);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_notificationsKey, value);
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: const AppAppBar(title: '설정'),
-      body: ListView(
-        children: const [
-          SwitchListTile(
-            title: Text('알림 수신'),
-            value: true,
-            onChanged: null, // TODO: implement preferences toggle
-          ),
-          ListTile(
-            title: Text('앱 버전'),
-            subtitle: Text('1.0.0'),
-          ),
-        ],
-      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              children: [
+                SwitchListTile(
+                  title: const Text('알림 수신'),
+                  value: _notificationsEnabled,
+                  onChanged: _toggleNotification,
+                ),
+                const ListTile(
+                  title: Text('앱 버전'),
+                  subtitle: Text('1.0.0'),
+                ),
+              ],
+            ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- score and sort the policy list/search results with regional affinity, deadlines, novelty, and engagement data that is captured through a new policy engagement controller
- expand the detail and home experiences with sharing, related recommendations, and recently viewed sections while persisting search history for hashtag-friendly discovery
- add bookmark folders with sorting controls plus folder selection UI so saved policies can be organized locally

## Testing
- Not run (Flutter SDK unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bb62d2b2c8324b63826c5e535f236)