### PR TITLE
Add retry/backoff handling and harden API integration tests

### DIFF
--- a/lib/core/api/youth_api_service.dart
+++ b/lib/core/api/youth_api_service.dart
@@ -5,11 +5,32 @@ import 'dto/policy_request_dto.dart';
 import 'models/department_list_response.dart';
 import 'models/institution_list_response.dart';
 import 'models/policy_list_response.dart';
+import '../network/api_interceptor.dart';
 
 part 'youth_api_service.g.dart';
 
 const String baseUrl = "https://api.youthroad.kr/v1";
 const String apiKey = "yAlMhwGFZps7vHtbsjnbsL6Cpha6bHqaPDSScV6pgU0";
+
+YouthApiService createYouthApiService({
+  Dio? dio,
+  TokenProvider? tokenProvider,
+}) {
+  final client = dio ??
+      Dio(
+        BaseOptions(
+          baseUrl: baseUrl,
+          connectTimeout: const Duration(seconds: 10),
+          receiveTimeout: const Duration(seconds: 10),
+        ),
+      );
+  final hasInterceptor =
+      client.interceptors.whereType<ApiInterceptor>().isNotEmpty;
+  if (!hasInterceptor) {
+    client.interceptors.add(ApiInterceptor(dio: client, tokenProvider: tokenProvider));
+  }
+  return YouthApiService(client);
+}
 
 @RestApi(baseUrl: baseUrl)
 abstract class YouthApiService {

--- a/lib/core/network/api_interceptor.dart
+++ b/lib/core/network/api_interceptor.dart
@@ -1,13 +1,22 @@
 import 'dart:developer';
+import 'dart:math';
 
 import 'package:dio/dio.dart';
 
 typedef TokenProvider = String? Function();
 
 class ApiInterceptor extends Interceptor {
-  ApiInterceptor({this.tokenProvider});
+  ApiInterceptor({
+    this.tokenProvider,
+    Dio? dio,
+    this.maxRetries = 3,
+    this.backoffBase = const Duration(milliseconds: 500),
+  }) : _dio = dio;
 
   final TokenProvider? tokenProvider;
+  final Dio? _dio;
+  final int maxRetries;
+  final Duration backoffBase;
 
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
@@ -20,11 +29,34 @@ class ApiInterceptor extends Interceptor {
   }
 
   @override
-  void onError(DioException err, ErrorInterceptorHandler handler) {
+  Future<void> onError(DioException err, ErrorInterceptorHandler handler) async {
     final code = err.response?.statusCode;
     log('❌ ${code ?? 'ERR'} ${err.requestOptions.uri}: ${err.message}',
         name: 'ApiInterceptor');
-    super.onError(err, handler);
+
+    final retryCount = (err.requestOptions.extra['retry_count'] as int?) ?? 0;
+    if (_shouldRetry(err, retryCount) && _dio != null) {
+      final nextCount = retryCount + 1;
+      final delay = _calculateBackoff(nextCount);
+      log(
+        '🔁 Retrying request ($nextCount/$maxRetries) after '
+        '${delay.inMilliseconds}ms',
+        name: 'ApiInterceptor',
+      );
+      await Future<void>.delayed(delay);
+      final response = await _dio!.fetch<dynamic>(
+        err.requestOptions.copyWith(
+          extra: <String, dynamic>{
+            ...err.requestOptions.extra,
+            'retry_count': nextCount,
+          },
+        ),
+      );
+      handler.resolve(response);
+      return;
+    }
+
+    handler.next(_mapStatusToError(err));
   }
 
   @override
@@ -32,5 +64,37 @@ class ApiInterceptor extends Interceptor {
     log('✅ ${response.statusCode} ${response.requestOptions.uri}',
         name: 'ApiInterceptor');
     super.onResponse(response, handler);
+  }
+
+  bool _shouldRetry(DioException err, int retryCount) {
+    final statusCode = err.response?.statusCode;
+    final isServerError = statusCode != null && statusCode >= 500;
+    final isRateLimited = statusCode == 429;
+    final isTimeoutError = err.type == DioExceptionType.connectionTimeout ||
+        err.type == DioExceptionType.receiveTimeout ||
+        err.type == DioExceptionType.sendTimeout;
+    return retryCount < maxRetries &&
+        (isRateLimited || isServerError || isTimeoutError);
+  }
+
+  Duration _calculateBackoff(int attempt) {
+    return Duration(
+      milliseconds: backoffBase.inMilliseconds * pow(2, attempt - 1).toInt(),
+    );
+  }
+
+  DioException _mapStatusToError(DioException error) {
+    final statusCode = error.response?.statusCode;
+    if (statusCode == 429) {
+      return error.copyWith(
+        message: 'YouthRoad API rate limit exceeded (429). Please retry later.',
+      );
+    }
+    if (statusCode != null && statusCode >= 500) {
+      return error.copyWith(
+        message: 'YouthRoad API is unavailable (HTTP $statusCode).',
+      );
+    }
+    return error;
   }
 }

--- a/lib/core/network/dio_client.dart
+++ b/lib/core/network/dio_client.dart
@@ -9,6 +9,6 @@ Dio createDioClient() {
       receiveTimeout: const Duration(seconds: 10),
     ),
   );
-  dio.interceptors.add(ApiInterceptor());
+  dio.interceptors.add(ApiInterceptor(dio: dio));
   return dio;
 }

--- a/lib/features/policy/data/policy_repository.dart
+++ b/lib/features/policy/data/policy_repository.dart
@@ -1,3 +1,5 @@
+import 'package:dio/dio.dart';
+
 import '../../../core/api/dto/policy_request_dto.dart';
 import '../../../core/api/models/policy.dart' as remote;
 import '../../../core/api/youth_api_service.dart';
@@ -33,25 +35,29 @@ class PolicyRepository {
     final normalizedStatus = status?.trim().isEmpty ?? true ? null : status?.trim();
     final normalizedAge = age == null || age <= 0 ? null : age;
     final normalizedKeyword = keyword?.trim().isEmpty ?? true ? null : keyword?.trim();
-    final response = await _api.fetchPolicies(
-      PolicyRequestDto(
-        apiKey: apiKey,
-        searchRgnSe: normalizedRegion,
-        searchPolicyType: normalizedCategories,
-        searchPolicyStatus: normalizedStatus,
-        searchAge: normalizedAge,
-        searchKeyword: normalizedKeyword,
-        pageIndex: page <= 0 ? 1 : page,
-        pageSize: size,
-      ),
-    );
-    final policies = (response.resultList ?? const <remote.Policy>[]) 
-        .map(Policy.fromRemote)
-        .toList(growable: false);
-    for (final policy in policies) {
-      _policyCache[policy.id] = policy;
+    try {
+      final response = await _api.fetchPolicies(
+        PolicyRequestDto(
+          apiKey: apiKey,
+          searchRgnSe: normalizedRegion,
+          searchPolicyType: normalizedCategories,
+          searchPolicyStatus: normalizedStatus,
+          searchAge: normalizedAge,
+          searchKeyword: normalizedKeyword,
+          pageIndex: page <= 0 ? 1 : page,
+          pageSize: size,
+        ),
+      );
+      final policies = (response.resultList ?? const <remote.Policy>[])
+          .map(Policy.fromRemote)
+          .toList(growable: false);
+      for (final policy in policies) {
+        _policyCache[policy.id] = policy;
+      }
+      return policies;
+    } on DioException catch (error) {
+      throw _mapDioException(error, 'Failed to load policy list');
     }
-    return policies;
   }
 
   Future<Policy> getPolicyDetail(String id) async {
@@ -59,25 +65,29 @@ class PolicyRepository {
     if (cached != null) {
       return cached;
     }
-    final response = await _api.fetchPolicies(
-      PolicyRequestDto(
-        apiKey: apiKey,
-        searchKeyword: id,
-        pageIndex: 1,
-        pageSize: 5,
-      ),
-    );
-    final candidates = response.resultList ?? const <remote.Policy>[];
-    if (candidates.isEmpty) {
-      throw StateError('Policy not found');
+    try {
+      final response = await _api.fetchPolicies(
+        PolicyRequestDto(
+          apiKey: apiKey,
+          searchKeyword: id,
+          pageIndex: 1,
+          pageSize: 5,
+        ),
+      );
+      final candidates = response.resultList ?? const <remote.Policy>[];
+      if (candidates.isEmpty) {
+        throw StateError('Policy not found');
+      }
+      final remotePolicy = candidates.firstWhere(
+        (item) => item.id == id || item.policyName == id,
+        orElse: () => candidates.first,
+      );
+      final policy = Policy.fromRemote(remotePolicy);
+      _policyCache[policy.id] = policy;
+      return policy;
+    } on DioException catch (error) {
+      throw _mapDioException(error, 'Failed to load policy detail');
     }
-    final remotePolicy = candidates.firstWhere(
-      (item) => item.id == id || item.policyName == id,
-      orElse: () => candidates.first,
-    );
-    final policy = Policy.fromRemote(remotePolicy);
-    _policyCache[policy.id] = policy;
-    return policy;
   }
 
   String? _joinCategories(List<String>? categories) {
@@ -92,6 +102,17 @@ class PolicyRepository {
       return null;
     }
     return nonEmpty.join(',');
+  }
+
+  StateError _mapDioException(DioException error, String context) {
+    final statusCode = error.response?.statusCode;
+    if (statusCode == 429) {
+      return StateError('$context: rate limited (429). Please try again.');
+    }
+    if (statusCode != null && statusCode >= 500) {
+      return StateError('$context: server unavailable (HTTP $statusCode).');
+    }
+    return StateError('$context: ${error.message}');
   }
 }
 

--- a/test/integration/youth_api_integration_test.dart
+++ b/test/integration/youth_api_integration_test.dart
@@ -1,13 +1,29 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:youth_road_app/core/api/dto/policy_request_dto.dart';
 import 'package:youth_road_app/core/api/youth_api_service.dart';
+import 'package:youth_road_app/core/network/api_interceptor.dart';
 
-const String _apiKey = String.fromEnvironment('YOUTHROAD_API_KEY');
+final String _apiKey = _loadApiKey();
+
+String _loadApiKey() {
+  const fromDefine = String.fromEnvironment('YOUTHROAD_API_KEY');
+  if (fromDefine.isNotEmpty) {
+    return fromDefine;
+  }
+  return Platform.environment['YOUTHROAD_API_KEY'] ?? '';
+}
 
 void main() {
   group('YouthRoad live API', () {
     if (_apiKey.isEmpty) {
+      // ignore: avoid_print
+      print(
+        '⚠️  Skipping YouthRoad live API tests: set YOUTHROAD_API_KEY via '
+        '--dart-define or environment variable to enable.',
+      );
       test(
         'skipped because YOUTHROAD_API_KEY is not provided',
         () {},
@@ -24,9 +40,10 @@ void main() {
       final dio = Dio(
         BaseOptions(
           connectTimeout: const Duration(seconds: 10),
-          receiveTimeout: const Duration(seconds: 10),
+          receiveTimeout: const Duration(seconds: 5),
         ),
       );
+      dio.interceptors.add(ApiInterceptor(dio: dio));
       dio.interceptors.add(
         InterceptorsWrapper(
           onResponse: (response, handler) {

--- a/unity_project/Assets/Tests/EditMode/YouthApiIntegrationTests.cs
+++ b/unity_project/Assets/Tests/EditMode/YouthApiIntegrationTests.cs
@@ -10,11 +10,18 @@ namespace YouthRoadTests
     public class YouthApiIntegrationTests
     {
         private const string BaseUrl = "https://api.youthroad.kr/v1";
+        private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(10);
         private string _apiKey = string.Empty;
 
         [SetUp]
         public void SetUp()
         {
+            var unityLicense = Environment.GetEnvironmentVariable("UNITY_LICENSE");
+            if (string.IsNullOrWhiteSpace(unityLicense))
+            {
+                Assert.Ignore("UNITY_LICENSE is not provided; skipping live API checks.");
+            }
+
             _apiKey = Environment.GetEnvironmentVariable("YOUTHROAD_API_KEY");
             if (string.IsNullOrWhiteSpace(_apiKey))
             {
@@ -25,50 +32,104 @@ namespace YouthRoadTests
         [Test]
         public async Task PoliciesEndpoint_ReturnsContent()
         {
-            using (var client = CreateClient())
+            try
             {
-                var response = await client.GetAsync($"/policies?apiKey={_apiKey}&pageIndex=1&pageSize=5");
-                var body = await response.Content.ReadAsStringAsync();
+                using (var client = CreateClient())
+                {
+                    var response = await client.GetAsync($"/policies?apiKey={_apiKey}&pageIndex=1&pageSize=5");
+                    var body = await response.Content.ReadAsStringAsync();
 
-                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-                Assert.IsNotEmpty(body);
+                    if (response.StatusCode != HttpStatusCode.OK)
+                    {
+                        TestContext.Out.WriteLine($"Unexpected status {(int)response.StatusCode} from /policies.");
+                    }
+
+                    Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+                    Assert.IsNotEmpty(body);
+                }
+            }
+            catch (TaskCanceledException ex)
+            {
+                LogHttpError(ex, "/policies");
+                throw;
+            }
+            catch (HttpRequestException ex)
+            {
+                LogHttpError(ex, "/policies");
+                throw;
             }
         }
 
         [Test]
         public async Task InstitutionsAndDepartments_ReturnsContent()
         {
-            using (var client = CreateClient())
+            try
             {
-                var institutionsResponse = await client.GetAsync($"/institutions?apiKey={_apiKey}");
-                var institutionsBody = await institutionsResponse.Content.ReadAsStringAsync();
-
-                Assert.AreEqual(HttpStatusCode.OK, institutionsResponse.StatusCode);
-                Assert.IsNotEmpty(institutionsBody);
-
-                var instNo = ExtractFirstValue(institutionsBody, "\"instNo\"\\s*:\\s*\"?([^\\\"]+)\"?");
-                if (string.IsNullOrEmpty(instNo))
+                using (var client = CreateClient())
                 {
-                    Assert.Inconclusive("No instNo found in institution response");
+                    var institutionsResponse = await client.GetAsync($"/institutions?apiKey={_apiKey}");
+                    var institutionsBody = await institutionsResponse.Content.ReadAsStringAsync();
+
+                    if (institutionsResponse.StatusCode != HttpStatusCode.OK)
+                    {
+                        TestContext.Out.WriteLine($"Unexpected status {(int)institutionsResponse.StatusCode} from /institutions.");
+                    }
+
+                    Assert.AreEqual(HttpStatusCode.OK, institutionsResponse.StatusCode);
+                    Assert.IsNotEmpty(institutionsBody);
+
+                    var instNo = ExtractFirstValue(institutionsBody, "\"instNo\"\\s*:\\s*\"?([^\\\"]+)\"?");
+                    if (string.IsNullOrEmpty(instNo))
+                    {
+                        Assert.Inconclusive("No instNo found in institution response");
+                    }
+
+                    var departmentsResponse = await client.GetAsync($"/departments?apiKey={_apiKey}&instNo={Uri.EscapeDataString(instNo)}");
+                    var departmentsBody = await departmentsResponse.Content.ReadAsStringAsync();
+
+                    if (departmentsResponse.StatusCode != HttpStatusCode.OK)
+                    {
+                        TestContext.Out.WriteLine($"Unexpected status {(int)departmentsResponse.StatusCode} from /departments.");
+                    }
+
+                    Assert.AreEqual(HttpStatusCode.OK, departmentsResponse.StatusCode);
+                    Assert.IsNotEmpty(departmentsBody);
                 }
-
-                var departmentsResponse = await client.GetAsync($"/departments?apiKey={_apiKey}&instNo={Uri.EscapeDataString(instNo)}");
-                var departmentsBody = await departmentsResponse.Content.ReadAsStringAsync();
-
-                Assert.AreEqual(HttpStatusCode.OK, departmentsResponse.StatusCode);
-                Assert.IsNotEmpty(departmentsBody);
+            }
+            catch (TaskCanceledException ex)
+            {
+                LogHttpError(ex, "/institutions or /departments");
+                throw;
+            }
+            catch (HttpRequestException ex)
+            {
+                LogHttpError(ex, "/institutions or /departments");
+                throw;
             }
         }
 
         private static HttpClient CreateClient()
         {
-            return new HttpClient { BaseAddress = new Uri(BaseUrl) };
+            return new HttpClient
+            {
+                BaseAddress = new Uri(BaseUrl),
+                Timeout = RequestTimeout,
+            };
         }
 
         private static string ExtractFirstValue(string json, string pattern)
         {
             var match = Regex.Match(json, pattern);
             return match.Success ? match.Groups[1].Value : string.Empty;
+        }
+
+        private static void LogHttpError(Exception ex, string path)
+        {
+            TestContext.Out.WriteLine($"HTTP error while calling {path}: {ex.Message}");
+            if (ex is TaskCanceledException)
+            {
+                TestContext.Out.WriteLine("Request timed out.");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add YouthRoad API Dio interceptor retry/backoff behavior and rate-limit/server-error mapping, exposing a helper factory for the Retrofit client
- map Dio errors to domain-friendly messages in the policy repository and ensure the default Dio client uses the retry-aware interceptor
- harden Dart and Unity integration tests with shorter timeouts, environment-variable warnings, and richer HTTP error logging

## Testing
- Not run (not requested)
- dart format (fails: command not found)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bfbc48428832aadbd41340c5d596f)