### PR TITLE
Ensure department and institution repositories use shared providers

### DIFF
--- a/lib/application/notifiers/department_notifier.dart
+++ b/lib/application/notifiers/department_notifier.dart
@@ -3,9 +3,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/api/models/department_model.dart';
-import '../../data/repositories/dept_repository_impl.dart';
-import '../../data/sources/remote/department_remote_source.dart';
-import '../di.dart';
+import '../repository_providers.dart';
 
 final departmentNotifierProvider = AutoDisposeAsyncNotifierProviderFamily<
     DepartmentNotifier, List<DepartmentModel>, String>(
@@ -35,8 +33,7 @@ class DepartmentNotifier
   }
 
   Future<List<DepartmentModel>> _fetch() async {
-    final dio = ref.read(dioProvider);
-    final repository = DeptRepositoryImpl(null, DepartmentRemoteSource(dio));
+    final repository = ref.read(deptRepositoryProvider);
     final items = await repository.getDepartments(
       instId: _instId,
       keyword: _keyword.isEmpty ? null : _keyword,

--- a/lib/application/notifiers/institution_notifier.dart
+++ b/lib/application/notifiers/institution_notifier.dart
@@ -3,9 +3,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/api/models/institution_model.dart';
-import '../../data/repositories/inst_repository_impl.dart';
-import '../../data/sources/remote/institution_remote_source.dart';
-import '../di.dart';
+import '../repository_providers.dart';
 
 final institutionNotifierProvider =
     AutoDisposeAsyncNotifierProvider<InstitutionNotifier, List<InstitutionModel>>(
@@ -27,8 +25,7 @@ class InstitutionNotifier extends AutoDisposeAsyncNotifier<List<InstitutionModel
   }
 
   Future<List<InstitutionModel>> _fetch() async {
-    final dio = ref.read(dioProvider);
-    final repository = InstRepositoryImpl(null, InstitutionRemoteSource(dio));
+    final repository = ref.read(instRepositoryProvider);
     final items = await repository.getInstitutions(keyword: _keyword);
     return items;
   }

--- a/lib/application/providers.dart
+++ b/lib/application/providers.dart
@@ -1,15 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../data/models/dept_model.dart';
-import '../data/models/inst_model.dart';
-import '../data/repositories/dept_repository_impl.dart';
-import '../data/repositories/inst_repository_impl.dart';
-import '../data/sources/remote/dept_remote_source.dart';
-import '../data/sources/remote/inst_remote_source.dart';
-import '../domain/repositories/dept_repository.dart';
-import '../domain/repositories/inst_repository.dart';
 import '../domain/entities/policy.dart';
 import 'di.dart';
+import 'repository_providers.dart';
 import 'notifiers/chat_notifier.dart';
 import 'notifiers/compare_notifier.dart';
 import 'notifiers/favorites_notifier.dart';
@@ -18,6 +11,7 @@ import 'notifiers/policy_list_notifier.dart';
 import 'notifiers/policy_paging_notifier.dart';
 
 export 'di.dart';
+export 'repository_providers.dart';
 export 'notifiers/region_notifier.dart' show regionProvider, RegionNotifier;
 
 final policyListNotifierProvider =
@@ -45,36 +39,3 @@ final compareProvider = AsyncNotifierProvider<CompareNotifier, List<Policy>>(
 
 final chatProvider =
     NotifierProvider.autoDispose<ChatNotifier, ChatState>(ChatNotifier.new);
-
-final instRemoteSourceProvider = Provider<InstRemoteSource>((ref) {
-  final dio = ref.watch(dioProvider);
-  return InstRemoteSource(dio);
-});
-
-final instRepositoryProvider = Provider<InstRepository>((ref) {
-  final remote = ref.watch(instRemoteSourceProvider);
-  return InstRepositoryImpl(remote);
-});
-
-final instListProvider =
-    AutoDisposeFutureProvider<List<InstModel>>((ref) async {
-  final repository = ref.watch(instRepositoryProvider);
-  return repository.fetchInstList();
-});
-
-final deptRemoteSourceProvider = Provider<DeptRemoteSource>((ref) {
-  final dio = ref.watch(dioProvider);
-  return DeptRemoteSource(dio);
-});
-
-final deptRepositoryProvider = Provider<DeptRepository>((ref) {
-  final remote = ref.watch(deptRemoteSourceProvider);
-  return DeptRepositoryImpl(remote);
-});
-
-final deptListProvider = AutoDisposeFutureProvider.family<List<DeptModel>, String>(
-  (ref, instNo) async {
-    final repository = ref.watch(deptRepositoryProvider);
-    return repository.fetchDeptList(instNo: instNo);
-  },
-);

--- a/lib/application/repository_providers.dart
+++ b/lib/application/repository_providers.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/models/dept_model.dart';
+import '../data/models/inst_model.dart';
+import '../data/repositories/dept_repository_impl.dart';
+import '../data/repositories/inst_repository_impl.dart';
+import '../data/sources/remote/dept_remote_source.dart';
+import '../data/sources/remote/inst_remote_source.dart';
+import '../domain/repositories/dept_repository.dart';
+import '../domain/repositories/inst_repository.dart';
+import 'di.dart';
+
+final instRemoteSourceProvider = Provider<InstRemoteSource>((ref) {
+  final dio = ref.watch(dioProvider);
+  return InstRemoteSource(dio);
+});
+
+final instRepositoryProvider = Provider<InstRepository>((ref) {
+  final remote = ref.watch(instRemoteSourceProvider);
+  return InstRepositoryImpl(remote);
+});
+
+final instListProvider = AutoDisposeFutureProvider<List<InstModel>>((ref) async {
+  final repository = ref.watch(instRepositoryProvider);
+  return repository.fetchInstList();
+});
+
+final deptRemoteSourceProvider = Provider<DeptRemoteSource>((ref) {
+  final dio = ref.watch(dioProvider);
+  return DeptRemoteSource(dio);
+});
+
+final deptRepositoryProvider = Provider<DeptRepository>((ref) {
+  final remote = ref.watch(deptRemoteSourceProvider);
+  return DeptRepositoryImpl(remote);
+});
+
+final deptListProvider = AutoDisposeFutureProvider.family<List<DeptModel>, String>(
+  (ref, instNo) async {
+    final repository = ref.watch(deptRepositoryProvider);
+    return repository.fetchDeptList(instNo: instNo);
+  },
+);


### PR DESCRIPTION
## Summary
- centralize department and institution repository providers in a shared module
- update related notifiers to read repository providers instead of constructing new instances

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ef5de9a08324a1d42cd0e38a7ffa)