### PR TITLE
Fix export directive order in providers

### DIFF
--- a/lib/application/providers.dart
+++ b/lib/application/providers.dart
@@ -11,6 +11,7 @@ import 'notifiers/policy_list_notifier.dart';
 import 'notifiers/policy_paging_notifier.dart';
 
 export 'di.dart';
+export 'notifiers/region_notifier.dart' show regionProvider, RegionNotifier;
 
 final policyListNotifierProvider =
     AsyncNotifierProvider<PolicyListNotifier, List<Policy>>(
@@ -44,5 +45,3 @@ final memoProvider =
 
 final chatProvider =
     NotifierProvider.autoDispose<ChatNotifier, ChatState>(ChatNotifier.new);
-
-export 'notifiers/region_notifier.dart' show regionProvider, RegionNotifier;


### PR DESCRIPTION
## Summary
- move the region notifier export alongside other directives in providers.dart to satisfy directive ordering rules

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692293c6fea88324b4f9f1dd59a821a9)