### PR TITLE
Implement favorites screen and routing

### DIFF
--- a/lib/navigation/app_router.dart
+++ b/lib/navigation/app_router.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import '../ui/screens/category/category_screen.dart';
 import '../ui/screens/chatbot/chatbot_screen.dart';
 import '../ui/screens/home/home_screen.dart';
+import '../ui/screens/favorites/favorites_screen.dart';
 import '../ui/screens/institution/department_list_screen.dart';
 import '../ui/screens/institution/institution_list_screen.dart';
 import '../ui/screens/map/kakao_map_screen.dart';
@@ -110,6 +111,11 @@ class AppRouter {
         GoRoute(
           path: RoutePaths.mapWithList,
           builder: (context, state) => const MapWithListScreen(),
+        ),
+        GoRoute(
+          path: RoutePaths.favorites,
+          name: 'FavoritesScreen',
+          builder: (context, state) => const FavoritesScreen(),
         ),
         GoRoute(
           path: RoutePaths.instList,

--- a/lib/navigation/route_paths.dart
+++ b/lib/navigation/route_paths.dart
@@ -12,6 +12,7 @@ class RoutePaths {
   static const policyListV2 = '/policy/list/v2';
   static const policyLegacyList = '/policy/list';
   static const policyCompare = '/policy/compare';
+  static const favorites = '/favorites';
   static const instList = '/inst/list';
   static const deptList = '/inst/:instNo/dept/list';
   static const splashLegacy = '/splash';

--- a/lib/ui/screens/favorites/favorites_screen.dart
+++ b/lib/ui/screens/favorites/favorites_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../application/providers.dart';
+import '../../../domain/entities/policy.dart';
+import '../../../domain/repositories/policy_repository.dart';
+import '../../widgets/policy_card_v2.dart';
+
+class FavoritesScreen extends ConsumerWidget {
+  const FavoritesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final favorites = ref.watch(favoritesProvider);
+    final policyRepository = ref.watch(policyRepositoryProvider);
+    final favoriteIds = favorites.toList()..sort();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('즐겨찾기'),
+      ),
+      body: favoriteIds.isEmpty
+          ? const Center(
+              child: Text('즐겨찾기한 정책이 없습니다.'),
+            )
+          : FutureBuilder<List<Policy>>(
+              key: ValueKey(favoriteIds.join(',')),
+              future: _loadPolicies(favoriteIds, policyRepository),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+
+                if (snapshot.hasError) {
+                  return Center(
+                    child: Text(
+                      '데이터를 불러오지 못했습니다.\n${snapshot.error}',
+                      textAlign: TextAlign.center,
+                    ),
+                  );
+                }
+
+                final policies = snapshot.data ?? [];
+
+                if (policies.isEmpty) {
+                  return const Center(
+                    child: Text('즐겨찾기한 정책이 없습니다.'),
+                  );
+                }
+
+                return ListView.separated(
+                  padding: const EdgeInsets.all(16),
+                  itemCount: policies.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 12),
+                  itemBuilder: (context, index) {
+                    final policy = policies[index];
+                    return PolicyCardV2(policy: policy);
+                  },
+                );
+              },
+            ),
+    );
+  }
+}
+
+Future<List<Policy>> _loadPolicies(
+  List<String> ids,
+  PolicyRepository repository,
+) {
+  return Future.wait(ids.map(repository.fetchPolicyById));
+}

--- a/lib/ui/screens/setting/setting_v2_screen.dart
+++ b/lib/ui/screens/setting/setting_v2_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../application/providers.dart';
 import '../../widgets/app_appbar.dart';
+import '../../../navigation/route_paths.dart';
 
 class SettingV2Screen extends ConsumerWidget {
   const SettingV2Screen({super.key});
@@ -23,8 +24,10 @@ class SettingV2Screen extends ConsumerWidget {
             onTap: () => ref.read(regionProvider.notifier).clear(),
           ),
           ListTile(
-            title: const Text('즐겨찾기 개수'),
+            title: const Text('즐겨찾기 목록'),
             subtitle: Text('${favorites.length}건'),
+            trailing: const Icon(Icons.favorite),
+            onTap: () => context.push(RoutePaths.favorites),
           ),
           ListTile(
             title: const Text('정책 비교함으로 이동'),


### PR DESCRIPTION
## Summary
- add a new Favorites screen that loads saved policies and displays them via PolicyCardV2
- register the /favorites route and expose navigation from the Settings V2 screen
- fetch favorite policy details in parallel for responsive loading

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69229bd8aa60832a891fbf45e691321d)