### PR TITLE
Normalize YouthRoad API decoding

### DIFF
--- a/lib/core/api/models/department.dart
+++ b/lib/core/api/models/department.dart
@@ -13,5 +13,14 @@ class Department with _$Department {
   }) = _Department;
 
   factory Department.fromJson(Map<String, dynamic> json) =>
-      _$DepartmentFromJson(json);
+      _$DepartmentFromJson(_normalizeDepartmentJson(json));
+}
+
+Map<String, dynamic> _normalizeDepartmentJson(Map<String, dynamic> json) {
+  return {
+    'id': json['id'] ?? json['deptId'] ?? json['deptNo'],
+    'name': json['name'] ?? json['deptName'] ?? json['deptNm'],
+    'institutionId': json['institutionId'] ?? json['instNo'],
+    'description': json['description'] ?? json['deptIntrcn'],
+  }..removeWhere((_, value) => value == null);
 }

--- a/lib/core/api/models/institution.dart
+++ b/lib/core/api/models/institution.dart
@@ -13,5 +13,14 @@ class Institution with _$Institution {
   }) = _Institution;
 
   factory Institution.fromJson(Map<String, dynamic> json) =>
-      _$InstitutionFromJson(json);
+      _$InstitutionFromJson(_normalizeInstitutionJson(json));
+}
+
+Map<String, dynamic> _normalizeInstitutionJson(Map<String, dynamic> json) {
+  return {
+    'id': json['id'] ?? json['institutionId'] ?? json['instNo'],
+    'name': json['name'] ?? json['institutionName'] ?? json['instNm'],
+    'description': json['description'] ?? json['instIntrcn'],
+    'region': json['region'] ?? json['rgnSe'],
+  }..removeWhere((_, value) => value == null);
 }

--- a/lib/core/api/models/policy.dart
+++ b/lib/core/api/models/policy.dart
@@ -19,5 +19,23 @@ class Policy with _$Policy {
     String? displayYn,
   }) = _Policy;
 
-  factory Policy.fromJson(Map<String, dynamic> json) => _$PolicyFromJson(json);
+  factory Policy.fromJson(Map<String, dynamic> json) =>
+      _$PolicyFromJson(_normalizePolicyJson(json));
+}
+
+Map<String, dynamic> _normalizePolicyJson(Map<String, dynamic> json) {
+  return {
+    'id': json['id'] ?? json['policyId'] ?? json['policyNo'],
+    'policyName': json['policyName'] ?? json['policyNm'] ?? json['title'],
+    'policyType': json['policyType'] ?? json['policyTypeCd'],
+    'region': json['region'] ?? json['searchRgnSe'] ?? json['policyRgnSe'],
+    'institutionName':
+        json['institutionName'] ?? json['instNm'] ?? json['instName'],
+    'departmentName': json['departmentName'] ?? json['deptNm'],
+    'startDate': json['startDate'] ?? json['policyStartDate'],
+    'endDate': json['endDate'] ?? json['policyEndDate'],
+    'applyUrl': json['applyUrl'] ?? json['applicationUrl'],
+    'description': json['description'] ?? json['policyContent'],
+    'displayYn': json['displayYn'] ?? json['policyPblancEndAtYn'],
+  }..removeWhere((_, value) => value == null);
 }

--- a/lib/core/api/models/policy_list_response.dart
+++ b/lib/core/api/models/policy_list_response.dart
@@ -16,7 +16,7 @@ class PolicyListResponse {
 
   factory PolicyListResponse.fromJson(Map<String, dynamic> json) {
     return PolicyListResponse(
-      success: json['success'] as bool? ?? false,
+      success: _asBool(json['success']),
       msg: json['msg'] as String?,
       resultList: (json['resultList'] as List<dynamic>?)
           ?.map((item) => Policy.fromJson(item as Map<String, dynamic>))
@@ -37,4 +37,15 @@ class PolicyListResponse {
       'paginationInfo': paginationInfo?.toJson(),
     };
   }
+}
+
+bool _asBool(dynamic value) {
+  if (value == null) {
+    return false;
+  }
+  if (value is bool) {
+    return value;
+  }
+  final lowered = value.toString().toLowerCase();
+  return lowered == 'true' || lowered == 'y';
 }

--- a/lib/features/policy/data/policy_repository.dart
+++ b/lib/features/policy/data/policy_repository.dart
@@ -28,11 +28,13 @@ class PolicyRepository {
     int page = 1,
     int size = 20,
   }) async {
+    final normalizedRegion = (region == null || region == 'ALL') ? null : region;
+    final normalizedCategories = _joinCategories(categories);
     final response = await _api.fetchPolicies(
       PolicyRequestDto(
         apiKey: apiKey,
-        searchRgnSe: region,
-        searchPolicyType: _joinCategories(categories),
+        searchRgnSe: normalizedRegion,
+        searchPolicyType: normalizedCategories,
         searchKeyword: keyword,
         pageIndex: page <= 0 ? 1 : page,
         pageSize: size,
@@ -77,7 +79,14 @@ class PolicyRepository {
     if (categories == null || categories.isEmpty) {
       return null;
     }
-    return categories.join(',');
+    final nonEmpty = categories
+        .map((category) => category.trim())
+        .where((category) => category.isNotEmpty)
+        .toList();
+    if (nonEmpty.isEmpty) {
+      return null;
+    }
+    return nonEmpty.join(',');
   }
 }
 


### PR DESCRIPTION
## Summary
- normalize YouthRoad policy, institution, and department decoding to handle YouthRoad API field aliases
- make policy list response tolerant of string-based boolean flags
- sanitize policy query parameters before calling the YouthRoad policy endpoint

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691beb61e8e8832a9293ab3c92db90bb)