### PR TITLE
Fix missing ChatMessage import

### DIFF
--- a/lib/ui/screens/chatbot/chatbot_screen.dart
+++ b/lib/ui/screens/chatbot/chatbot_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../application/notifiers/chat_notifier.dart';
 import '../../../application/providers.dart' show chatProvider;
 import '../../../core/constants/app_strings.dart';
+import '../../../domain/entities/chat_message.dart';
 import '../../widgets/app_appbar.dart';
 
 class ChatbotScreen extends ConsumerStatefulWidget {


### PR DESCRIPTION
## Summary
- import ChatMessage entity into chatbot screen so bubbles type resolves

## Testing
- flutter analyze (fails: flutter not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922abb057f8832a800e9ebd7aa4b08b)