### PR TITLE
Handle Unity message payload without UnityMessage class

### DIFF
--- a/lib/application/controllers/unity_map_controller.dart
+++ b/lib/application/controllers/unity_map_controller.dart
@@ -48,8 +48,8 @@ class UnityMapController {
   void onUnityMessage(dynamic message) {
     dynamic payload = message;
 
-    if (message is UnityMessage) {
-      payload = message.data ?? message.toString();
+    if (message is Map<String, dynamic> && message.containsKey('data')) {
+      payload = message['data'] ?? message.toString();
     }
 
     if (payload is String) {


### PR DESCRIPTION
## Summary
- remove the dependency on the UnityMessage type when handling Unity messages
- keep message parsing logic working for string and map payloads

## Testing
- flutter analyze *(not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922b382fa14832aac4c3c726eaf8958)