### PR TITLE
Fix missing ChatMessage import

### DIFF
--- a/lib/ui/screens/chatbot/chatbot_screen.dart
+++ b/lib/ui/screens/chatbot/chatbot_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../application/notifiers/chat_notifier.dart';
 import '../../../application/providers.dart' show chatProvider;
 import '../../../core/constants/app_strings.dart';
+import '../../../domain/entities/chat_message.dart';
 import '../../widgets/app_appbar.dart';
 
 class ChatbotScreen extends ConsumerStatefulWidget {


### PR DESCRIPTION
## Summary
- add missing ChatMessage entity import to chatbot screen

## Testing
- flutter analyze (fails: flutter not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a8f5a7a8832aa461e73c80f90f3b)