### PR TITLE
Fix policy detail field names after normalization

### DIFF
--- a/lib/ui/screens/policy/policy_detail_screen.dart
+++ b/lib/ui/screens/policy/policy_detail_screen.dart
@@ -197,12 +197,13 @@ class _PolicyDetailScreenState extends ConsumerState<PolicyDetailScreen> {
             ),
             const Divider(height: 32),
             FilledButton.icon(
-  onPressed: () {
-    final url = policy.detailUrl;
-    if (url == null || url.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-                        content: Text('정책 상세 웹페이지 정보를 찾을 수 없습니다.')),
+              onPressed: () {
+                final url = policy.dtlLinkUrl;
+                if (url == null || url.isEmpty) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('정책 상세 웹페이지 정보를 찾을 수 없습니다.'),
+                    ),
                   );
                   return;
                 }

--- a/lib/ui/widgets/policy_detail_metadata.dart
+++ b/lib/ui/widgets/policy_detail_metadata.dart
@@ -40,17 +40,17 @@ class PolicyDetailMetadata extends StatelessWidget {
             MetadataRow(
               icon: '🏢',
               label: '주관 기관',
-              value: _textOrFallback(policy.supervisorName),
+              value: _textOrFallback(policy.sprvsnInstNm),
             ),
             MetadataRow(
               icon: '👥',
               label: '운영 기관',
-              value: _textOrFallback(policy.operatorName),
+              value: _textOrFallback(policy.operInstNm),
             ),
             MetadataRow(
               icon: '📍',
               label: '지역',
-              value: _formatRegion(policy.regionName),
+              value: _formatRegion(policy.rgnSeNm),
             ),
             MetadataRow(
               icon: '📝',
@@ -60,7 +60,7 @@ class PolicyDetailMetadata extends StatelessWidget {
             MetadataRow(
               icon: '📄',
               label: '신청 기간',
-              value: _formatPeriod(policy.applyStartDate, policy.applyEndDate),
+              value: _formatPeriod(policy.applyStart, policy.applyEnd),
             ),
             MetadataRow(
               icon: '☎️',
@@ -70,7 +70,7 @@ class PolicyDetailMetadata extends StatelessWidget {
             MetadataRow(
               icon: '📅',
               label: '운영 기간',
-              value: _formatPeriod(policy.startDate, policy.endDate),
+              value: _formatPeriod(policy.policyBgngYmd, policy.policyEndYmd),
             ),
             MetadataRow(
               icon: '⏳',
@@ -172,8 +172,8 @@ class _StatusBadge {
 
   static _StatusBadge? fromPolicy(Policy policy) {
     final now = DateTime.now();
-    final start = policy.startDate;
-    final end = policy.endDate;
+    final start = policy.policyBgngYmd;
+    final end = policy.policyEndYmd;
 
     if (policy.isOngoing == true) {
       return const _StatusBadge('모집중', Colors.blue);


### PR DESCRIPTION
## Summary
- update policy metadata widget to use the normalized Policy fields for institutions, region, and date ranges
- use the normalized `dtlLinkUrl` when launching the policy detail webview

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922f5786ad8832ab7ce62fe0ad4fa07)