### PR TITLE
Add global error fallback and cleanup controllers

### DIFF
--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -1,8 +1,10 @@
+import 'package:flutter/foundation.dart';
+
 class Logger {
   const Logger._();
 
   static void debug(String message) {
-    // Simple debug logger that can be enhanced later.
+    if (!kDebugMode) return;
     // ignore: avoid_print
     print('[DEBUG] $message');
   }

--- a/lib/navigation/app_router.dart
+++ b/lib/navigation/app_router.dart
@@ -20,6 +20,7 @@ import '../ui/screens/setting/setting_v2_screen.dart';
 import '../ui/screens/splash/splash_screen.dart';
 import '../ui/screens/unity/unity_screen.dart';
 import '../ui/widgets/bottom_nav.dart';
+import '../ui/widgets/global_error_view.dart';
 import 'route_paths.dart';
 
 class AppRouter {
@@ -28,6 +29,14 @@ class AppRouter {
   GoRouter router() {
     return GoRouter(
       initialLocation: RoutePaths.splash,
+      errorBuilder: (context, state) {
+        return Scaffold(
+          body: GlobalErrorView(
+            message: state.error?.toString() ?? '페이지를 불러오지 못했습니다.',
+            onRetry: () => context.go(RoutePaths.home),
+          ),
+        );
+      },
       routes: [
         GoRoute(
           path: RoutePaths.splash,

--- a/lib/ui/screens/institution/institution_list_screen.dart
+++ b/lib/ui/screens/institution/institution_list_screen.dart
@@ -28,10 +28,17 @@ class _InstitutionListScreenState extends ConsumerState<InstitutionListScreen> {
     setState(() => _loading = true);
     final repo = ref.read(institutionRepositoryProvider);
     final data = await repo.fetchInstitutions(keyword: keyword);
+    if (!mounted) return;
     setState(() {
       _items = data;
       _loading = false;
     });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
   }
 
   @override

--- a/lib/ui/screens/map/map_with_list_screen.dart
+++ b/lib/ui/screens/map/map_with_list_screen.dart
@@ -9,6 +9,7 @@ import '../../../core/constants/env.dart';
 import '../../../domain/entities/policy.dart';
 import '../../widgets/app_appbar.dart';
 import '../../widgets/policy_card_v2.dart';
+import '../../widgets/global_error_view.dart';
 import 'kakao_map_html_builder.dart';
 
 class MapWithListScreen extends ConsumerStatefulWidget {
@@ -120,8 +121,12 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
                   itemCount: data.length,
                 ),
                 loading: () => const Center(child: CircularProgressIndicator()),
-                error: (e, st) => Center(
-                  child: Text('정책을 불러오지 못했습니다: $e'),
+                error: (e, st) => GlobalErrorView(
+                  message: '정책을 불러오지 못했습니다: $e',
+                  onRetry: () {
+                    ref.invalidate(policyListNotifierProvider);
+                    ref.read(policyListNotifierProvider); // trigger reload
+                  },
                 ),
               ),
             ),

--- a/lib/ui/widgets/global_error_view.dart
+++ b/lib/ui/widgets/global_error_view.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class GlobalErrorView extends StatelessWidget {
+  const GlobalErrorView({
+    super.key,
+    this.message = '일시적인 오류가 발생했습니다.',
+    this.onRetry,
+  });
+
+  final String message;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.cloud_off, size: 48),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            if (onRetry != null)
+              FilledButton.icon(
+                onPressed: onRetry,
+                icon: const Icon(Icons.refresh),
+                label: const Text('다시 시도'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable global error view and wire it into the router and list map screen
- guard debug logging in release builds
- ensure institution search controller is disposed properly
- prevent InstitutionListScreen from calling setState after dispose with a mounted check

## Testing
- dart format lib || echo "dart format unavailable"
- flutter test || echo "flutter test unavailable"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922b41f2688832a8f85e370580b0312)