### PR TITLE
Fix chat message import and map scroll offset type

### DIFF
--- a/lib/ui/screens/chatbot/chatbot_screen.dart
+++ b/lib/ui/screens/chatbot/chatbot_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../domain/entities/chat_message.dart';
 import '../../../application/notifiers/chat_notifier.dart';
 import '../../../application/providers.dart' show chatProvider;
 import '../../../core/constants/app_strings.dart';

--- a/lib/ui/screens/map/map_with_list_screen.dart
+++ b/lib/ui/screens/map/map_with_list_screen.dart
@@ -236,7 +236,7 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
       final targetOffset = (index * _estimatedItemHeight)
           .clamp(0, _listController.position.maxScrollExtent);
       _listController.animateTo(
-        targetOffset,
+        targetOffset.toDouble(),
         duration: const Duration(milliseconds: 300),
         curve: Curves.easeOut,
       );


### PR DESCRIPTION
## Summary
- import ChatMessage entity into chatbot screen to resolve missing type
- ensure map list scroll animation uses a double offset

## Testing
- flutter analyze (fails: Flutter not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922b0536854832a997e66c748c27342)