### PR TITLE
Fix policy list V2 provider import

### DIFF
--- a/lib/ui/screens/policy/policy_list_v2_screen.dart
+++ b/lib/ui/screens/policy/policy_list_v2_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../application/notifiers/policy_list_notifier.dart';
+import '../../../application/providers.dart';
 import '../../../navigation/route_paths.dart';
 import '../../../data/sources/local/search_history_source.dart';
 import '../../widgets/app_appbar.dart';


### PR DESCRIPTION
## Summary
- add the shared providers import to policy list V2 screen so the policy notifier provider is available

## Testing
- flutter analyze *(fails: flutter command unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922db7c1f388324887e5dfcf29c6eba)