### PR TITLE
Improve CI caching and document required secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,24 @@ jobs:
         with:
           channel: stable
 
+      - name: Cache Flutter dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('android/**/build.gradle', 'android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: Install dependencies
         run: flutter pub get
 
@@ -28,9 +46,9 @@ jobs:
   unity-editmode-tests:
     name: Unity EditMode Tests
     runs-on: ubuntu-latest
-    if: ${{ secrets.UNITY_LICENSE != '' }}
     env:
       UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+    if: ${{ env.UNITY_LICENSE != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -45,3 +63,13 @@ jobs:
           testMode: editmode
           unityVersion: 2021.3.30f1
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+  unity-editmode-tests-skip:
+    name: Unity EditMode Tests (skipped)
+    runs-on: ubuntu-latest
+    env:
+      UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+    if: ${{ env.UNITY_LICENSE == '' }}
+    steps:
+      - name: Skip Unity tests
+        run: echo "Skipping Unity EditMode tests because UNITY_LICENSE is not set."

--- a/README.md
+++ b/README.md
@@ -65,8 +65,12 @@ cd youth_app
 flutter pub get
 ```
 
+### 🔐 CI Secrets
+- **YOUTHROAD_API_KEY**: YouthRoad API 연동 테스트 실행용 API Key (없으면 관련 테스트가 스킵됩니다).
+- **UNITY_LICENSE**: Unity EditMode 테스트 실행용 라이선스 텍스트 (없으면 CI에서 Unity 테스트가 스킵됩니다).
+
 ### 3. Build & Run
-- **APK 빌드 (arm64 전용 / 실제 기기 권장)**  
+- **APK 빌드 (arm64 전용 / 실제 기기 권장)**
   ```bash
   cd android
   ./gradlew.bat app:assembleDebug

--- a/TESTS.md
+++ b/TESTS.md
@@ -11,6 +11,10 @@
 - GitHub Actions runs Flutter tests in the repository root (see [`.github/workflows/ci.yml`](./.github/workflows/ci.yml)).
 - Unity EditMode tests run via `game-ci/unity-test-runner` and are skipped automatically if `UNITY_LICENSE` is not provided.
 
+Before triggering CI, configure the following GitHub Secrets so tests can execute without being skipped:
+- `YOUTHROAD_API_KEY` for API-driven Flutter and Unity tests
+- `UNITY_LICENSE` for Unity EditMode test execution
+
 ## Recommended next steps
 1. **Secrets wiring:** Ensure `YOUTHROAD_API_KEY` is present in repository secrets so live integration tests execute instead of skipping.
 2. **Unity license (optional):** Add `UNITY_LICENSE` to run EditMode tests; otherwise they will skip by design.


### PR DESCRIPTION
## Summary
- add caching for Flutter pub and Gradle dependencies in the CI workflow
- gate Unity EditMode tests on the UNITY_LICENSE environment variable and provide a skip notice when missing
- document required GitHub Secrets for CI in README.md and TESTS.md

## Testing
- not run (workflow changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bfbdbdac0832ab032ba73a37337ab)