### PR TITLE
Fix provider tracker entry retention

### DIFF
--- a/lib/debug/debug_provider_tracker.dart
+++ b/lib/debug/debug_provider_tracker.dart
@@ -33,7 +33,11 @@ class DebugProviderTracker {
   void addEntry(ProviderStatusEntry entry) {
     if (!kDebugMode) return;
     final updated = List<ProviderStatusEntry>.from(_entries.value)..add(entry);
-    _entries.value = updated.takeLast(100);
+    if (updated.length > 100) {
+      _entries.value = updated.sublist(updated.length - 100);
+    } else {
+      _entries.value = updated;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- prevent provider tracker from calling the missing takeLast helper by capping entries with sublist

## Testing
- flutter analyze *(fails: flutter not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922fa64af8c832a9834fdb37b3ce08f)