### PR TITLE
Fix export directive order in providers.dart

### DIFF
--- a/lib/application/providers.dart
+++ b/lib/application/providers.dart
@@ -44,5 +44,3 @@ final memoProvider =
 
 final chatProvider =
     NotifierProvider.autoDispose<ChatNotifier, ChatState>(ChatNotifier.new);
-
-export 'notifiers/region_notifier.dart' show regionProvider, RegionNotifier;


### PR DESCRIPTION
## Summary
- move export directives before provider declarations in `providers.dart`
- remove duplicate export to satisfy Dart directive ordering

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922981c47d48324b53de97c004f2d4b)