### PR TITLE
Fix policy field references and provider usage

### DIFF
--- a/lib/application/notifiers/department_notifier.dart
+++ b/lib/application/notifiers/department_notifier.dart
@@ -13,7 +13,7 @@ final departmentNotifierProvider = AutoDisposeAsyncNotifierProviderFamily<
 );
 
 class DepartmentNotifier
-    extends AutoDisposeAsyncNotifier<List<DepartmentModel>> {
+    extends AutoDisposeFamilyAsyncNotifier<List<DepartmentModel>, String> {
   late String _instId;
   String _keyword = '';
 

--- a/lib/data/sources/remote/policy_remote_source.dart
+++ b/lib/data/sources/remote/policy_remote_source.dart
@@ -53,8 +53,8 @@ class PolicyRemoteSource {
   Future<List<PolicyModel>> fetchSimilar(String id) async {
     final base = await fetchPolicyById(id);
     final filter = PolicyFilter(
-      searchRgnSe: base.rgnSeNm,
-      searchPolicyType: base.policyTypeNm,
+      searchRgnSe: base.regionName,
+      searchPolicyType: base.typeName,
       pageIndex: 1,
       recordCount: 10,
     );

--- a/lib/ui/screens/policy/policy_detail_screen.dart
+++ b/lib/ui/screens/policy/policy_detail_screen.dart
@@ -198,7 +198,7 @@ class _PolicyDetailScreenState extends ConsumerState<PolicyDetailScreen> {
             const Divider(height: 32),
             FilledButton.icon(
   onPressed: () {
-    final url = policy.detailUrl;
+    final url = policy.dtlLinkUrl;
     if (url == null || url.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(

--- a/lib/ui/screens/policy/policy_list_v2_screen.dart
+++ b/lib/ui/screens/policy/policy_list_v2_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../application/notifiers/policy_list_notifier.dart';
+import '../../../application/providers.dart';
 import '../../../navigation/route_paths.dart';
 import '../../../data/sources/local/search_history_source.dart';
 import '../../widgets/app_appbar.dart';

--- a/lib/ui/widgets/policy_detail_metadata.dart
+++ b/lib/ui/widgets/policy_detail_metadata.dart
@@ -40,17 +40,17 @@ class PolicyDetailMetadata extends StatelessWidget {
             MetadataRow(
               icon: '🏢',
               label: '주관 기관',
-              value: _textOrFallback(policy.supervisorName),
+              value: _textOrFallback(policy.sprvsnInstNm),
             ),
             MetadataRow(
               icon: '👥',
               label: '운영 기관',
-              value: _textOrFallback(policy.operatorName),
+              value: _textOrFallback(policy.operInstNm),
             ),
             MetadataRow(
               icon: '📍',
               label: '지역',
-              value: _formatRegion(policy.regionName),
+              value: _formatRegion(policy.rgnSeNm),
             ),
             MetadataRow(
               icon: '📝',
@@ -60,7 +60,7 @@ class PolicyDetailMetadata extends StatelessWidget {
             MetadataRow(
               icon: '📄',
               label: '신청 기간',
-              value: _formatPeriod(policy.applyStartDate, policy.applyEndDate),
+              value: _formatPeriod(policy.applyStart, policy.applyEnd),
             ),
             MetadataRow(
               icon: '☎️',
@@ -70,7 +70,7 @@ class PolicyDetailMetadata extends StatelessWidget {
             MetadataRow(
               icon: '📅',
               label: '운영 기간',
-              value: _formatPeriod(policy.startDate, policy.endDate),
+              value: _formatPeriod(policy.policyBgngYmd, policy.policyEndYmd),
             ),
             MetadataRow(
               icon: '⏳',
@@ -172,8 +172,8 @@ class _StatusBadge {
 
   static _StatusBadge? fromPolicy(Policy policy) {
     final now = DateTime.now();
-    final start = policy.startDate;
-    final end = policy.endDate;
+    final start = policy.policyBgngYmd;
+    final end = policy.policyEndYmd;
 
     if (policy.isOngoing == true) {
       return const _StatusBadge('모집중', Colors.blue);


### PR DESCRIPTION
## Summary
- adjust department notifier to use the family async notifier type
- align policy field usage across data sources and UI with existing entity properties
- import shared providers so policy list screen can access the notifier provider

## Testing
- flutter analyze (fails: flutter not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922e2e937788324b6973f064a736f44)