### PR TITLE
Remove duplicate export directive in providers file

### DIFF
--- a/lib/application/providers.dart
+++ b/lib/application/providers.dart
@@ -43,5 +43,3 @@ final memoProvider =
 
 final chatProvider =
     NotifierProvider.autoDispose<ChatNotifier, ChatState>(ChatNotifier.new);
-
-export 'notifiers/region_notifier.dart' show regionProvider, RegionNotifier;


### PR DESCRIPTION
## Summary
- remove duplicate region_notifier export appearing after declarations
- keep exports grouped at top of providers file

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69229afdb5d8832aae73415a686c6910)