### PR TITLE
Attach debug network logger to Dio provider

### DIFF
--- a/lib/application/di.dart
+++ b/lib/application/di.dart
@@ -9,6 +9,7 @@ import '../data/sources/remote/policy_remote_source.dart';
 import '../domain/repositories/policy_repository.dart';
 import 'services/memo_repository.dart';
 import '../core/constants/env.dart';
+import '../debug/debug_network_logger.dart';
 
 final sharedPreferencesProvider = Provider<SharedPreferences>((ref) {
   throw UnimplementedError('SharedPreferences not initialized');
@@ -24,7 +25,11 @@ final policyRepositoryProvider = Provider<PolicyRepository>((ref) {
   return PolicyRepositoryImpl(remoteSource);
 });
 
-final dioProvider = Provider<Dio>((_) => Dio());
+final dioProvider = Provider<Dio>((_) {
+  final dio = Dio();
+  DebugNetworkLogger.instance.attachTo(dio);
+  return dio;
+});
 
 final chatRepositoryProvider = Provider<ChatRepository>((ref) {
   final dio = ref.watch(dioProvider);


### PR DESCRIPTION
## Summary
- attach the debug network logger to the shared Dio provider so all requests are captured in debug builds

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69230bf089c0832a818b96cf759bb400)