### PR TITLE
Fix repository providers to use injected Dio (Codex review follow-up for #67)

### DIFF
--- a/lib/application/repository_providers.dart
+++ b/lib/application/repository_providers.dart
@@ -4,15 +4,15 @@ import '../data/models/dept_model.dart';
 import '../data/models/inst_model.dart';
 import '../data/repositories/dept_repository_impl.dart';
 import '../data/repositories/inst_repository_impl.dart';
-import '../data/sources/remote/dept_remote_source.dart';
-import '../data/sources/remote/inst_remote_source.dart';
+import '../data/sources/remote/department_remote_source.dart';
+import '../data/sources/remote/institution_remote_source.dart';
 import '../domain/repositories/dept_repository.dart';
 import '../domain/repositories/inst_repository.dart';
 import 'di.dart';
 
-final instRemoteSourceProvider = Provider<InstRemoteSource>((ref) {
+final instRemoteSourceProvider = Provider<InstitutionRemoteSource>((ref) {
   final dio = ref.watch(dioProvider);
-  return InstRemoteSource(dio);
+  return InstitutionRemoteSource(dio);
 });
 
 final instRepositoryProvider = Provider<InstRepository>((ref) {
@@ -25,9 +25,9 @@ final instListProvider = AutoDisposeFutureProvider<List<InstModel>>((ref) async 
   return repository.fetchInstList();
 });
 
-final deptRemoteSourceProvider = Provider<DeptRemoteSource>((ref) {
+final deptRemoteSourceProvider = Provider<DepartmentRemoteSource>((ref) {
   final dio = ref.watch(dioProvider);
-  return DeptRemoteSource(dio);
+  return DepartmentRemoteSource(dio);
 });
 
 final deptRepositoryProvider = Provider<DeptRepository>((ref) {

--- a/lib/data/repositories/dept_repository_impl.dart
+++ b/lib/data/repositories/dept_repository_impl.dart
@@ -1,17 +1,13 @@
-import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 
 import '../../core/api/models/department_model.dart';
 import '../models/dept_model.dart';
-import '../sources/remote/dept_remote_source.dart';
 import '../sources/remote/department_remote_source.dart';
 import '../../domain/repositories/dept_repository.dart';
 
 class DeptRepositoryImpl implements DeptRepository {
-  DeptRepositoryImpl([this._legacyRemote, DepartmentRemoteSource? remoteSource])
-      : _remoteSource = remoteSource ?? DepartmentRemoteSource(Dio());
+  DeptRepositoryImpl(this._remoteSource);
 
-  final DeptRemoteSource? _legacyRemote;
   final DepartmentRemoteSource _remoteSource;
 
   @override

--- a/lib/data/repositories/inst_repository_impl.dart
+++ b/lib/data/repositories/inst_repository_impl.dart
@@ -1,17 +1,13 @@
-import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 
 import '../../core/api/models/institution_model.dart';
 import '../models/inst_model.dart';
-import '../sources/remote/inst_remote_source.dart';
 import '../sources/remote/institution_remote_source.dart';
 import '../../domain/repositories/inst_repository.dart';
 
 class InstRepositoryImpl implements InstRepository {
-  InstRepositoryImpl([this._legacyRemote, InstitutionRemoteSource? remoteSource])
-      : _remoteSource = remoteSource ?? InstitutionRemoteSource(Dio());
+  InstRepositoryImpl(this._remoteSource);
 
-  final InstRemoteSource? _legacyRemote;
   final InstitutionRemoteSource _remoteSource;
 
   @override


### PR DESCRIPTION
This PR addresses the P1 issues from Codex on #67 by ensuring all institution and department fetches use the configured dioProvider (with interceptors, timeouts, and overrides).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922f54fd8cc832a9a340b7eb2fd7e38)