### PR TITLE
Harden debug-only overlay gating and animate tabs

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -27,3 +27,12 @@ class _MyAppState extends ConsumerState<MyApp> {
     );
   }
 }
+
+class App extends StatelessWidget {
+  const App({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MyApp();
+  }
+}

--- a/lib/application/controllers/unity_map_controller.dart
+++ b/lib/application/controllers/unity_map_controller.dart
@@ -1,10 +1,12 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_unity_widget/flutter_unity_widget.dart';
 
 import '../../domain/entities/policy.dart';
 import '../providers.dart';
+import '../../debug/debug_unity_logger.dart';
 
 /// Provides a bridge between Flutter and Unity for marker exchange on the map
 /// scene.
@@ -53,8 +55,15 @@ class UnityMapController {
     }
 
     if (payload is String) {
+      if (kDebugMode) {
+        DebugUnityLogger.instance.log('Unity -> Flutter: $payload');
+      }
       _parseMessage(payload);
     } else if (payload is Map<String, dynamic>) {
+      if (kDebugMode) {
+        DebugUnityLogger.instance
+            .log('Unity -> Flutter Map: ${payload.toString()}');
+      }
       _handleParsedMessage(payload);
     }
   }

--- a/lib/core/api/youth_api_service.dart
+++ b/lib/core/api/youth_api_service.dart
@@ -1,6 +1,8 @@
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:retrofit/retrofit.dart';
 
+import '../../debug/debug_network_logger.dart';
 import 'dto/policy_request_dto.dart';
 import 'models/department_list_response.dart';
 import 'models/institution_list_response.dart';
@@ -13,7 +15,12 @@ const String apiKey = "yAlMhwGFZps7vHtbsjnbsL6Cpha6bHqaPDSScV6pgU0";
 
 @RestApi(baseUrl: baseUrl)
 abstract class YouthApiService {
-  factory YouthApiService(Dio dio, {String baseUrl}) = _YouthApiService;
+  factory YouthApiService(Dio dio, {String baseUrl}) {
+    if (kDebugMode) {
+      DebugNetworkLogger.instance.attachTo(dio);
+    }
+    return _YouthApiService(dio, baseUrl: baseUrl);
+  }
 
   @GET("/policies")
   Future<PolicyListResponse> fetchPolicies(@Queries() PolicyRequestDto query);

--- a/lib/debug/debug_button.dart
+++ b/lib/debug/debug_button.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class DebugButton extends StatelessWidget {
+  const DebugButton({super.key, required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      bottom: 24,
+      right: 24,
+      child: FloatingActionButton(
+        mini: true,
+        backgroundColor: const Color(0xFF4D8AF0),
+        elevation: 2,
+        onPressed: onPressed,
+        child: const Icon(
+          Icons.bug_report,
+          color: Colors.white,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/debug/debug_network_logger.dart
+++ b/lib/debug/debug_network_logger.dart
@@ -1,0 +1,313 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class NetworkLogEntry {
+  NetworkLogEntry({
+    required this.method,
+    required this.path,
+    this.statusCode,
+    this.duration,
+    required this.timestamp,
+    required this.category,
+  });
+
+  final String method;
+  final String path;
+  final int? statusCode;
+  final Duration? duration;
+  final DateTime timestamp;
+  final String category;
+
+  bool get isSuccess => statusCode != null && statusCode! < 400;
+}
+
+class DebugNetworkLogger {
+  DebugNetworkLogger._();
+
+  static final DebugNetworkLogger instance = DebugNetworkLogger._();
+
+  final ValueNotifier<List<NetworkLogEntry>> _entries =
+      ValueNotifier<List<NetworkLogEntry>>(<NetworkLogEntry>[]);
+
+  ValueListenable<List<NetworkLogEntry>> get entries => _entries;
+
+  void attachTo(Dio dio) {
+    if (!kDebugMode) return;
+    final alreadyAttached = dio.interceptors.any(
+      (interceptor) => interceptor is _DebugNetworkInterceptor,
+    );
+    if (alreadyAttached) return;
+
+    dio.interceptors.add(_DebugNetworkInterceptor(this));
+  }
+
+  void add(NetworkLogEntry entry) {
+    if (!kDebugMode) return;
+    final updated = List<NetworkLogEntry>.from(_entries.value)..add(entry);
+    _entries.value = updated.takeLast(200);
+  }
+}
+
+extension _ListTail<T> on List<T> {
+  List<T> takeLast(int count) {
+    if (length <= count) return List<T>.from(this);
+    return sublist(length - count, length);
+  }
+}
+
+class _DebugNetworkInterceptor extends Interceptor {
+  _DebugNetworkInterceptor(this.logger);
+
+  final DebugNetworkLogger logger;
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    options.extra['_startTime'] = DateTime.now();
+    super.onRequest(options, handler);
+  }
+
+  @override
+  void onResponse(Response response, ResponseInterceptorHandler handler) {
+    _record(response.requestOptions, response.statusCode);
+    super.onResponse(response, handler);
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    _record(err.requestOptions, err.response?.statusCode);
+    super.onError(err, handler);
+  }
+
+  void _record(RequestOptions options, int? statusCode) {
+    final start = options.extra['_startTime'] as DateTime?;
+    final duration =
+        start != null ? DateTime.now().difference(start) : Duration.zero;
+    final uri = Uri.parse(options.uri.toString());
+    final path = uri.path;
+    logger.add(
+      NetworkLogEntry(
+        method: options.method,
+        path: path,
+        statusCode: statusCode,
+        duration: duration,
+        timestamp: DateTime.now(),
+        category: _categoryFor(path),
+      ),
+    );
+  }
+
+  String _categoryFor(String path) {
+    if (path.contains('/policies')) return 'policy';
+    if (path.contains('/institutions') || path.contains('/departments')) {
+      return 'institution';
+    }
+    return 'other';
+  }
+}
+
+class DebugNetworkPanel extends StatefulWidget {
+  const DebugNetworkPanel({super.key});
+
+  @override
+  State<DebugNetworkPanel> createState() => _DebugNetworkPanelState();
+}
+
+class _DebugNetworkPanelState extends State<DebugNetworkPanel> {
+  String _filter = 'all';
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Wrap(
+            spacing: 8,
+            children: [
+              _FilterChip(
+                label: 'All',
+                selected: _filter == 'all',
+                onSelected: () => setState(() => _filter = 'all'),
+              ),
+              _FilterChip(
+                label: '정책 API',
+                selected: _filter == 'policy',
+                onSelected: () => setState(() => _filter = 'policy'),
+                color: const Color(0xFF4D8AF0),
+              ),
+              _FilterChip(
+                label: '기관/부서 API',
+                selected: _filter == 'institution',
+                onSelected: () => setState(() => _filter = 'institution'),
+                color: const Color(0xFF7A63F1),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: ValueListenableBuilder<List<NetworkLogEntry>>(
+            valueListenable: DebugNetworkLogger.instance.entries,
+            builder: (context, entries, _) {
+              final filtered = entries.reversed
+                  .where((entry) => _filter == 'all' || entry.category == _filter)
+                  .toList();
+              if (filtered.isEmpty) {
+                return const Center(
+                  child: Text(
+                    'No network logs yet.',
+                    style: TextStyle(color: Colors.white70),
+                  ),
+                );
+              }
+              return ListView.builder(
+                itemCount: filtered.length,
+                itemBuilder: (context, index) {
+                  final entry = filtered[index];
+                  return _NetworkCard(entry: entry);
+                },
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _FilterChip extends StatelessWidget {
+  const _FilterChip({
+    required this.label,
+    required this.selected,
+    required this.onSelected,
+    this.color,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onSelected;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    final activeColor = color ?? const Color(0xFFCBD5E0);
+    return ChoiceChip(
+      label: Text(label),
+      selected: selected,
+      labelStyle: TextStyle(
+        color: selected ? Colors.white : const Color(0xFF4A5568),
+        fontWeight: FontWeight.w600,
+      ),
+      backgroundColor: Colors.white,
+      selectedColor: activeColor,
+      side: const BorderSide(color: Color(0xFFE2E8F0)),
+      onSelected: (_) => onSelected(),
+    );
+  }
+}
+
+class _NetworkCard extends StatelessWidget {
+  const _NetworkCard({required this.entry});
+
+  final NetworkLogEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final badgeLabel = entry.category == 'policy'
+        ? '정책 API'
+        : entry.category == 'institution'
+            ? '기관 API'
+            : '기타';
+    final badgeColor = entry.category == 'policy'
+        ? const Color(0xFF4D8AF0)
+        : entry.category == 'institution'
+            ? const Color(0xFF7A63F1)
+            : const Color(0xFF4A5568);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          border: Border.all(color: const Color(0xFFE2E8F0)),
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  _Badge(
+                    label: entry.method,
+                    color: entry.isSuccess
+                        ? const Color(0xFF4D8AF0)
+                        : const Color(0xFFFF4D6D),
+                  ),
+                  const SizedBox(width: 8),
+                  if (entry.duration != null)
+                    Text(
+                      '${entry.duration!.inMilliseconds} ms',
+                      style: const TextStyle(
+                        color: Color(0xFF4A5568),
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  const Spacer(),
+                  Text(
+                    entry.statusCode?.toString() ?? '--',
+                    style: TextStyle(
+                      color: entry.isSuccess
+                          ? const Color(0xFF2F855A)
+                          : const Color(0xFFFF4D6D),
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text(
+                entry.path,
+                style: const TextStyle(
+                  color: Color(0xFF1A202C),
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 6),
+              _Badge(
+                label: badgeLabel,
+                color: badgeColor,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Badge extends StatelessWidget {
+  const _Badge({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/debug/debug_overlay.dart
+++ b/lib/debug/debug_overlay.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+
+import 'debug_network_logger.dart';
+import 'debug_provider_tracker.dart';
+import 'debug_unity_logger.dart';
+
+class DebugOverlay extends StatefulWidget {
+  const DebugOverlay({super.key, required this.onClose});
+
+  final VoidCallback onClose;
+
+  @override
+  State<DebugOverlay> createState() => _DebugOverlayState();
+}
+
+class _DebugOverlayState extends State<DebugOverlay> {
+  @override
+  Widget build(BuildContext context) {
+    return Positioned.fill(
+      child: ColoredBox(
+        color: const Color(0x8C000000),
+        child: SafeArea(
+          child: DefaultTabController(
+            length: 3,
+            child: Builder(
+              builder: (context) {
+                final tabController = DefaultTabController.of(context)!;
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    _DebugOverlayAppBar(onClose: widget.onClose),
+                    const _DebugTabBar(),
+                    const Divider(
+                      height: 1,
+                      thickness: 1,
+                      color: Color(0xFFE2E8F0),
+                    ),
+                    Expanded(
+                      child: TabBarView(
+                        physics: const BouncingScrollPhysics(),
+                        children: [
+                          _AnimatedTabContent(
+                            controller: tabController,
+                            tabIndex: 0,
+                            child: const DebugProviderPanel(),
+                          ),
+                          _AnimatedTabContent(
+                            controller: tabController,
+                            tabIndex: 1,
+                            child: const DebugNetworkPanel(),
+                          ),
+                          _AnimatedTabContent(
+                            controller: tabController,
+                            tabIndex: 2,
+                            child: const DebugUnityPanel(),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AnimatedTabContent extends StatelessWidget {
+  const _AnimatedTabContent({
+    required this.controller,
+    required this.tabIndex,
+    required this.child,
+  });
+
+  final TabController controller;
+  final int tabIndex;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final animation = controller.animation!;
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, _) {
+        final distance = (tabIndex - animation.value).abs();
+        final t = (1 - distance).clamp(0.0, 1.0);
+        final curved = Curves.easeOut.transform(t);
+        final offsetY = (1 - curved) * 18;
+        return Opacity(
+          opacity: curved,
+          child: Transform.translate(
+            offset: Offset(0, offsetY),
+            child: child,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _DebugOverlayAppBar extends StatelessWidget {
+  const _DebugOverlayAppBar({required this.onClose});
+
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.white,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            height: 52,
+            child: Row(
+              children: [
+                IconButton(
+                  onPressed: onClose,
+                  icon: const Icon(Icons.close, color: Color(0xFF4D8AF0)),
+                ),
+                const SizedBox(width: 4),
+                const Text(
+                  'Debug Overlay',
+                  style: TextStyle(
+                    color: Color(0xFF4D8AF0),
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DebugTabBar extends StatelessWidget {
+  const _DebugTabBar();
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.white,
+      child: TabBar(
+        indicatorColor: const Color(0xFF4D8AF0),
+        indicatorWeight: 3,
+        labelColor: const Color(0xFF4D8AF0),
+        unselectedLabelColor: const Color(0xFFA0AEC0),
+        labelStyle: const TextStyle(fontWeight: FontWeight.w600),
+        tabs: const [
+          Tab(text: 'Provider'),
+          Tab(text: 'Network'),
+          Tab(text: 'Unity'),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/debug/debug_provider_tracker.dart
+++ b/lib/debug/debug_provider_tracker.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'debug_toast.dart';
+
+class ProviderStatusEntry {
+  ProviderStatusEntry({
+    required this.providerName,
+    required this.state,
+    this.error,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  final String providerName;
+  final String state;
+  final Object? error;
+  final DateTime timestamp;
+
+  bool get isError => error != null || state.toLowerCase() == 'error';
+}
+
+class DebugProviderTracker {
+  DebugProviderTracker._();
+
+  static final DebugProviderTracker instance = DebugProviderTracker._();
+
+  final ValueNotifier<List<ProviderStatusEntry>> _entries =
+      ValueNotifier<List<ProviderStatusEntry>>(<ProviderStatusEntry>[]);
+
+  ValueListenable<List<ProviderStatusEntry>> get entries => _entries;
+
+  void addEntry(ProviderStatusEntry entry) {
+    if (!kDebugMode) return;
+    final updated = List<ProviderStatusEntry>.from(_entries.value)..add(entry);
+    _entries.value = updated.takeLast(100);
+  }
+}
+
+class DebugProviderObserver extends ProviderObserver {
+  String _resolveProviderName(ProviderBase<Object?> provider) {
+    if (provider.name != null && provider.name!.isNotEmpty) {
+      return provider.name!;
+    }
+    return provider.runtimeType.toString();
+  }
+
+  @override
+  void didUpdateProvider(
+    ProviderBase<Object?> provider,
+    Object? previousValue,
+    Object? newValue,
+    ProviderContainer container,
+  ) {
+    if (!kDebugMode) return;
+
+    final name = _resolveProviderName(provider);
+    final state = _describeState(newValue);
+    DebugProviderTracker.instance.addEntry(
+      ProviderStatusEntry(providerName: name, state: state),
+    );
+  }
+
+  @override
+  void providerDidFail(
+    ProviderBase<Object?> provider,
+    Object error,
+    StackTrace stackTrace,
+    ProviderContainer container,
+  ) {
+    if (!kDebugMode) return;
+
+    final name = _resolveProviderName(provider);
+    DebugProviderTracker.instance.addEntry(
+      ProviderStatusEntry(providerName: name, state: 'error', error: error),
+    );
+    DebugToastController.instance
+        .show('Provider "$name" error: ${error.toString()}');
+  }
+
+  String _describeState(Object? value) {
+    if (value is AsyncValue) {
+      if (value.isLoading) return 'loading';
+      if (value.hasError) return 'error';
+      return 'data';
+    }
+    return 'data';
+  }
+}
+
+class DebugProviderPanel extends StatelessWidget {
+  const DebugProviderPanel({super.key});
+
+  Color _stateColor(ProviderStatusEntry entry) {
+    if (entry.isError) return const Color(0xFFFF4D6D);
+    if (entry.state == 'loading') return const Color(0xFF4D8AF0);
+    return const Color(0xFF4A5568);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<List<ProviderStatusEntry>>(
+      valueListenable: DebugProviderTracker.instance.entries,
+      builder: (context, entries, _) {
+        if (entries.isEmpty) {
+          return const Center(
+            child: Text(
+              'No provider activity yet.',
+              style: TextStyle(color: Colors.white70),
+            ),
+          );
+        }
+
+        final reversed = entries.reversed.toList();
+        return ListView.builder(
+          itemCount: reversed.length,
+          itemBuilder: (context, index) {
+            final entry = reversed[index];
+            return _ProviderRow(entry: entry);
+          },
+        );
+      },
+    );
+  }
+}
+
+class _ProviderRow extends StatelessWidget {
+  const _ProviderRow({required this.entry});
+
+  final ProviderStatusEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 44,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        child: Row(
+          children: [
+            Container(
+              width: 8,
+              height: 8,
+              decoration: BoxDecoration(
+                color: entry.isError
+                    ? const Color(0xFFFF4D6D)
+                    : const Color(0xFFCBD5E0),
+                shape: BoxShape.circle,
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                entry.providerName,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: entry.isError
+                      ? const Color(0xFFFF4D6D)
+                      : const Color(0xFF4A5568),
+                  fontWeight:
+                      entry.isError ? FontWeight.w700 : FontWeight.w500,
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Text(
+              entry.state.toUpperCase(),
+              style: TextStyle(
+                color: _stateColor(entry),
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Color _stateColor(ProviderStatusEntry entry) {
+    if (entry.isError) return const Color(0xFFFF4D6D);
+    if (entry.state == 'loading') return const Color(0xFF4D8AF0);
+    return const Color(0xFF4A5568);
+  }
+}

--- a/lib/debug/debug_toast.dart
+++ b/lib/debug/debug_toast.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class DebugToastMessage {
+  DebugToastMessage(this.message, this.timestamp);
+
+  final String message;
+  final DateTime timestamp;
+}
+
+class DebugToastController {
+  DebugToastController._();
+
+  static final DebugToastController instance = DebugToastController._();
+
+  final ValueNotifier<List<DebugToastMessage>> _messages =
+      ValueNotifier<List<DebugToastMessage>>(<DebugToastMessage>[]);
+
+  final Map<String, DateTime> _lastShownAt = <String, DateTime>{};
+
+  ValueListenable<List<DebugToastMessage>> get messages => _messages;
+
+  void show(String message) {
+    if (!kDebugMode) return;
+
+    final now = DateTime.now();
+    final last = _lastShownAt[message];
+    if (last != null && now.difference(last) < const Duration(seconds: 2)) {
+      return;
+    }
+
+    _lastShownAt[message] = now;
+    final updated = List<DebugToastMessage>.from(_messages.value)
+      ..add(DebugToastMessage(message, now));
+    _messages.value = updated.takeLast(3);
+
+    Future.delayed(const Duration(seconds: 3), () {
+      final current = List<DebugToastMessage>.from(_messages.value);
+      if (current.isNotEmpty && current.first.timestamp == now) {
+        current.removeAt(0);
+        _messages.value = current;
+      }
+    });
+  }
+}
+
+extension _ListTrim<T> on List<T> {
+  List<T> takeLast(int count) {
+    if (length <= count) return List<T>.from(this);
+    return sublist(length - count, length);
+  }
+}
+
+class DebugToastOverlay extends StatelessWidget {
+  const DebugToastOverlay({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: SafeArea(
+        child: Align(
+          alignment: Alignment.bottomCenter,
+          child: Padding(
+            padding: const EdgeInsets.only(bottom: 28),
+            child: ValueListenableBuilder<List<DebugToastMessage>>(
+              valueListenable: DebugToastController.instance.messages,
+              builder: (context, messages, _) {
+                if (messages.isEmpty) return const SizedBox.shrink();
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: messages
+                      .map((message) => _DebugToast(message: message))
+                      .toList(),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DebugToast extends StatelessWidget {
+  const _DebugToast({required this.message});
+
+  final DebugToastMessage message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 150),
+        opacity: 1,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: const Color(0xFF4D8AF0),
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: const [
+              BoxShadow(
+                color: Colors.black26,
+                blurRadius: 6,
+                offset: Offset(0, 2),
+              ),
+            ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            child: Text(
+              message.message,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/debug/debug_unity_logger.dart
+++ b/lib/debug/debug_unity_logger.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class UnityLogEntry {
+  UnityLogEntry({required this.message, DateTime? timestamp})
+      : timestamp = timestamp ?? DateTime.now();
+
+  final String message;
+  final DateTime timestamp;
+}
+
+class DebugUnityLogger {
+  DebugUnityLogger._();
+
+  static final DebugUnityLogger instance = DebugUnityLogger._();
+
+  final ValueNotifier<List<UnityLogEntry>> _entries =
+      ValueNotifier<List<UnityLogEntry>>(<UnityLogEntry>[]);
+
+  ValueListenable<List<UnityLogEntry>> get entries => _entries;
+
+  void log(String message) {
+    if (!kDebugMode) return;
+    final updated = List<UnityLogEntry>.from(_entries.value)
+      ..add(UnityLogEntry(message: message));
+    _entries.value = updated.takeLast(200);
+  }
+}
+
+extension _ListClip<T> on List<T> {
+  List<T> takeLast(int count) {
+    if (length <= count) return List<T>.from(this);
+    return sublist(length - count, length);
+  }
+}
+
+class DebugUnityPanel extends StatelessWidget {
+  const DebugUnityPanel({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<List<UnityLogEntry>>(
+      valueListenable: DebugUnityLogger.instance.entries,
+      builder: (context, entries, _) {
+        if (entries.isEmpty) {
+          return const Center(
+            child: Text(
+              'No Unity events yet.',
+              style: TextStyle(color: Colors.white70),
+            ),
+          );
+        }
+        final reversed = entries.reversed.toList();
+        return ListView.builder(
+          itemCount: reversed.length,
+          itemBuilder: (context, index) {
+            final entry = reversed[index];
+            return _UnityRow(entry: entry);
+          },
+        );
+      },
+    );
+  }
+}
+
+class _UnityRow extends StatelessWidget {
+  const _UnityRow({required this.entry});
+
+  final UnityLogEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: Colors.white.withOpacity(0.05),
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: const Color(0xFFE2E8F0)),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFA8C5FF),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: const Text(
+                  '[UNITY]',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  entry.message,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontFamily: 'monospace',
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/debug/debug_wrapper.dart
+++ b/lib/debug/debug_wrapper.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'debug_button.dart';
+import 'debug_overlay.dart';
+import 'debug_toast.dart';
+
+class DebugWrapper extends StatefulWidget {
+  const DebugWrapper({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<DebugWrapper> createState() => _DebugWrapperState();
+}
+
+class _DebugWrapperState extends State<DebugWrapper> {
+  bool _overlayVisible = false;
+
+  void _toggleOverlay(bool visible) {
+    setState(() {
+      _overlayVisible = visible;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kDebugMode) {
+      return widget.child;
+    }
+
+    return Stack(
+      children: [
+        widget.child,
+        if (kDebugMode) const DebugToastOverlay(),
+        if (_overlayVisible)
+          DebugOverlay(
+            onClose: () => _toggleOverlay(false),
+          ),
+        if (!_overlayVisible)
+          DebugButton(
+            onPressed: () => _toggleOverlay(true),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,19 +1,29 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'app.dart';
 import 'application/di.dart';
+import 'debug/debug_provider_tracker.dart';
+import 'debug/debug_wrapper.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final prefs = await SharedPreferences.getInstance();
+  final observers = <ProviderObserver>[];
+  if (kDebugMode) {
+    observers.add(DebugProviderObserver());
+  }
   runApp(
     ProviderScope(
       overrides: [
         sharedPreferencesProvider.overrideWithValue(prefs),
       ],
-      child: const MyApp(),
+      observers: observers,
+      child: const DebugWrapper(
+        child: App(),
+      ),
     ),
   );
 }


### PR DESCRIPTION
## Summary
- restrict debug observers, wrappers, and logging pipelines to run only in kDebugMode
- add per-tab entry animations for provider, network, and unity panels while keeping overlay layout intact
- guard dio and unity debug instrumentation so they attach exclusively in debug builds

## Testing
- not run (environment lacks Flutter/Dart SDK)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922f3432564832aa616ba13b0698891)