### PR TITLE
Add onboarding state store and guard home route

### DIFF
--- a/lib/app/app_router.dart
+++ b/lib/app/app_router.dart
@@ -11,9 +11,10 @@ import '../features/unity/presentation/unity_map_page.dart';
 import '../features/onboarding/presentation/splash_page.dart';
 import '../features/home/home_page.dart';
 import '../features/settings/settings_page.dart';
+import '../core/state/app_store.dart';
 
 final routerProvider = Provider<GoRouter>((ref) {
-  return GoRouter(
+  final router = GoRouter(
     initialLocation: '/',
     routes: [
       GoRoute(
@@ -29,6 +30,14 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/home',
         name: 'home',
+        redirect: (context, state) {
+          final onboardingCompleted = ref
+              .read(appStoreProvider.select((state) => state.onboardingCompleted));
+          if (!onboardingCompleted) {
+            return '/onboarding';
+          }
+          return null;
+        },
         builder: (context, state) => const HomePage(),
         routes: [
           GoRoute(
@@ -75,4 +84,6 @@ final routerProvider = Provider<GoRouter>((ref) {
       ),
     ],
   );
+  ref.listen<AppState>(appStoreProvider, (_, __) => router.refresh());
+  return router;
 });

--- a/lib/app/app_startup.dart
+++ b/lib/app/app_startup.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../features/onboarding/controller/onboarding_controller.dart';
 import '../features/policy/controller/policy_list_controller.dart';
 import '../features/profile/providers/user_preferences_provider.dart';
+import '../core/state/app_store.dart';
 
 /// Loads persisted onboarding and preference data so that routing and filters
 /// are hydrated before the rest of the app renders.
@@ -11,6 +12,7 @@ final appStartupProvider = FutureProvider<void>((ref) async {
   ref.read(userRegionProvider.notifier).state = snapshot.region;
   ref.read(userInterestsProvider.notifier).state = snapshot.interests;
   ref.read(userAgeProvider.notifier).state = snapshot.age;
+  ref.read(appStoreProvider.notifier).hydrate(snapshot);
 
   final onboardingNotifier = ref.read(onboardingStateProvider.notifier);
   onboardingNotifier.state =

--- a/lib/core/state/app_store.dart
+++ b/lib/core/state/app_store.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../features/profile/providers/user_preferences_provider.dart';
+
+class AppState {
+  final String? region;
+  final List<String> interests;
+  final int? age;
+  final bool onboardingCompleted;
+
+  const AppState({
+    this.region,
+    this.interests = const [],
+    this.age,
+    this.onboardingCompleted = false,
+  });
+
+  AppState copyWith({
+    String? region,
+    List<String>? interests,
+    int? age,
+    bool? onboardingCompleted,
+  }) {
+    return AppState(
+      region: region ?? this.region,
+      interests: interests ?? this.interests,
+      age: age ?? this.age,
+      onboardingCompleted: onboardingCompleted ?? this.onboardingCompleted,
+    );
+  }
+}
+
+class AppStore extends StateNotifier<AppState> {
+  AppStore({AppState? initialState}) : super(initialState ?? const AppState());
+
+  void hydrate(UserPreferencesSnapshot snapshot) {
+    state = state.copyWith(
+      region: snapshot.region,
+      interests: snapshot.interests,
+      age: snapshot.age,
+      onboardingCompleted: snapshot.onboardingCompleted,
+    );
+  }
+
+  void completeOnboarding({
+    required String region,
+    required List<String> interests,
+    int? age,
+  }) {
+    state = state.copyWith(
+      region: region,
+      interests: interests,
+      age: age,
+      onboardingCompleted: true,
+    );
+  }
+}
+
+final appStoreProvider = StateNotifierProvider<AppStore, AppState>((ref) {
+  return AppStore();
+});

--- a/lib/features/onboarding/presentation/onboarding_page.dart
+++ b/lib/features/onboarding/presentation/onboarding_page.dart
@@ -9,6 +9,7 @@ import '../../policy/controller/policy_list_controller.dart';
 import '../../policy/data/models/region.dart';
 import '../../policy/data/models/category.dart';
 import '../controller/onboarding_controller.dart';
+import '../../../core/state/app_store.dart';
 
 class OnboardingPage extends ConsumerStatefulWidget {
   const OnboardingPage({super.key});
@@ -46,9 +47,14 @@ class _OnboardingPageState extends ConsumerState<OnboardingPage> {
     ref.read(policyFilterUseProfileProvider.notifier).state = true;
     ref.read(policyFilterStateProvider.notifier).state =
         PolicyFilter.initial();
+    ref.read(appStoreProvider.notifier).completeOnboarding(
+          region: region,
+          interests: interests,
+        );
     final onboardingNotifier = ref.read(onboardingStateProvider.notifier);
     onboardingNotifier.state =
         onboardingNotifier.state.copyWith(completed: true);
+    ref.invalidate(policyListControllerProvider);
     if (!mounted) {
       return;
     }

--- a/lib/features/onboarding/presentation/splash_page.dart
+++ b/lib/features/onboarding/presentation/splash_page.dart
@@ -2,17 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../controller/onboarding_controller.dart';
+import '../../../core/state/app_store.dart';
 
 class SplashPage extends ConsumerWidget {
   const SplashPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final onboardingState = ref.watch(onboardingStateProvider);
+    final appState = ref.watch(appStoreProvider);
     Future.microtask(() {
       if (!context.mounted) return;
-      final nextRoute = onboardingState.completed ? '/home' : '/onboarding';
+      final nextRoute = appState.onboardingCompleted ? '/home' : '/onboarding';
       context.go(nextRoute);
     });
     return const Scaffold(

--- a/test/features/home/home_flow_test.dart
+++ b/test/features/home/home_flow_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:youth_road/app/app_router.dart';
+import 'package:youth_road/core/state/app_store.dart';
+import 'package:youth_road/features/bookmark/controller/bookmark_controller.dart';
+import 'package:youth_road/features/bookmark/data/bookmark_models.dart';
+import 'package:youth_road/features/onboarding/presentation/onboarding_page.dart';
+import 'package:youth_road/features/policy/controller/policy_engagement_controller.dart';
+import 'package:youth_road/features/policy/controller/policy_list_controller.dart';
+import 'package:youth_road/features/policy/data/models/category.dart';
+import 'package:youth_road/features/policy/data/models/policy.dart';
+import 'package:youth_road/features/policy/data/models/region.dart';
+import 'package:youth_road/features/policy/data/policy_repository.dart';
+import 'package:youth_road/features/profile/providers/user_preferences_provider.dart';
+
+class FakePolicyRepository implements PolicyRepository {
+  FakePolicyRepository(this.policies);
+
+  final List<Policy> policies;
+  String? lastRegion;
+  List<String>? lastCategories;
+
+  @override
+  Future<List<Category>> getCategories() async => const [];
+
+  @override
+  Future<Policy> getPolicyDetail(String id) async {
+    return policies.firstWhere((policy) => policy.id == id, orElse: () => policies.first);
+  }
+
+  @override
+  Future<List<Policy>> getPolicies({
+    String? region,
+    int? age,
+    List<String>? categories,
+    String? status,
+    String? keyword,
+    int page = 1,
+    int size = 20,
+  }) async {
+    lastRegion = region;
+    lastCategories = categories;
+    return policies;
+  }
+
+  @override
+  Future<List<Region>> getRegions() async => const [];
+}
+
+class FakeEngagementController extends AsyncNotifier<PolicyEngagementState> {
+  @override
+  Future<PolicyEngagementState> build() async => const PolicyEngagementState();
+}
+
+class FakeBookmarkController extends AsyncNotifier<List<BookmarkEntry>> {
+  @override
+  Future<List<BookmarkEntry>> build() async => const [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('redirects to onboarding when onboarding is incomplete', (tester) async {
+    final container = ProviderContainer(overrides: [
+      appStoreProvider.overrideWith(
+        (ref) => AppStore(initialState: const AppState(onboardingCompleted: false)),
+      ),
+      policyRepositoryProvider.overrideWithValue(FakePolicyRepository(const [])),
+      policyEngagementControllerProvider.overrideWith(FakeEngagementController.new),
+      bookmarkControllerProvider.overrideWith(FakeBookmarkController.new),
+    ]);
+    addTearDown(container.dispose);
+
+    final router = container.read(routerProvider);
+    final app = UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp.router(routerConfig: router),
+    );
+
+    await tester.pumpWidget(app);
+    router.go('/home');
+    await tester.pumpAndSettle();
+
+    expect(find.byType(OnboardingPage), findsOneWidget);
+  });
+
+  testWidgets('injects onboarding preferences into the first home fetch', (tester) async {
+    final fakeRepo = FakePolicyRepository([
+      Policy(
+        id: '1',
+        policyName: '청년 취업 지원',
+        region: '47',
+        categories: const ['EMPLOYMENT'],
+      ),
+    ]);
+
+    final container = ProviderContainer(overrides: [
+      appStoreProvider.overrideWith(
+        (ref) => AppStore(
+          initialState: const AppState(
+            region: '47',
+            interests: ['EMPLOYMENT'],
+            onboardingCompleted: true,
+          ),
+        ),
+      ),
+      policyRepositoryProvider.overrideWithValue(fakeRepo),
+      policyEngagementControllerProvider.overrideWith(FakeEngagementController.new),
+      bookmarkControllerProvider.overrideWith(FakeBookmarkController.new),
+    ]);
+    addTearDown(container.dispose);
+
+    container.read(userRegionProvider.notifier).state = '47';
+    container.read(userInterestsProvider.notifier).state = const ['EMPLOYMENT'];
+    container.read(policyFilterUseProfileProvider.notifier).state = true;
+    container.read(policyFilterStateProvider.notifier).state = PolicyFilter.initial();
+
+    final router = container.read(routerProvider);
+    final app = UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp.router(routerConfig: router),
+    );
+
+    await tester.pumpWidget(app);
+    router.go('/home');
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pumpAndSettle();
+
+    expect(fakeRepo.lastRegion, '47');
+    expect(fakeRepo.lastCategories, ['EMPLOYMENT']);
+    expect(find.text('청년 취업 지원'), findsWidgets);
+  });
+}

--- a/test/features/onboarding/app_state_sync_test.dart
+++ b/test/features/onboarding/app_state_sync_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:youth_road/app/app_startup.dart';
+import 'package:youth_road/core/state/app_store.dart';
+import 'package:youth_road/features/profile/providers/user_preferences_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('hydrates persisted preferences into the app store and providers', () async {
+    SharedPreferences.setMockInitialValues({
+      'user_region': '47',
+      'user_interests': <String>['EMPLOYMENT', 'WELFARE'],
+      'user_age': 28,
+      'onboarding_completed': true,
+    });
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await container.read(appStartupProvider.future);
+
+    final appState = container.read(appStoreProvider);
+    expect(appState.region, '47');
+    expect(appState.interests, ['EMPLOYMENT', 'WELFARE']);
+    expect(appState.age, 28);
+    expect(appState.onboardingCompleted, isTrue);
+
+    expect(container.read(userRegionProvider), '47');
+    expect(container.read(userInterestsProvider), ['EMPLOYMENT', 'WELFARE']);
+    expect(container.read(userAgeProvider), 28);
+  });
+}


### PR DESCRIPTION
## Summary
- introduce an application state store that hydrates onboarding preferences and updates after completion
- guard the home route with onboarding completion state and refresh the initial policy fetch when onboarding finishes
- add widget and state initialization tests for the onboarding flow and home loading scenarios

## Testing
- flutter test *(fails: Flutter SDK unavailable in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bfbd98288832a9a3960104d1077fd)