### PR TITLE
Fix Riverpod providers and imports

### DIFF
--- a/lib/application/notifiers/department_notifier.dart
+++ b/lib/application/notifiers/department_notifier.dart
@@ -13,7 +13,7 @@ final departmentNotifierProvider = AutoDisposeAsyncNotifierProviderFamily<
 );
 
 class DepartmentNotifier
-    extends AutoDisposeAsyncNotifier<List<DepartmentModel>> {
+    extends AutoDisposeFamilyAsyncNotifier<List<DepartmentModel>, String> {
   late String _instId;
   String _keyword = '';
 

--- a/lib/ui/screens/policy/policy_list_v2_screen.dart
+++ b/lib/ui/screens/policy/policy_list_v2_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../application/notifiers/policy_list_notifier.dart';
+import '../../../application/providers.dart';
 import '../../../navigation/route_paths.dart';
 import '../../../data/sources/local/search_history_source.dart';
 import '../../widgets/app_appbar.dart';


### PR DESCRIPTION
## Summary
- update department notifier to use family async notifier signature
- ensure policy list v2 screen imports provider definitions for notifier usage

## Testing
- flutter analyze (fails: flutter not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922e046d3d88324bb41344b6803e58a)