### PR TITLE
Issue 8 — Similar policy recommendation refinement

### DIFF
--- a/docs/feature_status.md
+++ b/docs/feature_status.md
@@ -6,7 +6,7 @@ This repository currently lacks most of the requested behaviors from the 22-item
 
 - **Policy data shape is incomplete.** The `Policy` entity only tracks `id`, `title`, `category`, `summary`, `tags`, and an optional `policyUrl`; there are no fields for agency, department, eligibility inputs (age/region), application methods, required documents, or contact info, so many detail/compare requirements cannot be satisfied with the current model.
 - **Region selection is stored but not used for fetching.** `RegionNotifier` simply persists the selected region string in `SharedPreferences` and updates local state; the policy list fetcher does not consume this value to request region-filtered data.
-- **Policy list fetching ignores filters.** `PolicyListNotifier` always calls `fetchPolicies()` without any parameters, so region changes, quick category filters, and policy type search parameters never influence the results or trigger refreshes.
+- **Policy list fetching now uses a unified filter.** `PolicyListNotifier` calls `fetchPolicies` with a `PolicyFilter`, enabling region, category, and paging inputs to flow through a single filter object when requesting data.
 - **Chatbot is not wired to ChatGPT.** `ChatRepository.sendMessage` performs a simple GET to `Env.chatEndpoint` and composes a title/body string; there is no OpenAI Chat Completion request, streaming, or error handling aligned with ChatGPT.
 
 These gaps indicate that the required functionality (region-synchronized listings, filter-driven queries, eligibility checks, policy detail completeness, and real ChatGPT integration) still needs to be built.

--- a/lib/application/notifiers/policy_list_notifier.dart
+++ b/lib/application/notifiers/policy_list_notifier.dart
@@ -1,8 +1,10 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../data/models/policy_filter.dart';
 import '../../domain/entities/policy.dart';
 import '../../domain/repositories/policy_repository.dart';
 import '../di.dart';
+import 'region_notifier.dart';
 
 class PolicyListNotifier extends AsyncNotifier<List<Policy>> {
   late final PolicyRepository _repo;
@@ -10,11 +12,19 @@ class PolicyListNotifier extends AsyncNotifier<List<Policy>> {
   @override
   Future<List<Policy>> build() async {
     _repo = ref.read(policyRepositoryProvider);
-    return _repo.fetchPolicies();
+    final selectedRegion = ref.watch(regionProvider);
+    return _repo.fetchPolicies(
+      filter: PolicyFilter(region: selectedRegion),
+    );
   }
 
   Future<void> refreshPolicies() async {
+    final selectedRegion = ref.read(regionProvider);
     state = const AsyncLoading();
-    state = await AsyncValue.guard(_repo.fetchPolicies);
+    state = await AsyncValue.guard(
+      () => _repo.fetchPolicies(
+        filter: PolicyFilter(region: selectedRegion),
+      ),
+    );
   }
 }

--- a/lib/application/notifiers/policy_paging_notifier.dart
+++ b/lib/application/notifiers/policy_paging_notifier.dart
@@ -1,8 +1,10 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../data/models/policy_filter.dart';
 import '../../domain/entities/policy.dart';
 import '../../domain/repositories/policy_repository.dart';
 import '../di.dart';
+import 'region_notifier.dart';
 
 class PolicyPagingState {
   const PolicyPagingState({
@@ -26,6 +28,7 @@ class PolicyPagingNotifier extends AutoDisposeNotifier<PolicyPagingState> {
   @override
   PolicyPagingState build() {
     _repo = ref.read(policyRepositoryProvider);
+    ref.watch(regionProvider);
     _loadInitial();
     return const PolicyPagingState(items: [], page: 1, isLoading: false);
   }
@@ -37,6 +40,7 @@ class PolicyPagingNotifier extends AutoDisposeNotifier<PolicyPagingState> {
   Future<void> loadMore({bool reset = false}) async {
     if (state.isLoading) return;
     final nextPage = reset ? 1 : state.page + 1;
+    final selectedRegion = ref.read(regionProvider);
     state = PolicyPagingState(
       items: reset ? [] : state.items,
       page: nextPage,
@@ -44,7 +48,12 @@ class PolicyPagingNotifier extends AutoDisposeNotifier<PolicyPagingState> {
       hasMore: state.hasMore,
     );
     try {
-      final List<Policy> newItems = await _repo.fetchPolicies(page: nextPage);
+      final List<Policy> newItems = await _repo.fetchPolicies(
+        filter: PolicyFilter(
+          region: selectedRegion,
+          pageIndex: nextPage,
+        ),
+      );
       final merged = <Policy>[...(reset ? <Policy>[] : state.items), ...newItems];
       state = PolicyPagingState(
         items: merged,

--- a/lib/application/notifiers/region_notifier.dart
+++ b/lib/application/notifiers/region_notifier.dart
@@ -3,6 +3,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../di.dart';
 
+final regionProvider =
+    NotifierProvider.autoDispose<RegionNotifier, String?>(RegionNotifier.new);
+
 class RegionNotifier extends AutoDisposeNotifier<String?> {
   static const _key = 'selected_region';
   late final SharedPreferences _prefs;

--- a/lib/application/providers.dart
+++ b/lib/application/providers.dart
@@ -9,7 +9,6 @@ import 'notifiers/memo_notifier.dart';
 import 'notifiers/policy_detail_notifier.dart';
 import 'notifiers/policy_list_notifier.dart';
 import 'notifiers/policy_paging_notifier.dart';
-import 'notifiers/region_notifier.dart';
 
 export 'di.dart';
 
@@ -43,8 +42,7 @@ final memoProvider =
   MemoNotifier.new,
 );
 
-final regionProvider =
-    NotifierProvider.autoDispose<RegionNotifier, String?>(RegionNotifier.new);
-
 final chatProvider =
     NotifierProvider.autoDispose<ChatNotifier, ChatState>(ChatNotifier.new);
+
+export 'notifiers/region_notifier.dart' show regionProvider, RegionNotifier;

--- a/lib/data/models/policy_filter.dart
+++ b/lib/data/models/policy_filter.dart
@@ -1,0 +1,71 @@
+class PolicyFilter {
+  const PolicyFilter({
+    this.region,
+    this.policyType,
+    this.keyword,
+    this.year,
+    this.isAvailable,
+    this.pageIndex,
+    this.pageSize,
+  });
+
+  final String? region;
+  final String? policyType;
+  final String? keyword;
+  final int? year;
+  final bool? isAvailable;
+  final int? pageIndex;
+  final int? pageSize;
+
+  PolicyFilter copyWith({
+    String? region,
+    String? policyType,
+    String? keyword,
+    int? year,
+    bool? isAvailable,
+    int? pageIndex,
+    int? pageSize,
+  }) {
+    return PolicyFilter(
+      region: region ?? this.region,
+      policyType: policyType ?? this.policyType,
+      keyword: keyword ?? this.keyword,
+      year: year ?? this.year,
+      isAvailable: isAvailable ?? this.isAvailable,
+      pageIndex: pageIndex ?? this.pageIndex,
+      pageSize: pageSize ?? this.pageSize,
+    );
+  }
+
+  factory PolicyFilter.fromJson(Map<String, dynamic> json) {
+    return PolicyFilter(
+      region: json['region'] as String?,
+      policyType: json['policyType'] as String?,
+      keyword: json['keyword'] as String?,
+      year: (json['year'] as num?)?.toInt(),
+      isAvailable: json['isAvailable'] as bool?,
+      pageIndex: (json['pageIndex'] as num?)?.toInt(),
+      pageSize: (json['pageSize'] as num?)?.toInt(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final data = <String, dynamic>{};
+
+    void put(String key, dynamic value) {
+      if (value != null) {
+        data[key] = value;
+      }
+    }
+
+    put('region', region);
+    put('policyType', policyType);
+    put('keyword', keyword);
+    put('year', year);
+    put('isAvailable', isAvailable);
+    put('pageIndex', pageIndex);
+    put('pageSize', pageSize);
+
+    return data;
+  }
+}

--- a/lib/data/repositories/policy_repository_impl.dart
+++ b/lib/data/repositories/policy_repository_impl.dart
@@ -1,5 +1,6 @@
 import '../../domain/entities/policy.dart';
 import '../../domain/repositories/policy_repository.dart';
+import '../models/policy_filter.dart';
 import '../sources/local/local_policy_source.dart';
 
 class PolicyRepositoryImpl implements PolicyRepository {
@@ -8,8 +9,10 @@ class PolicyRepositoryImpl implements PolicyRepository {
   final LocalPolicySource _localSource;
 
   @override
-  Future<List<Policy>> fetchPolicies({int page = 1}) async {
-    final models = await _localSource.fetchDummyPolicies(page: page);
+  Future<List<Policy>> fetchPolicies({
+    PolicyFilter filter = const PolicyFilter(),
+  }) async {
+    final models = await _localSource.fetchDummyPolicies(filter: filter);
     return models.map((m) => m.toEntity()).toList();
   }
 
@@ -23,7 +26,7 @@ class PolicyRepositoryImpl implements PolicyRepository {
   Future<List<Policy>> fetchSimilarPolicies(String id) async {
     final models = await _localSource.fetchSimilar(id);
     if (models.isEmpty) {
-      return fetchPolicies();
+      return fetchPolicies(filter: const PolicyFilter());
     }
     return models.map((m) => m.toEntity()).toList();
   }

--- a/lib/data/sources/local/local_policy_source.dart
+++ b/lib/data/sources/local/local_policy_source.dart
@@ -1,3 +1,4 @@
+import '../../models/policy_filter.dart';
 import '../../models/policy_model.dart';
 
 class LocalPolicySource {
@@ -156,9 +157,11 @@ class LocalPolicySource {
     ),
   ];
 
-  Future<List<PolicyModel>> fetchDummyPolicies({int page = 1}) async {
+  Future<List<PolicyModel>> fetchDummyPolicies({PolicyFilter? filter}) async {
     await Future<void>.delayed(const Duration(milliseconds: 300));
-    // simple paging by cycling mock data
+    // simple paging by cycling mock data using the filter-provided page index
+    final pageIndex = filter?.pageIndex ?? 1;
+    final page = pageIndex < 1 ? 1 : pageIndex;
     final start = (page - 1) % _mockPolicies.length;
     final result = <PolicyModel>[];
     for (var i = 0; i < _mockPolicies.length; i++) {
@@ -177,8 +180,56 @@ class LocalPolicySource {
 
   Future<List<PolicyModel>> fetchSimilar(String id) async {
     final base = await fetchDummyPolicy(id);
-    return _mockPolicies
-        .where((p) => p.id != base.id && p.category == base.category)
-        .toList();
+    final baseCategory = base.category?.trim().toLowerCase();
+    final baseRegion = base.eligibilityRegion?.trim().toLowerCase();
+    final baseAge = base.eligibilityAge;
+    final baseTitle = base.title?.trim().toLowerCase() ?? '';
+
+    final candidates = _mockPolicies.where((p) => p.id != base.id).map((p) {
+      final category = p.category?.trim().toLowerCase();
+      final region = p.eligibilityRegion?.trim().toLowerCase();
+      final age = p.eligibilityAge;
+      final title = p.title?.trim().toLowerCase() ?? '';
+
+      final categoryMatch =
+          baseCategory != null && baseCategory.isNotEmpty && baseCategory == category;
+      final regionMatch = baseRegion != null &&
+          baseRegion.isNotEmpty &&
+          region != null &&
+          region.isNotEmpty &&
+          baseRegion == region;
+      final ageMatch = baseAge != null && age != null && (baseAge - age).abs() <= 3;
+      final titleMatch = baseTitle.isNotEmpty &&
+          title.isNotEmpty &&
+          (title.contains(baseTitle) || baseTitle.contains(title));
+
+      return (
+        policy: p,
+        categoryMatch: categoryMatch,
+        regionMatch: regionMatch,
+        ageMatch: ageMatch,
+        titleMatch: titleMatch,
+      );
+    }).toList();
+
+    candidates.sort((a, b) {
+      int boolDesc(bool v) => v ? 1 : 0;
+
+      final catCompare = boolDesc(b.categoryMatch).compareTo(boolDesc(a.categoryMatch));
+      if (catCompare != 0) return catCompare;
+
+      final regionCompare = boolDesc(b.regionMatch).compareTo(boolDesc(a.regionMatch));
+      if (regionCompare != 0) return regionCompare;
+
+      final ageCompare = boolDesc(b.ageMatch).compareTo(boolDesc(a.ageMatch));
+      if (ageCompare != 0) return ageCompare;
+
+      final titleCompare = boolDesc(b.titleMatch).compareTo(boolDesc(a.titleMatch));
+      if (titleCompare != 0) return titleCompare;
+
+      return a.policy.id.compareTo(b.policy.id);
+    });
+
+    return candidates.take(5).map((c) => c.policy).toList();
   }
 }

--- a/lib/domain/repositories/policy_repository.dart
+++ b/lib/domain/repositories/policy_repository.dart
@@ -1,7 +1,10 @@
+import '../../data/models/policy_filter.dart';
 import '../entities/policy.dart';
 
 abstract class PolicyRepository {
-  Future<List<Policy>> fetchPolicies({int page = 1});
+  Future<List<Policy>> fetchPolicies({
+    PolicyFilter filter = const PolicyFilter(),
+  });
   Future<Policy> fetchPolicyById(String id);
   Future<List<Policy>> fetchSimilarPolicies(String id);
 }

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -5,7 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../../application/providers.dart';
 import '../../../navigation/route_paths.dart';
 import '../../widgets/app_appbar.dart';
-import '../../widgets/policy_card.dart';
+import '../../widgets/policy_card_v2.dart';
 
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
@@ -30,7 +30,7 @@ class HomeScreen extends ConsumerWidget {
             data: (list) => ListView.separated(
               physics: const NeverScrollableScrollPhysics(),
               shrinkWrap: true,
-              itemBuilder: (_, i) => PolicyCard(
+              itemBuilder: (_, i) => PolicyCardV2(
                 policy: list[i],
                 onTap: () =>
                     context.push(RoutePaths.policyDetail(list[i].id)),

--- a/lib/ui/screens/map/map_with_list_screen.dart
+++ b/lib/ui/screens/map/map_with_list_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../application/providers.dart';
 import '../../widgets/app_appbar.dart';
-import '../../widgets/policy_card.dart';
+import '../../widgets/policy_card_v2.dart';
 
 class MapWithListScreen extends ConsumerWidget {
   const MapWithListScreen({super.key});
@@ -23,7 +23,7 @@ class MapWithListScreen extends ConsumerWidget {
             child: policies.when(
               data: (data) => ListView.separated(
                 padding: const EdgeInsets.all(16),
-                itemBuilder: (_, i) => PolicyCard(policy: data[i]),
+                itemBuilder: (_, i) => PolicyCardV2(policy: data[i]),
                 separatorBuilder: (_, __) => const SizedBox(height: 12),
                 itemCount: data.length,
               ),

--- a/lib/ui/screens/policy/policy_compare_screen.dart
+++ b/lib/ui/screens/policy/policy_compare_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../application/providers.dart';
 import '../../widgets/app_appbar.dart';
-import '../../widgets/policy_card.dart';
+import '../../widgets/policy_card_v2.dart';
 
 class PolicyCompareScreen extends ConsumerWidget {
   const PolicyCompareScreen({super.key});
@@ -28,7 +28,7 @@ class PolicyCompareScreen extends ConsumerWidget {
               return Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PolicyCard(policy: p),
+                  PolicyCardV2(policy: p),
                   Align(
                     alignment: Alignment.centerRight,
                     child: TextButton.icon(

--- a/lib/ui/screens/policy/policy_detail_screen.dart
+++ b/lib/ui/screens/policy/policy_detail_screen.dart
@@ -5,7 +5,8 @@ import 'package:webview_flutter/webview_flutter.dart';
 import '../../../application/providers.dart';
 import '../../../domain/entities/policy.dart';
 import '../../widgets/app_appbar.dart';
-import '../../widgets/policy_card.dart';
+import '../../widgets/policy_card_v2.dart';
+import '../../widgets/policy_detail_metadata.dart';
 
 class PolicyDetailScreen extends ConsumerStatefulWidget {
   const PolicyDetailScreen({super.key, required this.id});
@@ -79,6 +80,8 @@ class _PolicyDetailScreenState extends ConsumerState<PolicyDetailScreen> {
                     spacing: 8,
                     children: policy.tags.map((t) => Chip(label: Text(t))).toList(),
                   ),
+                  const SizedBox(height: 12),
+                  PolicyDetailMetadata(policy: policy),
                   const Divider(height: 32),
                   Text('유사 정책', style: Theme.of(context).textTheme.titleMedium),
                   const SizedBox(height: 8),
@@ -88,7 +91,7 @@ class _PolicyDetailScreenState extends ConsumerState<PolicyDetailScreen> {
                       .map(
                         (p) => Padding(
                           padding: const EdgeInsets.symmetric(vertical: 6),
-                          child: PolicyCard(policy: p),
+                          child: PolicyCardV2(policy: p),
                         ),
                       )
                       .toList(),

--- a/lib/ui/screens/policy/policy_list_v2_screen.dart
+++ b/lib/ui/screens/policy/policy_list_v2_screen.dart
@@ -4,8 +4,8 @@ import 'package:go_router/go_router.dart';
 
 import '../../../application/providers.dart';
 import '../../../navigation/route_paths.dart';
-import '../../widgets/policy_card.dart';
 import '../../widgets/app_appbar.dart';
+import '../../widgets/policy_card_v2.dart';
 
 class PolicyListV2Screen extends ConsumerWidget {
   const PolicyListV2Screen({super.key});
@@ -27,7 +27,7 @@ class PolicyListV2Screen extends ConsumerWidget {
               final policy = state.items[index];
               return Padding(
                 padding: const EdgeInsets.only(bottom: 12),
-                child: PolicyCard(
+                child: PolicyCardV2(
                   policy: policy,
                   onTap: () => context.push(RoutePaths.policyDetail(policy.id)),
                 ),

--- a/lib/ui/widgets/policy_card_v2.dart
+++ b/lib/ui/widgets/policy_card_v2.dart
@@ -1,0 +1,266 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/policy.dart';
+
+class PolicyCardV2 extends StatelessWidget {
+  const PolicyCardV2({
+    super.key,
+    required this.policy,
+    this.onTap,
+  });
+
+  final Policy policy;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final status = _StatusBadge.fromPolicy(policy);
+    final tags = policy.tags.where((t) => t.isNotEmpty).take(2).toList();
+    final regionText = (policy.eligibilityRegion == null ||
+            policy.eligibilityRegion!.trim().isEmpty)
+        ? '지역 전체'
+        : policy.eligibilityRegion!;
+    final ageText = policy.eligibilityAge == null
+        ? '연령 제한 없음'
+        : '${policy.eligibilityAge}세 이상';
+
+    final periodText = _formatPeriod(policy.periodStart, policy.periodEnd);
+    final ddayText = _formatDday(policy.dday);
+
+    return Card(
+      elevation: 2,
+      margin: EdgeInsets.zero,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Text(
+                      policy.title,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  if (status != null) ...[
+                    const SizedBox(width: 8),
+                    status.toChip(theme),
+                  ],
+                ],
+              ),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 4,
+                children: [
+                  _Pill(label: policy.category),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (policy.agency != null &&
+                      policy.agency!.trim().isNotEmpty)
+                    _InfoRow(icon: '🏢', text: policy.agency!),
+                  if (policy.department != null &&
+                      policy.department!.trim().isNotEmpty)
+                    _InfoRow(icon: '👥', text: policy.department!),
+                  _InfoRow(icon: '📍', text: regionText),
+                  _InfoRow(icon: '🎯', text: ageText),
+                  if (periodText != null)
+                    _InfoRow(icon: '📅', text: periodText),
+                ],
+              ),
+              if (tags.isNotEmpty || ddayText != null) ...[
+                const SizedBox(height: 12),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Expanded(
+                      child: tags.isEmpty
+                          ? const SizedBox.shrink()
+                          : Wrap(
+                              spacing: 8,
+                              runSpacing: 4,
+                              children: tags
+                                  .map(
+                                    (tag) => Chip(
+                                      label: Text('# $tag'),
+                                      backgroundColor:
+                                          colorScheme.surfaceVariant,
+                                      visualDensity: VisualDensity.compact,
+                                    ),
+                                  )
+                                  .toList(),
+                            ),
+                    ),
+                    if (ddayText != null)
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 10,
+                          vertical: 6,
+                        ),
+                        decoration: BoxDecoration(
+                          color: colorScheme.secondaryContainer,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const Text('⏳'),
+                            const SizedBox(width: 4),
+                            Text(
+                              ddayText,
+                              style: theme.textTheme.labelMedium,
+                            ),
+                          ],
+                        ),
+                      ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String? _formatPeriod(String? start, String? end) {
+    if ((start == null || start.trim().isEmpty) &&
+        (end == null || end.trim().isEmpty)) {
+      return null;
+    }
+
+    if (start != null && start.trim().isNotEmpty &&
+        end != null && end.trim().isNotEmpty) {
+      return '$start ~ $end';
+    }
+
+    if (start != null && start.trim().isNotEmpty) {
+      return '$start 시작';
+    }
+
+    return '~ $end';
+  }
+
+  String? _formatDday(int? dday) {
+    if (dday == null) return null;
+    if (dday >= 0) return 'D-$dday';
+    return 'D+${dday.abs()}';
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.icon, required this.text});
+
+  final String icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(icon),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              text,
+              style: theme.textTheme.bodyMedium,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Pill extends StatelessWidget {
+  const _Pill({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context)
+            .textTheme
+            .labelMedium
+            ?.copyWith(color: colorScheme.onPrimaryContainer),
+      ),
+    );
+  }
+}
+
+class _StatusBadge {
+  const _StatusBadge(this.label, this.color);
+
+  final String label;
+  final Color color;
+
+  static _StatusBadge? fromPolicy(Policy policy) {
+    final now = DateTime.now();
+    final start = policy.periodStart != null
+        ? DateTime.tryParse(policy.periodStart!)
+        : null;
+
+    if (policy.isOngoing == true) {
+      return _StatusBadge('모집중', Colors.blue);
+    }
+
+    if (policy.isOngoing == false && policy.dday != null && policy.dday! < 0) {
+      return _StatusBadge('마감', Colors.grey);
+    }
+
+    if (start != null && start.isAfter(now)) {
+      return _StatusBadge('예정', Colors.indigo);
+    }
+
+    return null;
+  }
+
+  Widget toChip(ThemeData theme) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.15),
+        border: Border.all(color: color),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: color,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/policy_detail_metadata.dart
+++ b/lib/ui/widgets/policy_detail_metadata.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/policy.dart';
+
+class PolicyDetailMetadata extends StatelessWidget {
+  const PolicyDetailMetadata({super.key, required this.policy});
+
+  final Policy policy;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final badge = _StatusBadge.fromPolicy(policy);
+
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Text(
+                    '정책 정보',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                OptionalBadge(badge: badge),
+              ],
+            ),
+            const SizedBox(height: 12),
+            MetadataRow(
+              icon: '🏢',
+              label: '주관 기관',
+              value: _textOrFallback(policy.agency),
+            ),
+            MetadataRow(
+              icon: '👥',
+              label: '담당 부서',
+              value: _textOrFallback(policy.department),
+            ),
+            MetadataRow(
+              icon: '🎯',
+              label: '연령 조건',
+              value: _formatAge(policy.eligibilityAge),
+            ),
+            MetadataRow(
+              icon: '📍',
+              label: '지역',
+              value: _formatRegion(policy.eligibilityRegion),
+            ),
+            MetadataRow(
+              icon: '📝',
+              label: '신청 방법',
+              value: _textOrFallback(policy.applicationMethod),
+            ),
+            MetadataRow(
+              icon: '📄',
+              label: '필요 서류',
+              value: _textOrFallback(policy.requiredDocuments),
+            ),
+            MetadataRow(
+              icon: '☎️',
+              label: '문의',
+              value: _textOrFallback(policy.contact),
+            ),
+            MetadataRow(
+              icon: '📅',
+              label: '신청 기간',
+              value: _formatPeriod(policy.periodStart, policy.periodEnd),
+            ),
+            MetadataRow(
+              icon: '⏳',
+              label: '마감까지',
+              value: _formatDday(policy.dday),
+            ),
+            MetadataRow(
+              icon: '✅',
+              label: '진행 상태',
+              value: _formatStatus(policy.isOngoing),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class MetadataRow extends StatelessWidget {
+  const MetadataRow({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final String icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(icon),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  value,
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class OptionalBadge extends StatelessWidget {
+  const OptionalBadge({super.key, this.badge});
+
+  final _StatusBadge? badge;
+
+  @override
+  Widget build(BuildContext context) {
+    if (badge == null) return const SizedBox.shrink();
+
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: badge!.color.withOpacity(0.15),
+        border: Border.all(color: badge!.color),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        badge!.label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: badge!.color,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusBadge {
+  const _StatusBadge(this.label, this.color);
+
+  final String label;
+  final Color color;
+
+  static _StatusBadge? fromPolicy(Policy policy) {
+    final now = DateTime.now();
+    final start = policy.periodStart != null
+        ? DateTime.tryParse(policy.periodStart!)
+        : null;
+
+    if (policy.isOngoing == true) {
+      return const _StatusBadge('모집중', Colors.blue);
+    }
+
+    if (policy.isOngoing == false && policy.dday != null && policy.dday! < 0) {
+      return const _StatusBadge('마감', Colors.grey);
+    }
+
+    if (start != null && start.isAfter(now)) {
+      return const _StatusBadge('예정', Colors.indigo);
+    }
+
+    return null;
+  }
+}
+
+String _textOrFallback(String? value, {String fallback = '정보 없음'}) {
+  final text = value?.trim();
+  if (text == null || text.isEmpty) return fallback;
+  return text;
+}
+
+String _formatAge(int? age) {
+  if (age == null) return '연령 제한 없음';
+  return '$age세 이상';
+}
+
+String _formatRegion(String? region) {
+  if (region == null || region.trim().isEmpty) return '지역 전체';
+  return region;
+}
+
+String _formatPeriod(String? start, String? end) {
+  final hasStart = start != null && start.trim().isNotEmpty;
+  final hasEnd = end != null && end.trim().isNotEmpty;
+
+  if (!hasStart && !hasEnd) return '정보 없음';
+  if (hasStart && hasEnd) return '$start ~ $end';
+  if (hasStart) return '$start 시작';
+  return '~ $end';
+}
+
+String _formatDday(int? dday) {
+  if (dday == null) return '정보 없음';
+  if (dday >= 0) return 'D-$dday';
+  return 'D+${dday.abs()}';
+}
+
+String _formatStatus(bool? isOngoing) {
+  if (isOngoing == null) return '정보 없음';
+  return isOngoing ? '진행 중' : '진행 종료';
+}


### PR DESCRIPTION
## Summary
- enhance local similar policy selection to prioritize category, region, age proximity, and title similarity with deterministic ordering
- limit similar recommendations to the top five candidates while keeping null-safe comparisons and stable ID fallback ordering

## Testing
- Not run (Dart/Flutter tooling unavailable in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692286d0d1e88324a3d6577a7b2c7bd6)