### PR TITLE
Align API key injection and category provider scope

### DIFF
--- a/lib/application/di.dart
+++ b/lib/application/di.dart
@@ -8,6 +8,7 @@ import '../data/repositories/policy_repository_impl.dart';
 import '../data/sources/remote/policy_remote_source.dart';
 import '../domain/repositories/policy_repository.dart';
 import 'services/memo_repository.dart';
+import '../core/constants/env.dart';
 
 final sharedPreferencesProvider = Provider<SharedPreferences>((ref) {
   throw UnimplementedError('SharedPreferences not initialized');
@@ -15,7 +16,7 @@ final sharedPreferencesProvider = Provider<SharedPreferences>((ref) {
 
 final remotePolicySourceProvider = Provider<PolicyRemoteSource>((ref) {
   final dio = ref.watch(dioProvider);
-  return PolicyRemoteSource(dio);
+  return PolicyRemoteSource(dio, apiKey: Env.youthApiKey);
 });
 
 final policyRepositoryProvider = Provider<PolicyRepository>((ref) {

--- a/lib/application/notifiers/chat_notifier.dart
+++ b/lib/application/notifiers/chat_notifier.dart
@@ -20,15 +20,13 @@ class ChatState {
 }
 
 class ChatNotifier extends AutoDisposeNotifier<ChatState> {
-  late final ChatRepository _repository;
-  late final SharedPreferences _prefs;
+  ChatRepository get _repository => ref.read(chatRepositoryProvider);
+  SharedPreferences get _prefs => ref.read(sharedPreferencesProvider);
 
   static const _storageKey = 'chat_history';
 
   @override
   ChatState build() {
-    _repository = ref.read(chatRepositoryProvider);
-    _prefs = ref.read(sharedPreferencesProvider);
     final saved = _prefs.getStringList(_storageKey) ?? [];
     final restored = saved
         .map((jsonStr) => ChatMessage.fromJson(

--- a/lib/application/notifiers/compare_notifier.dart
+++ b/lib/application/notifiers/compare_notifier.dart
@@ -7,13 +7,11 @@ import '../di.dart';
 
 class CompareNotifier extends AsyncNotifier<List<Policy>> {
   static const _key = 'compare';
-  late final SharedPreferences _prefs;
-  late final PolicyRepository _repo;
+  SharedPreferences get _prefs => ref.read(sharedPreferencesProvider);
+  PolicyRepository get _repo => ref.read(policyRepositoryProvider);
 
   @override
   Future<List<Policy>> build() async {
-    _prefs = ref.read(sharedPreferencesProvider);
-    _repo = ref.read(policyRepositoryProvider);
     final ids = _prefs.getStringList(_key) ?? [];
     final normalized = _normalize(ids);
     if (normalized.length != ids.length) {

--- a/lib/application/notifiers/policy_detail_notifier.dart
+++ b/lib/application/notifiers/policy_detail_notifier.dart
@@ -34,12 +34,12 @@ class PolicyDetailState {
 }
 
 class PolicyDetailNotifier extends AutoDisposeNotifier<PolicyDetailState> {
-  late final PolicyRepository _repo;
   static const String errorMessage = '정책을 불러오지 못했습니다. 다시 시도해 주세요.';
+
+  PolicyRepository get _repo => ref.read(policyRepositoryProvider);
 
   @override
   PolicyDetailState build() {
-    _repo = ref.read(policyRepositoryProvider);
     return const PolicyDetailState(isLoading: false);
   }
 

--- a/lib/application/notifiers/policy_list_notifier.dart
+++ b/lib/application/notifiers/policy_list_notifier.dart
@@ -9,15 +9,14 @@ import '../../data/sources/local/search_history_source.dart';
 import 'region_notifier.dart';
 
 class PolicyListNotifier extends AutoDisposeAsyncNotifier<List<Policy>> {
-  late final PolicyRepository _repo;
-  late final SearchHistorySource _historySource;
   static const String errorMessage = '정책을 불러오지 못했습니다. 다시 시도해 주세요.';
   String? _lastQuery;
 
+  PolicyRepository get _repo => ref.read(policyRepositoryProvider);
+  SearchHistorySource get _historySource => ref.read(searchHistorySourceProvider);
+
   @override
   Future<List<Policy>> build() async {
-    _repo = ref.read(policyRepositoryProvider);
-    _historySource = ref.read(searchHistorySourceProvider);
     final selectedRegion = ref.watch(regionProvider);
     return _fetchPolicies(selectedRegion);
   }

--- a/lib/application/notifiers/policy_paging_notifier.dart
+++ b/lib/application/notifiers/policy_paging_notifier.dart
@@ -45,31 +45,38 @@ class PolicyPagingState {
 }
 
 class PolicyPagingNotifier extends AutoDisposeNotifier<PolicyPagingState> {
-  late final PolicyRepository _repo;
+  PolicyRepository get _repo => ref.read(policyRepositoryProvider);
   int _requestId = 0;
   String? _currentRegion;
   String? _searchQuery;
+  bool _initialized = false;
   static const String errorMessage = '정책을 불러오지 못했습니다. 다시 시도해 주세요.';
 
   @override
   PolicyPagingState build() {
-    _repo = ref.read(policyRepositoryProvider);
-    _currentRegion = ref.read(regionProvider);
-    ref.listen<String?>(regionProvider, (previous, next) {
-      if (previous == next) return;
-      _currentRegion = next;
+    final region = ref.watch(regionProvider);
+
+    if (!_initialized) {
+      _initialized = true;
+      _currentRegion = region;
+      const initialState = PolicyPagingState(
+        items: [],
+        page: 1,
+        isLoading: false,
+        hasMore: true,
+        initialLoaded: false,
+      );
+      state = initialState;
       _resetAndLoad();
-    });
-    const initialState = PolicyPagingState(
-      items: [],
-      page: 1,
-      isLoading: false,
-      hasMore: true,
-      initialLoaded: false,
-    );
-    state = initialState;
-    _resetAndLoad();
-    return initialState;
+      return initialState;
+    }
+
+    if (_currentRegion != region) {
+      _currentRegion = region;
+      _resetAndLoad();
+    }
+
+    return state;
   }
 
   void _resetAndLoad() {

--- a/lib/application/repository_providers.dart
+++ b/lib/application/repository_providers.dart
@@ -9,10 +9,11 @@ import '../data/sources/remote/institution_remote_source.dart';
 import '../domain/repositories/dept_repository.dart';
 import '../domain/repositories/inst_repository.dart';
 import 'di.dart';
+import '../core/constants/env.dart';
 
 final instRemoteSourceProvider = Provider<InstitutionRemoteSource>((ref) {
   final dio = ref.watch(dioProvider);
-  return InstitutionRemoteSource(dio);
+  return InstitutionRemoteSource(dio, apiKey: Env.youthApiKey);
 });
 
 final instRepositoryProvider = Provider<InstRepository>((ref) {
@@ -27,7 +28,7 @@ final instListProvider = AutoDisposeFutureProvider<List<InstModel>>((ref) async 
 
 final deptRemoteSourceProvider = Provider<DepartmentRemoteSource>((ref) {
   final dio = ref.watch(dioProvider);
-  return DepartmentRemoteSource(dio);
+  return DepartmentRemoteSource(dio, apiKey: Env.youthApiKey);
 });
 
 final deptRepositoryProvider = Provider<DeptRepository>((ref) {

--- a/lib/core/constants/env.dart
+++ b/lib/core/constants/env.dart
@@ -10,4 +10,9 @@ class Env {
     'CHAT_ENDPOINT',
     defaultValue: '',
   );
+
+  static const youthApiKey = String.fromEnvironment(
+    'YOUTH_API_KEY',
+    defaultValue: '',
+  );
 }

--- a/lib/data/sources/remote/department_remote_source.dart
+++ b/lib/data/sources/remote/department_remote_source.dart
@@ -1,10 +1,11 @@
 import 'package:dio/dio.dart';
 
 import '../../../core/api/models/department_model.dart';
+import '../../../core/constants/env.dart';
 
 class DepartmentRemoteSource {
   DepartmentRemoteSource(this._dio, {String? apiKey})
-      : _apiKey = apiKey ?? const String.fromEnvironment('YOUTH_API_KEY');
+      : _apiKey = apiKey ?? Env.youthApiKey;
 
   final Dio _dio;
   final String _apiKey;

--- a/lib/data/sources/remote/dept_remote_source.dart
+++ b/lib/data/sources/remote/dept_remote_source.dart
@@ -1,10 +1,11 @@
 import 'package:dio/dio.dart';
 
 import '../../models/dept_model.dart';
+import '../../../core/constants/env.dart';
 
 class DeptRemoteSource {
   DeptRemoteSource(this._dio, {String? apiKey})
-      : _apiKey = apiKey ?? const String.fromEnvironment('YOUTH_API_KEY');
+      : _apiKey = apiKey ?? Env.youthApiKey;
 
   final Dio _dio;
   final String _apiKey;

--- a/lib/data/sources/remote/inst_remote_source.dart
+++ b/lib/data/sources/remote/inst_remote_source.dart
@@ -1,10 +1,11 @@
 import 'package:dio/dio.dart';
 
 import '../../models/inst_model.dart';
+import '../../../core/constants/env.dart';
 
 class InstRemoteSource {
   InstRemoteSource(this._dio, {String? apiKey})
-      : _apiKey = apiKey ?? const String.fromEnvironment('YOUTH_API_KEY');
+      : _apiKey = apiKey ?? Env.youthApiKey;
 
   final Dio _dio;
   final String _apiKey;

--- a/lib/data/sources/remote/institution_remote_source.dart
+++ b/lib/data/sources/remote/institution_remote_source.dart
@@ -1,10 +1,11 @@
 import 'package:dio/dio.dart';
 
 import '../../../core/api/models/institution_model.dart';
+import '../../../core/constants/env.dart';
 
 class InstitutionRemoteSource {
   InstitutionRemoteSource(this._dio, {String? apiKey})
-      : _apiKey = apiKey ?? const String.fromEnvironment('YOUTH_API_KEY');
+      : _apiKey = apiKey ?? Env.youthApiKey;
 
   final Dio _dio;
   final String _apiKey;

--- a/lib/data/sources/remote/policy_remote_source.dart
+++ b/lib/data/sources/remote/policy_remote_source.dart
@@ -1,10 +1,11 @@
 import 'package:dio/dio.dart';
 import '../../models/policy_filter.dart';
 import '../../models/policy_model.dart';
+import '../../../core/constants/env.dart';
 
 class PolicyRemoteSource {
   PolicyRemoteSource(this._dio, {String? apiKey})
-      : _apiKey = apiKey ?? const String.fromEnvironment('YOUTH_API_KEY');
+      : _apiKey = apiKey ?? Env.youthApiKey;
 
   final Dio _dio;
   final String _apiKey;

--- a/lib/features/category/category_provider.dart
+++ b/lib/features/category/category_provider.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/policy.dart';
+
+final categoryPoliciesProvider = Provider<Map<String, List<Policy>>>((_) {
+  return {
+    '창업': const [
+      Policy(
+        id: 'c1',
+        policyNm: '창업 패스트트랙',
+        policyCn: '초기 창업팀 보육 및 자금 패키지',
+        tags: ['창업', '보육'],
+      ),
+    ],
+    '주거': const [
+      Policy(
+        id: 'c2',
+        policyNm: '청년 주거 바우처',
+        policyCn: '월세·전세 보증금 일부 지원',
+        tags: ['주거', '바우처'],
+      ),
+    ],
+  };
+});

--- a/lib/ui/screens/category/category_screen.dart
+++ b/lib/ui/screens/category/category_screen.dart
@@ -1,32 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../widgets/app_appbar.dart';
 import '../../widgets/policy_card.dart';
-import '../../../domain/entities/policy.dart';
+import '../../../features/category/category_provider.dart';
 
-class CategoryScreen extends StatelessWidget {
+class CategoryScreen extends ConsumerWidget {
   const CategoryScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final categories = <String, List<Policy>>{
-      '창업': [
-        const Policy(
-          id: 'c1',
-          policyNm: '창업 패스트트랙',
-          policyCn: '초기 창업팀 보육 및 자금 패키지',
-          tags: ['창업', '보육'],
-        ),
-      ],
-      '주거': [
-        const Policy(
-          id: 'c2',
-          policyNm: '청년 주거 바우처',
-          policyCn: '월세·전세 보증금 일부 지원',
-          tags: ['주거', '바우처'],
-        ),
-      ],
-    };
+  Widget build(BuildContext context, WidgetRef ref) {
+    final categories = ref.watch(categoryPoliciesProvider);
 
     return Scaffold(
       appBar: const AppAppBar(title: '카테고리별 탐색'),

--- a/lib/ui/screens/chatbot/chatbot_screen.dart
+++ b/lib/ui/screens/chatbot/chatbot_screen.dart
@@ -22,11 +22,6 @@ class _ChatbotScreenState extends ConsumerState<ChatbotScreen> {
   @override
   void initState() {
     super.initState();
-    ref.listen<ChatState>(chatProvider, (previous, next) {
-      if ((previous?.messages.length ?? 0) != next.messages.length) {
-        _scrollToBottom();
-      }
-    });
   }
 
   @override
@@ -38,6 +33,12 @@ class _ChatbotScreenState extends ConsumerState<ChatbotScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<ChatState>(chatProvider, (previous, next) {
+      if ((previous?.messages.length ?? 0) != next.messages.length) {
+        _scrollToBottom();
+      }
+    });
+
     final chatState = ref.watch(chatProvider);
     final notifier = ref.read(chatProvider.notifier);
     final error = chatState.error;

--- a/lib/ui/screens/map/kakao_map_screen.dart
+++ b/lib/ui/screens/map/kakao_map_screen.dart
@@ -67,7 +67,10 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
           markers: _policyMarkers(center, ref.read(policyListNotifierProvider)),
         ),
       );
+  }
 
+  @override
+  Widget build(BuildContext context) {
     ref.listen<String?>(regionProvider, (_, __) {
       _reloadMap();
     });
@@ -77,10 +80,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         _reloadMap();
       }
     });
-  }
 
-  @override
-  Widget build(BuildContext context) {
     return Scaffold(
       appBar: const AppAppBar(title: '카카오맵 보기'),
       body: Stack(

--- a/lib/ui/screens/map/map_with_list_screen.dart
+++ b/lib/ui/screens/map/map_with_list_screen.dart
@@ -66,16 +66,6 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
     super.initState();
     _listController = ScrollController()..addListener(_onListScroll);
     _initWebView();
-
-    ref.listen<String?>(regionProvider, (_, __) {
-      _reloadMap();
-    });
-
-    ref.listen<AsyncValue<List<Policy>>>(policyListNotifierProvider, (prev, next) {
-      if (next.hasValue && next.valueOrNull != prev?.valueOrNull) {
-        _reloadMap();
-      }
-    });
   }
 
   @override
@@ -87,6 +77,16 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<String?>(regionProvider, (_, __) {
+      _reloadMap();
+    });
+
+    ref.listen<AsyncValue<List<Policy>>>(policyListNotifierProvider, (prev, next) {
+      if (next.hasValue && next.valueOrNull != prev?.valueOrNull) {
+        _reloadMap();
+      }
+    });
+
     final policies = ref.watch(policyListNotifierProvider);
     return Scaffold(
       appBar: const AppAppBar(title: '지도 + 리스트'),

--- a/lib/ui/screens/unity/unity_screen.dart
+++ b/lib/ui/screens/unity/unity_screen.dart
@@ -22,7 +22,15 @@ class _UnityScreenState extends ConsumerState<UnityScreen> {
   @override
   void initState() {
     super.initState();
+  }
 
+  void _handlePolicySelection(Policy policy) {
+    if (!mounted) return;
+    context.push(RoutePaths.policyDetail(policy.id));
+  }
+
+  @override
+  Widget build(BuildContext context) {
     ref.listen(policyListNotifierProvider, (previous, next) {
       final policies = next.valueOrNull;
       if (policies != null && policies.isNotEmpty) {
@@ -36,15 +44,7 @@ class _UnityScreenState extends ConsumerState<UnityScreen> {
         }
       }
     });
-  }
 
-  void _handlePolicySelection(Policy policy) {
-    if (!mounted) return;
-    context.push(RoutePaths.policyDetail(policy.id));
-  }
-
-  @override
-  Widget build(BuildContext context) {
     final mapController = ref.watch(unityMapControllerProvider);
     mapController.onPolicySelected ??= _handlePolicySelection;
 


### PR DESCRIPTION
## Summary
- centralize YOUTH_API_KEY resolution in remote data sources via the shared Env configuration
- update the policy paging notifier to react to region changes through provider watching instead of listeners
- relocate the category provider to a dedicated features scope and update the category screen import

## Testing
- Not run (not supported in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922f77d79fc832abdfb6515af3906e3)