### PR TITLE
Improve debug overlay and policy error UX

### DIFF
--- a/lib/application/notifiers/policy_list_notifier.dart
+++ b/lib/application/notifiers/policy_list_notifier.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/models/policy_filter.dart';
 import '../../domain/entities/policy.dart';
 import '../../domain/repositories/policy_repository.dart';
+import '../../debug/debug_log_collector.dart';
 import '../di.dart';
 import '../../data/sources/local/search_history_source.dart';
 import 'region_notifier.dart';
@@ -18,7 +19,15 @@ class PolicyListNotifier extends AutoDisposeAsyncNotifier<List<Policy>> {
   @override
   Future<List<Policy>> build() async {
     final selectedRegion = ref.watch(regionProvider);
-    return _fetchPolicies(selectedRegion);
+    try {
+      return await _fetchPolicies(selectedRegion);
+    } catch (error, stackTrace) {
+      debugPrint('PolicyListNotifier.build failed: $error');
+      debugPrint('$stackTrace');
+      DebugLogCollector.instance
+          .add('PolicyListNotifier.build failed: $error\n$stackTrace');
+      throw Exception(errorMessage);
+    }
   }
 
   Future<List<Policy>> _fetchPolicies(String? region) async {
@@ -33,6 +42,8 @@ class PolicyListNotifier extends AutoDisposeAsyncNotifier<List<Policy>> {
     } catch (e, st) {
       debugPrint('Failed to fetch policies: $e');
       debugPrint('$st');
+      DebugLogCollector.instance
+          .add('Failed to fetch policies: $e\n$st');
       throw Exception(errorMessage);
     }
   }

--- a/lib/debug/debug_log_collector.dart
+++ b/lib/debug/debug_log_collector.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class DebugLogEntry {
+  DebugLogEntry({required this.timestamp, required this.message});
+
+  final DateTime timestamp;
+  final String message;
+}
+
+class DebugLogCollector {
+  DebugLogCollector._();
+
+  static final DebugLogCollector instance = DebugLogCollector._();
+
+  final ValueNotifier<List<DebugLogEntry>> _entries =
+      ValueNotifier<List<DebugLogEntry>>(<DebugLogEntry>[]);
+
+  ValueListenable<List<DebugLogEntry>> get entries => _entries;
+
+  void add(String message) {
+    if (!kDebugMode) return;
+    final updated = List<DebugLogEntry>.from(_entries.value)
+      ..add(DebugLogEntry(timestamp: DateTime.now(), message: message));
+    if (updated.length > 500) {
+      _entries.value = updated.sublist(updated.length - 500);
+    } else {
+      _entries.value = updated;
+    }
+  }
+}
+
+class DebugLogPanel extends StatelessWidget {
+  const DebugLogPanel({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<List<DebugLogEntry>>(
+      valueListenable: DebugLogCollector.instance.entries,
+      builder: (context, entries, _) {
+        if (entries.isEmpty) {
+          return const Center(
+            child: Text(
+              'No logs yet.',
+              style: TextStyle(color: Colors.white70),
+            ),
+          );
+        }
+
+        final reversed = entries.reversed.toList();
+        return ListView.separated(
+          itemCount: reversed.length,
+          separatorBuilder: (_, __) => const Divider(height: 1),
+          itemBuilder: (context, index) {
+            final log = reversed[index];
+            final preview = log.message.split('\n').first;
+            return ListTile(
+              title: Text(
+                preview,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(color: Colors.white),
+              ),
+              subtitle: Text(
+                _formatTimestamp(log.timestamp),
+                style: const TextStyle(color: Colors.white70, fontSize: 12),
+              ),
+              onTap: () => _showLogDetail(context, log),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  String _formatTimestamp(DateTime time) {
+    final h = time.hour.toString().padLeft(2, '0');
+    final m = time.minute.toString().padLeft(2, '0');
+    final s = time.second.toString().padLeft(2, '0');
+    return '$h:$m:$s';
+  }
+
+  void _showLogDetail(BuildContext context, DebugLogEntry log) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.white,
+      builder: (context) {
+        return SafeArea(
+          child: DraggableScrollableSheet(
+            expand: false,
+            initialChildSize: 0.7,
+            minChildSize: 0.4,
+            maxChildSize: 0.95,
+            builder: (context, scrollController) {
+              return Scaffold(
+                appBar: AppBar(
+                  title: const Text('Log Detail'),
+                ),
+                body: SingleChildScrollView(
+                  controller: scrollController,
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        log.timestamp.toLocal().toString(),
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                      const SizedBox(height: 8),
+                      SelectableText(
+                        log.message,
+                        style: const TextStyle(fontSize: 14),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/debug/debug_network_logger.dart
+++ b/lib/debug/debug_network_logger.dart
@@ -118,59 +118,62 @@ class _DebugNetworkPanelState extends State<DebugNetworkPanel> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: Wrap(
-            spacing: 8,
-            children: [
-              _FilterChip(
-                label: 'All',
-                selected: _filter == 'all',
-                onSelected: () => setState(() => _filter = 'all'),
-              ),
-              _FilterChip(
-                label: '정책 API',
-                selected: _filter == 'policy',
-                onSelected: () => setState(() => _filter = 'policy'),
-                color: const Color(0xFF4D8AF0),
-              ),
-              _FilterChip(
-                label: '기관/부서 API',
-                selected: _filter == 'institution',
-                onSelected: () => setState(() => _filter = 'institution'),
-                color: const Color(0xFF7A63F1),
-              ),
-            ],
+    return Material(
+      color: Colors.transparent,
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: Wrap(
+              spacing: 8,
+              children: [
+                _FilterChip(
+                  label: 'All',
+                  selected: _filter == 'all',
+                  onSelected: () => setState(() => _filter = 'all'),
+                ),
+                _FilterChip(
+                  label: '정책 API',
+                  selected: _filter == 'policy',
+                  onSelected: () => setState(() => _filter = 'policy'),
+                  color: const Color(0xFF4D8AF0),
+                ),
+                _FilterChip(
+                  label: '기관/부서 API',
+                  selected: _filter == 'institution',
+                  onSelected: () => setState(() => _filter = 'institution'),
+                  color: const Color(0xFF7A63F1),
+                ),
+              ],
+            ),
           ),
-        ),
-        Expanded(
-          child: ValueListenableBuilder<List<NetworkLogEntry>>(
-            valueListenable: DebugNetworkLogger.instance.entries,
-            builder: (context, entries, _) {
-              final filtered = entries.reversed
-                  .where((entry) => _filter == 'all' || entry.category == _filter)
-                  .toList();
-              if (filtered.isEmpty) {
-                return const Center(
-                  child: Text(
-                    'No network logs yet.',
-                    style: TextStyle(color: Colors.white70),
-                  ),
+          Expanded(
+            child: ValueListenableBuilder<List<NetworkLogEntry>>(
+              valueListenable: DebugNetworkLogger.instance.entries,
+              builder: (context, entries, _) {
+                final filtered = entries.reversed
+                    .where((entry) => _filter == 'all' || entry.category == _filter)
+                    .toList();
+                if (filtered.isEmpty) {
+                  return const Center(
+                    child: Text(
+                      'No network logs yet.',
+                      style: TextStyle(color: Colors.white70),
+                    ),
+                  );
+                }
+                return ListView.builder(
+                  itemCount: filtered.length,
+                  itemBuilder: (context, index) {
+                    final entry = filtered[index];
+                    return _NetworkCard(entry: entry);
+                  },
                 );
-              }
-              return ListView.builder(
-                itemCount: filtered.length,
-                itemBuilder: (context, index) {
-                  final entry = filtered[index];
-                  return _NetworkCard(entry: entry);
-                },
-              );
-            },
+              },
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/lib/debug/debug_overlay.dart
+++ b/lib/debug/debug_overlay.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'debug_log_collector.dart';
 import 'debug_network_logger.dart';
 import 'debug_provider_tracker.dart';
 import 'debug_unity_logger.dart';
@@ -21,7 +22,7 @@ class _DebugOverlayState extends State<DebugOverlay> {
         color: const Color(0x8C000000),
         child: SafeArea(
           child: DefaultTabController(
-            length: 3,
+            length: 4,
             child: Builder(
               builder: (context) {
                 final tabController = DefaultTabController.of(context)!;
@@ -53,6 +54,11 @@ class _DebugOverlayState extends State<DebugOverlay> {
                             controller: tabController,
                             tabIndex: 2,
                             child: const DebugUnityPanel(),
+                          ),
+                          _AnimatedTabContent(
+                            controller: tabController,
+                            tabIndex: 3,
+                            child: const DebugLogPanel(),
                           ),
                         ],
                       ),
@@ -156,6 +162,7 @@ class _DebugTabBar extends StatelessWidget {
           Tab(text: 'Provider'),
           Tab(text: 'Network'),
           Tab(text: 'Unity'),
+          Tab(text: 'Log'),
         ],
       ),
     );

--- a/lib/debug/debug_provider_tracker.dart
+++ b/lib/debug/debug_provider_tracker.dart
@@ -9,12 +9,14 @@ class ProviderStatusEntry {
     required this.providerName,
     required this.state,
     this.error,
+    this.stackTrace,
     DateTime? timestamp,
   }) : timestamp = timestamp ?? DateTime.now();
 
   final String providerName;
   final String state;
   final Object? error;
+  final StackTrace? stackTrace;
   final DateTime timestamp;
 
   bool get isError => error != null || state.toLowerCase() == 'error';
@@ -76,7 +78,12 @@ class DebugProviderObserver extends ProviderObserver {
 
     final name = _resolveProviderName(provider);
     DebugProviderTracker.instance.addEntry(
-      ProviderStatusEntry(providerName: name, state: 'error', error: error),
+      ProviderStatusEntry(
+        providerName: name,
+        state: 'error',
+        error: error,
+        stackTrace: stackTrace,
+      ),
     );
     DebugToastController.instance
         .show('Provider "$name" error: ${error.toString()}');
@@ -95,12 +102,6 @@ class DebugProviderObserver extends ProviderObserver {
 class DebugProviderPanel extends StatelessWidget {
   const DebugProviderPanel({super.key});
 
-  Color _stateColor(ProviderStatusEntry entry) {
-    if (entry.isError) return const Color(0xFFFF4D6D);
-    if (entry.state == 'loading') return const Color(0xFF4D8AF0);
-    return const Color(0xFF4A5568);
-  }
-
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder<List<ProviderStatusEntry>>(
@@ -116,44 +117,15 @@ class DebugProviderPanel extends StatelessWidget {
         }
 
         final reversed = entries.reversed.toList();
-        return ListView.builder(
+        return ListView.separated(
           itemCount: reversed.length,
+          separatorBuilder: (_, __) => const Divider(height: 1, color: Colors.white24),
           itemBuilder: (context, index) {
             final entry = reversed[index];
-            return _ProviderRow(entry: entry);
-          },
-        );
-      },
-    );
-  }
-}
-
-class _ProviderRow extends StatelessWidget {
-  const _ProviderRow({required this.entry});
-
-  final ProviderStatusEntry entry;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      height: 44,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12),
-        child: Row(
-          children: [
-            Container(
-              width: 8,
-              height: 8,
-              decoration: BoxDecoration(
-                color: entry.isError
-                    ? const Color(0xFFFF4D6D)
-                    : const Color(0xFFCBD5E0),
-                shape: BoxShape.circle,
-              ),
-            ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Text(
+            final preview = entry.error?.toString().split('\n').first ?? '';
+            return ListTile(
+              dense: true,
+              title: Text(
                 entry.providerName,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
@@ -161,28 +133,70 @@ class _ProviderRow extends StatelessWidget {
                   color: entry.isError
                       ? const Color(0xFFFF4D6D)
                       : const Color(0xFF4A5568),
-                  fontWeight:
-                      entry.isError ? FontWeight.w700 : FontWeight.w500,
+                  fontWeight: entry.isError ? FontWeight.w700 : FontWeight.w600,
                 ),
               ),
-            ),
-            const SizedBox(width: 12),
-            Text(
-              entry.state.toUpperCase(),
-              style: TextStyle(
-                color: _stateColor(entry),
-                fontWeight: FontWeight.w700,
+              subtitle: Text(
+                entry.isError
+                    ? 'STATE: ${entry.state.toUpperCase()} • $preview'
+                    : 'STATE: ${entry.state.toUpperCase()}',
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(color: Colors.white70),
               ),
-            ),
-          ],
-        ),
-      ),
+              trailing: const Icon(Icons.chevron_right, color: Colors.white70),
+              onTap: () => _showProviderDetail(context, entry),
+            );
+          },
+        );
+      },
     );
   }
 
-  Color _stateColor(ProviderStatusEntry entry) {
-    if (entry.isError) return const Color(0xFFFF4D6D);
-    if (entry.state == 'loading') return const Color(0xFF4D8AF0);
-    return const Color(0xFF4A5568);
+  void _showProviderDetail(BuildContext context, ProviderStatusEntry entry) {
+    final stateLabel = entry.state.toUpperCase();
+    final buffer = StringBuffer('State: $stateLabel');
+    if (entry.error != null) {
+      buffer.writeln('\nError: ${entry.error}');
+    }
+    if (entry.stackTrace != null) {
+      buffer.writeln('\nStackTrace:\n${entry.stackTrace}');
+    }
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) {
+        return SafeArea(
+          child: Scaffold(
+            appBar: AppBar(
+              title: Text(entry.providerName),
+            ),
+            body: SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Updated: ${entry.timestamp.toLocal()}',
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'State: $stateLabel',
+                    style: const TextStyle(fontWeight: FontWeight.w700),
+                  ),
+                  const SizedBox(height: 12),
+                  SelectableText(
+                    buffer.toString(),
+                    style: const TextStyle(fontSize: 14),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
   }
 }

--- a/lib/debug/debug_unity_logger.dart
+++ b/lib/debug/debug_unity_logger.dart
@@ -44,9 +44,21 @@ class DebugUnityPanel extends StatelessWidget {
       builder: (context, entries, _) {
         if (entries.isEmpty) {
           return const Center(
-            child: Text(
-              'No Unity events yet.',
-              style: TextStyle(color: Colors.white70),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Text(
+                  'No Unity events yet.',
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                ),
+                SizedBox(height: 8),
+                Text(
+                  '이 탭은 Unity 디버그용입니다.\n아직 수집된 Unity 이벤트가 없습니다.',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(color: Colors.white70),
+                ),
+              ],
             ),
           );
         }

--- a/lib/main_common.dart
+++ b/lib/main_common.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'app.dart';
 import 'application/di.dart';
+import 'debug/debug_log_collector.dart';
 import 'debug/debug_provider_tracker.dart';
 
 Future<void> mainCommon() async {
@@ -13,6 +14,13 @@ Future<void> mainCommon() async {
   final observers = <ProviderObserver>[];
 
   if (kDebugMode) {
+    final originalDebugPrint = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) {
+      if (message != null) {
+        DebugLogCollector.instance.add(message);
+      }
+      originalDebugPrint(message, wrapWidth: wrapWidth);
+    };
     observers.add(DebugProviderObserver());
   }
 

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../application/notifiers/policy_list_notifier.dart';
 import '../../../application/providers.dart';
 import '../../../navigation/route_paths.dart';
 import '../../widgets/app_appbar.dart';
+import '../../widgets/global_error_view.dart';
 import '../../widgets/policy_card_v2.dart';
 
 class HomeScreen extends ConsumerWidget {
@@ -39,8 +41,9 @@ class HomeScreen extends ConsumerWidget {
               itemCount: list.length,
             ),
             loading: () => const Center(child: CircularProgressIndicator()),
-            error: (e, st) => Center(
-              child: Text('불러오기에 실패했습니다: $e'),
+            error: (e, st) => GlobalErrorView(
+              message: PolicyListNotifier.errorMessage,
+              onRetry: () => ref.invalidate(policyListNotifierProvider),
             ),
           ),
         ],

--- a/lib/ui/screens/map/map_with_list_screen.dart
+++ b/lib/ui/screens/map/map_with_list_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
+import '../../../application/notifiers/policy_list_notifier.dart';
 import '../../../application/providers.dart';
 import '../../../core/constants/env.dart';
 import '../../../domain/entities/policy.dart';
@@ -122,7 +123,7 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
                 ),
                 loading: () => const Center(child: CircularProgressIndicator()),
                 error: (e, st) => GlobalErrorView(
-                  message: '정책을 불러오지 못했습니다: $e',
+                  message: PolicyListNotifier.errorMessage,
                   onRetry: () {
                     ref.invalidate(policyListNotifierProvider);
                     ref.read(policyListNotifierProvider); // trigger reload


### PR DESCRIPTION
## Summary
- add debug log collector and log tab with detailed views for provider/network/unity panels
- wrap network tab content with Material and refine provider/unity UI for better debugging
- harden policy list provider error handling and show user-friendly retry errors on policy screens

## Testing
- Not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692303135858832a96668c52b5f57ac7)