### PR TITLE
Add YouthRoad error mapping and bridge logging utilities

### DIFF
--- a/lib/core/location/location_service.dart
+++ b/lib/core/location/location_service.dart
@@ -1,0 +1,91 @@
+import 'package:geocoding/geocoding.dart';
+import 'package:geolocator/geolocator.dart';
+
+class LocationResult {
+  const LocationResult({
+    required this.latitude,
+    required this.longitude,
+    required this.placemark,
+    this.regionCode,
+  });
+
+  final double latitude;
+  final double longitude;
+  final Placemark placemark;
+  final String? regionCode;
+}
+
+class LocationService {
+  LocationService({YouthRoadRegionMapper? regionMapper})
+      : _regionMapper = regionMapper ?? const YouthRoadRegionMapper();
+
+  final YouthRoadRegionMapper _regionMapper;
+
+  Future<bool> ensurePermission() async {
+    final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      return false;
+    }
+    var permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+    }
+    return permission == LocationPermission.always ||
+        permission == LocationPermission.whileInUse;
+  }
+
+  Future<LocationResult> getCurrentLocation() async {
+    final allowed = await ensurePermission();
+    if (!allowed) {
+      throw const LocationServiceDisabledException();
+    }
+    final position = await Geolocator.getCurrentPosition(
+      desiredAccuracy: LocationAccuracy.high,
+    );
+    final placemarks = await placemarkFromCoordinates(
+      position.latitude,
+      position.longitude,
+      localeIdentifier: 'ko_KR',
+    );
+    final placemark = placemarks.first;
+    final regionCode = _regionMapper.fromPlacemark(placemark);
+    return LocationResult(
+      latitude: position.latitude,
+      longitude: position.longitude,
+      placemark: placemark,
+      regionCode: regionCode,
+    );
+  }
+}
+
+class YouthRoadRegionMapper {
+  const YouthRoadRegionMapper();
+
+  static const Map<String, String> _provinceMap = {
+    '서울특별시': '11',
+    '부산광역시': '26',
+    '대구광역시': '27',
+    '인천광역시': '28',
+    '광주광역시': '29',
+    '대전광역시': '30',
+    '울산광역시': '31',
+    '세종특별자치시': '36',
+    '경기도': '41',
+    '강원특별자치도': '42',
+    '충청북도': '43',
+    '충청남도': '44',
+    '전북특별자치도': '45',
+    '전라남도': '46',
+    '경상북도': '47',
+    '경상남도': '48',
+    '제주특별자치도': '49',
+  };
+
+  String? fromPlacemark(Placemark placemark) {
+    final administrativeArea = placemark.administrativeArea?.trim();
+    if (administrativeArea == null || administrativeArea.isEmpty) {
+      return null;
+    }
+    return _provinceMap[administrativeArea];
+  }
+}

--- a/lib/core/logging/app_logger.dart
+++ b/lib/core/logging/app_logger.dart
@@ -1,0 +1,113 @@
+import 'dart:async';
+import 'dart:developer';
+import 'dart:ui';
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/foundation.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import 'logging_config.dart';
+import 'network_event.dart';
+
+typedef FlutterAppRunner = FutureOr<void> Function();
+
+class AppLogger {
+  const AppLogger._();
+
+  static bool _crashlyticsReady = false;
+
+  /// Initializes Crashlytics and Sentry (if requested) around the Flutter app
+  /// entry point so that the first errors are captured with context.
+  static Future<void> bootstrap(FlutterAppRunner appRunner) async {
+    if (LoggingConfig.useSentry) {
+      await SentryFlutter.init(
+        (options) {
+          if (LoggingConfig.sentryDsn.isNotEmpty) {
+            options.dsn = LoggingConfig.sentryDsn;
+          }
+          options.tracesSampleRate = 0.25;
+          options.enableAutoPerformanceTracing = false;
+        },
+        appRunner: () => _runWithCrashlytics(appRunner),
+      );
+      return;
+    }
+
+    await _runWithCrashlytics(appRunner);
+  }
+
+  static Future<void> _runWithCrashlytics(FlutterAppRunner appRunner) async {
+    if (LoggingConfig.useCrashlytics) {
+      await Firebase.initializeApp();
+      _crashlyticsReady = true;
+      FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
+      PlatformDispatcher.instance.onError = (error, stack) {
+        FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+        return true;
+      };
+    }
+
+    await appRunner();
+  }
+
+  /// Records a network breadcrumb and optionally reports an error to Sentry or
+  /// Crashlytics, while still printing to stdout in debug mode.
+  static Future<void> recordNetworkEvent(NetworkLogEvent event) async {
+    final payload = <String, dynamic>{
+      'method': event.method,
+      'uri': event.uri.toString(),
+      'statusCode': event.statusCode,
+      'durationMs': event.duration?.inMilliseconds,
+      'timestamp': event.timestamp.toIso8601String(),
+      'error': event.errorMessage,
+      'requestBody': event.requestBody,
+      'responseBody': event.responseBody,
+      ...event.extra,
+    };
+
+    if (kDebugMode) {
+      log('[network] ${event.method} ${event.uri} => ${event.statusCode ?? 'ERR'}',
+          name: 'AppLogger', error: event.errorMessage, level: 800);
+    }
+
+    if (LoggingConfig.useSentry) {
+      Sentry.addBreadcrumb(
+        Breadcrumb(
+          category: 'http',
+          type: 'http',
+          data: payload,
+          message: '${event.method} ${event.uri}',
+          level: event.isError ? SentryLevel.error : SentryLevel.info,
+        ),
+      );
+
+      if (event.isError) {
+        await Sentry.captureMessage(
+          'HTTP ${event.statusCode ?? 'ERR'} ${event.uri}',
+          level: SentryLevel.error,
+          withScope: (scope) {
+            scope.setContexts('network', payload);
+            if (event.errorMessage != null) {
+              scope.setExtra('message', event.errorMessage!);
+            }
+          },
+        );
+      }
+    }
+
+    if (LoggingConfig.useCrashlytics && _crashlyticsReady) {
+      await FirebaseCrashlytics.instance
+          .log('[network] ${event.method} ${event.uri}');
+      if (event.isError) {
+        await FirebaseCrashlytics.instance.recordError(
+          event.errorMessage ?? 'Network error',
+          StackTrace.current,
+          reason: 'HTTP ${event.statusCode ?? 'ERR'} ${event.uri}',
+          information: [payload],
+          fatal: false,
+        );
+      }
+    }
+  }
+}

--- a/lib/core/logging/logging_config.dart
+++ b/lib/core/logging/logging_config.dart
@@ -1,0 +1,16 @@
+/// Centralized switches for remote logging backends so that build-time
+/// configuration can select Crashlytics or Sentry without touching call sites.
+class LoggingConfig {
+  /// Enable Firebase Crashlytics integration at build time.
+  static const bool useCrashlytics =
+      bool.fromEnvironment('USE_CRASHLYTICS', defaultValue: false);
+
+  /// Enable Sentry integration at build time.
+  static const bool useSentry =
+      bool.fromEnvironment('USE_SENTRY', defaultValue: false);
+
+  /// Optional Sentry DSN provided via `--dart-define` so sensitive values stay
+  /// out of source control.
+  static const String sentryDsn =
+      String.fromEnvironment('SENTRY_DSN', defaultValue: '');
+}

--- a/lib/core/logging/network_event.dart
+++ b/lib/core/logging/network_event.dart
@@ -1,0 +1,74 @@
+import 'package:dio/dio.dart';
+
+/// Captures metadata about outbound HTTP calls so it can be forwarded to
+/// Crashlytics or Sentry.
+class NetworkLogEvent {
+  NetworkLogEvent({
+    required this.method,
+    required this.uri,
+    this.statusCode,
+    this.duration,
+    this.errorMessage,
+    this.requestBody,
+    this.responseBody,
+    Map<String, dynamic>? extra,
+    DateTime? timestamp,
+  })  : timestamp = timestamp ?? DateTime.now(),
+        extra = extra ?? const {};
+
+  final String method;
+  final Uri uri;
+  final int? statusCode;
+  final Duration? duration;
+  final String? errorMessage;
+  final Object? requestBody;
+  final Object? responseBody;
+  final Map<String, dynamic> extra;
+  final DateTime timestamp;
+
+  bool get isError =>
+      errorMessage != null || (statusCode != null && statusCode! >= 400);
+
+  factory NetworkLogEvent.fromResponse(Response response) {
+    final startedAt = response.requestOptions.extra['startedAt'] as DateTime?;
+    return NetworkLogEvent(
+      method: response.requestOptions.method,
+      uri: response.requestOptions.uri,
+      statusCode: response.statusCode,
+      duration: startedAt != null ? DateTime.now().difference(startedAt) : null,
+      responseBody: response.data,
+      extra: {
+        'requestHeaders': Map<String, String>.fromEntries(
+          response.requestOptions.headers.entries
+              .where((entry) => entry.key.toLowerCase() != 'authorization')
+              .map(
+                (entry) => MapEntry(entry.key, entry.value.toString()),
+              ),
+        ),
+        'query': response.requestOptions.queryParameters,
+      },
+    );
+  }
+
+  factory NetworkLogEvent.fromError(DioException error) {
+    final startedAt = error.requestOptions.extra['startedAt'] as DateTime?;
+    return NetworkLogEvent(
+      method: error.requestOptions.method,
+      uri: error.requestOptions.uri,
+      statusCode: error.response?.statusCode,
+      duration: startedAt != null ? DateTime.now().difference(startedAt) : null,
+      errorMessage: error.message,
+      responseBody: error.response?.data,
+      extra: {
+        'requestHeaders': Map<String, String>.fromEntries(
+          error.requestOptions.headers.entries
+              .where((entry) => entry.key.toLowerCase() != 'authorization')
+              .map(
+                (entry) => MapEntry(entry.key, entry.value.toString()),
+              ),
+        ),
+        'query': error.requestOptions.queryParameters,
+      },
+    );
+  }
+}

--- a/lib/core/network/api_interceptor.dart
+++ b/lib/core/network/api_interceptor.dart
@@ -1,6 +1,6 @@
-import 'dart:developer';
-
 import 'package:dio/dio.dart';
+import '../logging/app_logger.dart';
+import '../logging/network_event.dart';
 
 typedef TokenProvider = String? Function();
 
@@ -15,22 +15,28 @@ class ApiInterceptor extends Interceptor {
     if (token != null && token.isNotEmpty) {
       options.headers['Authorization'] = 'Bearer $token';
     }
-    log('➡️ ${options.method} ${options.uri}', name: 'ApiInterceptor');
+    options.extra['startedAt'] = DateTime.now();
+    AppLogger.recordNetworkEvent(
+      NetworkLogEvent(
+        method: options.method,
+        uri: options.uri,
+        requestBody: options.data,
+        extra: {'query': options.queryParameters},
+      ),
+    );
     super.onRequest(options, handler);
   }
 
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) {
     final code = err.response?.statusCode;
-    log('❌ ${code ?? 'ERR'} ${err.requestOptions.uri}: ${err.message}',
-        name: 'ApiInterceptor');
+    AppLogger.recordNetworkEvent(NetworkLogEvent.fromError(err));
     super.onError(err, handler);
   }
 
   @override
   void onResponse(Response response, ResponseInterceptorHandler handler) {
-    log('✅ ${response.statusCode} ${response.requestOptions.uri}',
-        name: 'ApiInterceptor');
+    AppLogger.recordNetworkEvent(NetworkLogEvent.fromResponse(response));
     super.onResponse(response, handler);
   }
 }

--- a/lib/core/network/network_error.dart
+++ b/lib/core/network/network_error.dart
@@ -1,0 +1,99 @@
+import 'package:dio/dio.dart';
+
+/// YouthRoad domain-level error categories so the UI can make user-friendly
+/// decisions regardless of the underlying HTTP client error.
+enum YouthRoadErrorCategory {
+  network,
+  server,
+  filter,
+}
+
+class YouthRoadException implements Exception {
+  YouthRoadException(this.category, {this.statusCode, this.message, this.cause});
+
+  final YouthRoadErrorCategory category;
+  final int? statusCode;
+  final String? message;
+  final Object? cause;
+
+  @override
+  String toString() {
+    final buffer = StringBuffer('YouthRoadException($category');
+    if (statusCode != null) buffer.write(', status: $statusCode');
+    if (message != null) buffer.write(', message: $message');
+    buffer.write(')');
+    return buffer.toString();
+  }
+}
+
+class YouthRoadErrorMapper {
+  YouthRoadErrorMapper._();
+
+  static YouthRoadException fromDio(DioException error) {
+    if (_isNetworkTimeout(error)) {
+      return YouthRoadException(
+        YouthRoadErrorCategory.network,
+        message: error.message,
+        statusCode: error.response?.statusCode,
+        cause: error,
+      );
+    }
+
+    final status = error.response?.statusCode;
+    if (status != null) {
+      if (status >= 500) {
+        return YouthRoadException(
+          YouthRoadErrorCategory.server,
+          statusCode: status,
+          message: error.message,
+          cause: error,
+        );
+      }
+      if (status >= 400) {
+        return YouthRoadException(
+          YouthRoadErrorCategory.filter,
+          statusCode: status,
+          message: error.message,
+          cause: error,
+        );
+      }
+    }
+
+    switch (error.type) {
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.receiveTimeout:
+      case DioExceptionType.connectionError:
+        return YouthRoadException(
+          YouthRoadErrorCategory.network,
+          statusCode: status,
+          message: error.message,
+          cause: error,
+        );
+      case DioExceptionType.badResponse:
+        return YouthRoadException(
+          status != null && status >= 500
+              ? YouthRoadErrorCategory.server
+              : YouthRoadErrorCategory.filter,
+          statusCode: status,
+          message: error.message,
+          cause: error,
+        );
+      case DioExceptionType.cancel:
+      case DioExceptionType.badCertificate:
+      case DioExceptionType.unknown:
+        return YouthRoadException(
+          YouthRoadErrorCategory.network,
+          statusCode: status,
+          message: error.message,
+          cause: error,
+        );
+    }
+  }
+
+  static bool _isNetworkTimeout(DioException error) {
+    return error.type == DioExceptionType.connectionTimeout ||
+        error.type == DioExceptionType.receiveTimeout ||
+        error.type == DioExceptionType.sendTimeout;
+  }
+}

--- a/lib/features/policy/data/policy_repository.dart
+++ b/lib/features/policy/data/policy_repository.dart
@@ -1,6 +1,9 @@
+import 'package:dio/dio.dart';
+
 import '../../../core/api/dto/policy_request_dto.dart';
 import '../../../core/api/models/policy.dart' as remote;
 import '../../../core/api/youth_api_service.dart';
+import '../../../core/network/network_error.dart';
 import 'models/category.dart';
 import 'models/policy.dart';
 import 'models/region.dart';
@@ -33,25 +36,29 @@ class PolicyRepository {
     final normalizedStatus = status?.trim().isEmpty ?? true ? null : status?.trim();
     final normalizedAge = age == null || age <= 0 ? null : age;
     final normalizedKeyword = keyword?.trim().isEmpty ?? true ? null : keyword?.trim();
-    final response = await _api.fetchPolicies(
-      PolicyRequestDto(
-        apiKey: apiKey,
-        searchRgnSe: normalizedRegion,
-        searchPolicyType: normalizedCategories,
-        searchPolicyStatus: normalizedStatus,
-        searchAge: normalizedAge,
-        searchKeyword: normalizedKeyword,
-        pageIndex: page <= 0 ? 1 : page,
-        pageSize: size,
-      ),
-    );
-    final policies = (response.resultList ?? const <remote.Policy>[]) 
-        .map(Policy.fromRemote)
-        .toList(growable: false);
-    for (final policy in policies) {
-      _policyCache[policy.id] = policy;
+    try {
+      final response = await _api.fetchPolicies(
+        PolicyRequestDto(
+          apiKey: apiKey,
+          searchRgnSe: normalizedRegion,
+          searchPolicyType: normalizedCategories,
+          searchPolicyStatus: normalizedStatus,
+          searchAge: normalizedAge,
+          searchKeyword: normalizedKeyword,
+          pageIndex: page <= 0 ? 1 : page,
+          pageSize: size,
+        ),
+      );
+      final policies = (response.resultList ?? const <remote.Policy>[])
+          .map(Policy.fromRemote)
+          .toList(growable: false);
+      for (final policy in policies) {
+        _policyCache[policy.id] = policy;
+      }
+      return policies;
+    } on DioException catch (error) {
+      throw YouthRoadErrorMapper.fromDio(error);
     }
-    return policies;
   }
 
   Future<Policy> getPolicyDetail(String id) async {
@@ -59,25 +66,29 @@ class PolicyRepository {
     if (cached != null) {
       return cached;
     }
-    final response = await _api.fetchPolicies(
-      PolicyRequestDto(
-        apiKey: apiKey,
-        searchKeyword: id,
-        pageIndex: 1,
-        pageSize: 5,
-      ),
-    );
-    final candidates = response.resultList ?? const <remote.Policy>[];
-    if (candidates.isEmpty) {
-      throw StateError('Policy not found');
+    try {
+      final response = await _api.fetchPolicies(
+        PolicyRequestDto(
+          apiKey: apiKey,
+          searchKeyword: id,
+          pageIndex: 1,
+          pageSize: 5,
+        ),
+      );
+      final candidates = response.resultList ?? const <remote.Policy>[];
+      if (candidates.isEmpty) {
+        throw StateError('Policy not found');
+      }
+      final remotePolicy = candidates.firstWhere(
+        (item) => item.id == id || item.policyName == id,
+        orElse: () => candidates.first,
+      );
+      final policy = Policy.fromRemote(remotePolicy);
+      _policyCache[policy.id] = policy;
+      return policy;
+    } on DioException catch (error) {
+      throw YouthRoadErrorMapper.fromDio(error);
     }
-    final remotePolicy = candidates.firstWhere(
-      (item) => item.id == id || item.policyName == id,
-      orElse: () => candidates.first,
-    );
-    final policy = Policy.fromRemote(remotePolicy);
-    _policyCache[policy.id] = policy;
-    return policy;
   }
 
   String? _joinCategories(List<String>? categories) {

--- a/lib/features/region/presentation/region_select_page.dart
+++ b/lib/features/region/presentation/region_select_page.dart
@@ -1,13 +1,88 @@
 import 'package:flutter/material.dart';
 
-class RegionSelectPage extends StatelessWidget {
+import '../../../core/location/location_service.dart';
+
+class RegionSelectPage extends StatefulWidget {
   const RegionSelectPage({super.key});
+
+  @override
+  State<RegionSelectPage> createState() => _RegionSelectPageState();
+}
+
+class _RegionSelectPageState extends State<RegionSelectPage> {
+  final LocationService _locationService = LocationService();
+  bool _loading = false;
+  String? _regionCode;
+  String? _regionName;
+  String? _error;
+
+  Future<void> _useCurrentLocation() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final result = await _locationService.getCurrentLocation();
+      setState(() {
+        _regionCode = result.regionCode;
+        _regionName = result.placemark.administrativeArea ?? '-';
+      });
+    } on Exception catch (error) {
+      setState(() {
+        _error = error.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+        });
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('지역 선택')),
-      body: const Center(child: Text('Unity 지도와 리스트를 통한 지역 선택 UI 예정')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              '현재 위치로 검색',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'GPS 권한을 허용하면 현재 행정구역을 YouthRoad 지역 코드로 변환해 필터에 적용합니다.',
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton.icon(
+              icon: const Icon(Icons.my_location),
+              onPressed: _loading ? null : _useCurrentLocation,
+              label: Text(_loading ? '위치 확인 중...' : '현재 위치로 검색'),
+            ),
+            const SizedBox(height: 16),
+            if (_regionCode != null)
+              Card(
+                child: ListTile(
+                  title: Text('YouthRoad 코드: $_regionCode'),
+                  subtitle: Text('행정구역: ${_regionName ?? '-'}'),
+                ),
+              ),
+            if (_error != null)
+              Text(
+                _error!,
+                style: const TextStyle(color: Colors.red),
+              ),
+            const Spacer(),
+            const Text(
+              'Unity 지도에서 지역을 선택하면 동일한 YouthRoad 코드가 적용됩니다.',
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/unity/controller/unity_bridge_logger.dart
+++ b/lib/features/unity/controller/unity_bridge_logger.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+class UnityBridgeLogger {
+  const UnityBridgeLogger();
+
+  void logEvent({
+    required String direction,
+    required String event,
+    required Map<String, dynamic> payload,
+    bool success = true,
+    String? note,
+  }) {
+    final entry = {
+      'direction': direction,
+      'event': event,
+      'payload': payload,
+      'success': success,
+      'note': note,
+      'timestamp': DateTime.now().toIso8601String(),
+    };
+    debugPrint(jsonEncode(entry), wrapWidth: 0);
+  }
+}

--- a/lib/features/unity/controller/unity_controller.dart
+++ b/lib/features/unity/controller/unity_controller.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_unity_widget/flutter_unity_widget.dart';
 
 import '../../policy/controller/policy_list_controller.dart';
+import 'unity_bridge_logger.dart';
+import 'unity_region_mapper.dart';
 
 enum UnityMessageType {
   setSelectedRegion('SET_SELECTED_REGION'),
@@ -45,6 +47,13 @@ class UnityState {
 }
 
 class UnityController extends Notifier<UnityState> {
+  UnityController({UnityRegionMapper? regionMapper, UnityBridgeLogger? logger})
+      : _regionMapper = regionMapper ?? const UnityRegionMapper(),
+        _logger = logger ?? const UnityBridgeLogger();
+
+  final UnityRegionMapper _regionMapper;
+  final UnityBridgeLogger _logger;
+
   @override
   UnityState build() => const UnityState();
 
@@ -63,6 +72,11 @@ class UnityController extends Notifier<UnityState> {
     String methodName = 'OnFlutterMessage',
   }) async {
     final message = buildMessage(type, payload);
+    _logger.logEvent(
+      direction: 'flutter->unity',
+      event: type.value,
+      payload: payload,
+    );
     controller.postMessage(gameObject, methodName, message);
   }
 
@@ -72,9 +86,19 @@ class UnityController extends Notifier<UnityState> {
     final payload = decoded['payload'] as Map<String, dynamic>? ?? {};
     switch (type) {
       case 'REGION_SELECTED':
+        _logger.logEvent(
+          direction: 'unity->flutter',
+          event: type!,
+          payload: payload,
+        );
         _onRegionSelected(payload);
         break;
       case 'MAP_READY':
+        _logger.logEvent(
+          direction: 'unity->flutter',
+          event: type!,
+          payload: payload,
+        );
         state = state.copyWith(isReady: true);
         break;
       default:
@@ -85,14 +109,16 @@ class UnityController extends Notifier<UnityState> {
   void _onRegionSelected(Map<String, dynamic> payload) {
     final regionCode = payload['regionCode'] as String?;
     final regionName = payload['regionName'] as String?;
+    final youthRoadCode =
+        regionCode != null ? _regionMapper.toYouthRoadCode(regionCode) : null;
     state = state.copyWith(
-      selectedRegionCode: regionCode,
+      selectedRegionCode: youthRoadCode ?? regionCode,
       selectedRegionName: regionName,
     );
-    if (regionCode != null) {
+    if (youthRoadCode != null) {
       ref.read(policyFilterUseProfileProvider.notifier).state = false;
       final notifier = ref.read(policyFilterStateProvider.notifier);
-      notifier.state = notifier.state.copyWith(region: regionCode);
+      notifier.state = notifier.state.copyWith(region: youthRoadCode);
     }
   }
 }

--- a/lib/features/unity/controller/unity_region_mapper.dart
+++ b/lib/features/unity/controller/unity_region_mapper.dart
@@ -1,0 +1,22 @@
+class UnityRegionMapper {
+  const UnityRegionMapper();
+
+  /// Maps Unity-side composite codes (e.g., `GB-GS`) to YouthRoad numeric
+  /// region codes. The numeric codes follow the province/city administrative
+  /// codes used by the public API.
+  static const Map<String, String> _unityToYouthRoad = {
+    'GB-GS': '47', // 경상북도 (경산시 등 세부 지역 포함)
+    'GB-DG': '27', // 대구광역시
+    'GB-PO': '47', // 포항
+    'GB-AN': '47', // 안동
+    'GB-GM': '47', // 구미
+    'GB-GJ': '47', // 경주
+    'GB-YS': '47', // 영주/영천 등 기타 경북 권역
+  };
+
+  String? toYouthRoadCode(String unityCode) {
+    return _unityToYouthRoad[unityCode];
+  }
+
+  bool isSupported(String unityCode) => _unityToYouthRoad.containsKey(unityCode);
+}

--- a/lib/features/unity/presentation/unity_map_page.dart
+++ b/lib/features/unity/presentation/unity_map_page.dart
@@ -36,6 +36,10 @@ class _UnityMapPageState extends ConsumerState<UnityMapPage> {
       return;
     }
     final unityCtrl = ref.read(unityControllerProvider.notifier);
+    final state = ref.read(unityControllerProvider);
+    if (!state.isReady) {
+      return;
+    }
     unityCtrl.sendMessage(
       controller,
       UnityMessageType.highlightRegion,
@@ -53,7 +57,7 @@ class _UnityMapPageState extends ConsumerState<UnityMapPage> {
     final availabilityAsync = ref.watch(unityRuntimeAvailabilityProvider);
     final unityCtrl = ref.read(unityControllerProvider.notifier);
 
-    if (unityState.isReady) {
+    if (unityState.isReady && !_initialRegionDispatched) {
       _dispatchInitialRegion();
     }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'core/logging/app_logger.dart';
 import 'app/app_router.dart';
 import 'app/app_startup.dart';
 import 'app/app_theme.dart';
 
-void main() {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  runApp(const ProviderScope(child: YouthRoadApp()));
+  await AppLogger.bootstrap(
+    () => runApp(const ProviderScope(child: YouthRoadApp())),
+  );
 }
 
 class YouthRoadApp extends ConsumerWidget {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,11 @@ dependencies:
   shared_preferences: 2.1.1
   url_launcher: ^6.3.0
   device_info_plus: ^11.1.0
+  firebase_core: ^3.8.0
+  firebase_crashlytics: ^4.1.1
+  sentry_flutter: ^8.9.0
+  geocoding: ^2.2.5
+  geolocator: ^12.0.0
 
   # Unity 연동
   flutter_unity_widget: 2022.2.0

--- a/test/integration/youth_api_integration_test.dart
+++ b/test/integration/youth_api_integration_test.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:youth_road_app/core/api/dto/policy_request_dto.dart';
 import 'package:youth_road_app/core/api/youth_api_service.dart';
+import 'package:youth_road_app/core/network/network_error.dart';
 
 const String _apiKey = String.fromEnvironment('YOUTHROAD_API_KEY');
 
@@ -50,6 +51,54 @@ void main() {
       expect(lastStatus, equals(200));
       expect(response.success, isTrue);
       expect(response.resultList, isNotNull);
+    });
+
+    test('invalid endpoint surfaces as server error', () async {
+      final failingApi = YouthApiService(
+        Dio(
+          BaseOptions(
+            connectTimeout: const Duration(seconds: 5),
+            receiveTimeout: const Duration(seconds: 5),
+            baseUrl: '$baseUrl/invalid',
+          ),
+        ),
+        baseUrl: '$baseUrl/invalid',
+      );
+
+      expect(
+        () => failingApi.fetchPolicies(
+          PolicyRequestDto(apiKey: _apiKey, pageIndex: 1, pageSize: 1),
+        ),
+        throwsA(isA<DioException>().having(
+          (err) => YouthRoadErrorMapper.fromDio(err).category,
+          'category',
+          YouthRoadErrorCategory.server,
+        )),
+      );
+    });
+
+    test('connect timeout maps to network category', () async {
+      final slowApi = YouthApiService(
+        Dio(
+          BaseOptions(
+            baseUrl: 'https://10.255.255.1',
+            connectTimeout: const Duration(milliseconds: 500),
+            receiveTimeout: const Duration(seconds: 2),
+          ),
+        ),
+        baseUrl: 'https://10.255.255.1',
+      );
+
+      expect(
+        () => slowApi.fetchPolicies(
+          PolicyRequestDto(apiKey: _apiKey, pageIndex: 1, pageSize: 1),
+        ),
+        throwsA(isA<DioException>().having(
+          (err) => YouthRoadErrorMapper.fromDio(err).category,
+          'category',
+          YouthRoadErrorCategory.network,
+        )),
+      );
     });
 
     test('institutions endpoint returns data and departments resolve', () async {

--- a/tool/check_unity_bridge_logs.dart
+++ b/tool/check_unity_bridge_logs.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+import 'dart:io';
+
+Future<void> main(List<String> args) async {
+  if (args.isEmpty) {
+    stderr.writeln('Usage: dart run tool/check_unity_bridge_logs.dart <log_file>');
+    exitCode = 64;
+    return;
+  }
+  final file = File(args.first);
+  if (!await file.exists()) {
+    stderr.writeln('Log file not found: ${file.path}');
+    exitCode = 66;
+    return;
+  }
+
+  var mapReadySeen = false;
+  var regionSelectedSeen = false;
+
+  final lines = await file.readAsLines();
+  for (final line in lines) {
+    try {
+      final json = jsonDecode(line) as Map<String, dynamic>;
+      final event = json['event']?.toString();
+      final success = json['success'] != false;
+      if (success && event == 'MAP_READY') {
+        mapReadySeen = true;
+      }
+      if (success && event == 'REGION_SELECTED') {
+        regionSelectedSeen = true;
+      }
+    } catch (_) {
+      continue;
+    }
+  }
+
+  if (!mapReadySeen || !regionSelectedSeen) {
+    stderr.writeln(
+      'Missing bridge events: MAP_READY=${mapReadySeen}, REGION_SELECTED=${regionSelectedSeen}',
+    );
+    exitCode = 1;
+    return;
+  }
+  stdout.writeln('Unity bridge log validation passed.');
+}

--- a/unity_project/Assets/Scripts/Logging/UnityLogRelay.cs
+++ b/unity_project/Assets/Scripts/Logging/UnityLogRelay.cs
@@ -1,0 +1,62 @@
+using System;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace YouthRoad.Logging
+{
+    /// <summary>
+    /// Mirrors Unity log entries to a structured message so that Crashlytics or
+    /// Sentry captures consistent metadata with Flutter network events.
+    /// </summary>
+    [DefaultExecutionOrder(-500)]
+    public class UnityLogRelay : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("Optional tag to correlate Unity logs with Flutter network breadcrumbs.")]
+        private string sessionTag = "unity";
+
+        [SerializeField]
+        [Tooltip("Attach stack traces to forwarded messages.")]
+        private bool includeStackTrace = true;
+
+        private void OnEnable()
+        {
+            Application.logMessageReceived += HandleLog;
+        }
+
+        private void OnDisable()
+        {
+            Application.logMessageReceived -= HandleLog;
+        }
+
+        private void HandleLog(string condition, string stackTrace, LogType type)
+        {
+            var payload = new UnityLogPayload
+            {
+                Level = type.ToString(),
+                Message = condition,
+                StackTrace = includeStackTrace ? stackTrace : null,
+                Scene = SceneManager.GetActiveScene().name,
+                DeviceModel = SystemInfo.deviceModel,
+                Platform = Application.platform.ToString(),
+                SessionTag = sessionTag,
+                TimestampIso = DateTimeOffset.UtcNow.ToString("O")
+            };
+
+            Debug.unityLogger.Log($"[unity_log] {JsonUtility.ToJson(payload)}");
+        }
+
+        [Serializable]
+        private class UnityLogPayload
+        {
+            public string Level;
+            public string Message;
+            public string StackTrace;
+            public string Scene;
+            public string DeviceModel;
+            public string Platform;
+            public string SessionTag;
+            public string TimestampIso;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- map Dio errors into YouthRoad domain categories and expand integration coverage for success, error, and timeout cases
- gate Unity map highlights until MAP_READY, log bridge events for MAP_READY/REGION_SELECTED, and add a CI log validation helper
- add geolocation-backed region selection UI and supporting location service dependencies

## Testing
- ❌ `flutter test test/integration/youth_api_integration_test.dart` (flutter not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bfbdbeb78832ab0df6d057cd47368)