### PR TITLE
Fix policy provider wiring and expose friendly policy accessors

### DIFF
--- a/lib/application/notifiers/department_notifier.dart
+++ b/lib/application/notifiers/department_notifier.dart
@@ -13,7 +13,7 @@ final departmentNotifierProvider = AutoDisposeAsyncNotifierProviderFamily<
 );
 
 class DepartmentNotifier
-    extends AutoDisposeAsyncNotifier<List<DepartmentModel>> {
+    extends AutoDisposeFamilyAsyncNotifier<List<DepartmentModel>, String> {
   late String _instId;
   String _keyword = '';
 

--- a/lib/data/sources/remote/policy_remote_source.dart
+++ b/lib/data/sources/remote/policy_remote_source.dart
@@ -53,8 +53,8 @@ class PolicyRemoteSource {
   Future<List<PolicyModel>> fetchSimilar(String id) async {
     final base = await fetchPolicyById(id);
     final filter = PolicyFilter(
-      searchRgnSe: base.rgnSeNm,
-      searchPolicyType: base.policyTypeNm,
+      searchRgnSe: base.regionName,
+      searchPolicyType: base.typeName,
       pageIndex: 1,
       recordCount: 10,
     );

--- a/lib/domain/entities/policy.dart
+++ b/lib/domain/entities/policy.dart
@@ -49,4 +49,14 @@ class Policy {
   final List<String> tags;
   final int? dday;
   final bool? isOngoing;
+
+  String? get detailUrl => dtlLinkUrl;
+  String? get supervisorName => sprvsnInstNm;
+  String? get operatorName => operInstNm;
+  String? get regionName => rgnSeNm;
+  String? get typeName => policyTypeNm;
+  DateTime? get startDate => policyBgngYmd;
+  DateTime? get endDate => policyEndYmd;
+  DateTime? get applyStartDate => applyStart;
+  DateTime? get applyEndDate => applyEnd;
 }

--- a/lib/ui/screens/policy/policy_list_v2_screen.dart
+++ b/lib/ui/screens/policy/policy_list_v2_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../application/providers.dart';
 import '../../../application/notifiers/policy_paging_notifier.dart';
 import '../../../navigation/route_paths.dart';
 import '../../../data/sources/local/search_history_source.dart';


### PR DESCRIPTION
## Summary
- update department notifier to use family async notifier with argument
- expose user-friendly getters on the policy entity and align remote filter usage
- import shared providers for policy list v2 screen

## Testing
- not run (environment lacked Flutter SDK)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922e8584ca8832486669d29569ec565)