### PR TITLE
Ensure Directionality at app root, stabilize GoRouter integration, and split dev/prod entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ afterEvaluate {
 
 - Android Gradle 빌드에는 `android/local.properties`의 `flutter.sdk`/`sdk.dir` 값이 필요합니다.
 - 본 컨테이너에는 Flutter SDK와 Android SDK 경로가 비어 있어 Gradle wrapper 실행이 중단되었습니다.
+
+## ▶️ 앱 실행 엔트리포인트
+
+- 개발용: `flutter run -t lib/main_dev.dart`
+- 운영용(기본): `flutter run -t lib/main_prod.dart` 또는 기본 `lib/main.dart`
 - 로컬에서 확인 시 `android/local.properties.example`를 복사 후 실제 경로로 수정하면 `./gradlew assembleDebug`로 빌드 검증을 수행할 수 있습니다.
 
 flutter {

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,38 +1,39 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'core/constants/app_strings.dart';
+import 'debug/debug_wrapper.dart';
 import 'navigation/app_router.dart';
 import 'theme/app_theme.dart';
 
-class MyApp extends ConsumerStatefulWidget {
-  const MyApp({super.key});
+final appRouterProvider = Provider<GoRouter>((ref) {
+  return const AppRouter().router();
+});
+
+class App extends ConsumerWidget {
+  const App({super.key});
 
   @override
-  ConsumerState<MyApp> createState() => _MyAppState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(appRouterProvider);
 
-class _MyAppState extends ConsumerState<MyApp> {
-  late final GoRouter _router = const AppRouter().router();
-
-  @override
-  Widget build(BuildContext context) {
     return MaterialApp.router(
       title: AppStrings.appTitle,
       theme: AppTheme.lightTheme,
       darkTheme: AppTheme.darkTheme,
       themeMode: ThemeMode.system,
-      routerConfig: _router,
+      routerConfig: router,
+      builder: (context, child) {
+        if (!kDebugMode) {
+          return child ?? const SizedBox.shrink();
+        }
+
+        return DebugWrapper(
+          child: child ?? const SizedBox.shrink(),
+        );
+      },
     );
-  }
-}
-
-class App extends StatelessWidget {
-  const App({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const MyApp();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,29 +1,5 @@
-import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-
-import 'app.dart';
-import 'application/di.dart';
-import 'debug/debug_provider_tracker.dart';
-import 'debug/debug_wrapper.dart';
+import 'main_prod.dart' as prod;
 
 Future<void> main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  final prefs = await SharedPreferences.getInstance();
-  final observers = <ProviderObserver>[];
-  if (kDebugMode) {
-    observers.add(DebugProviderObserver());
-  }
-  runApp(
-    ProviderScope(
-      overrides: [
-        sharedPreferencesProvider.overrideWithValue(prefs),
-      ],
-      observers: observers,
-      child: const DebugWrapper(
-        child: App(),
-      ),
-    ),
-  );
+  await prod.main();
 }

--- a/lib/main_common.dart
+++ b/lib/main_common.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'app.dart';
+import 'application/di.dart';
+import 'debug/debug_provider_tracker.dart';
+
+Future<void> mainCommon() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final prefs = await SharedPreferences.getInstance();
+  final observers = <ProviderObserver>[];
+
+  if (kDebugMode) {
+    observers.add(DebugProviderObserver());
+  }
+
+  runApp(
+    ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+      ],
+      observers: observers,
+      child: const App(),
+    ),
+  );
+}

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -1,0 +1,5 @@
+import 'main_common.dart';
+
+Future<void> main() async {
+  await mainCommon();
+}

--- a/lib/main_prod.dart
+++ b/lib/main_prod.dart
@@ -1,0 +1,5 @@
+import 'main_common.dart';
+
+Future<void> main() async {
+  await mainCommon();
+}

--- a/test/app_root_directionality_test.dart
+++ b/test/app_root_directionality_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:youth_road_app/app.dart';
+import 'package:youth_road_app/navigation/route_paths.dart';
+
+void main() {
+  testWidgets('App provides Directionality at root', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: App(),
+      ),
+    );
+
+    expect(find.byType(Directionality), findsWidgets);
+  });
+
+  testWidgets('App uses GoRouter via MaterialApp.router', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: App(),
+      ),
+    );
+
+    final materialAppFinder = find.byType(MaterialApp);
+    expect(materialAppFinder, findsOneWidget);
+
+    final materialApp = tester.widget<MaterialApp>(materialAppFinder);
+    expect(materialApp.routerConfig, isNotNull);
+    expect(materialApp.routerConfig, isA<GoRouter>());
+  });
+
+  testWidgets('GoRouter has initial route configured', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: App(),
+      ),
+    );
+
+    final materialApp = tester.widget<MaterialApp>(find.byType(MaterialApp));
+    final router = materialApp.routerConfig as GoRouter;
+
+    expect(router.configuration.routes, isNotEmpty);
+    expect(router.configuration.initialLocation, RoutePaths.splash);
+  });
+}


### PR DESCRIPTION
## Summary
- Move application bootstrap into `main_common.dart` with dev/prod entrypoints while keeping shared preference overrides and provider observers centralized.
- Wrap the app router with `MaterialApp.router` inside `App`, placing the debug overlay inside the builder to ensure Directionality is always provided and GoRouter is stable.
- Add widget tests to verify Directionality and router configuration and document how to launch dev/prod targets.

## Testing
- `flutter test test/app_root_directionality_test.dart` *(fails: flutter command unavailable in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922fd493ee0832aa793983b7720f092)