### PR TITLE
Add debug support for policy API requests without key

### DIFF
--- a/lib/application/notifiers/policy_list_notifier.dart
+++ b/lib/application/notifiers/policy_list_notifier.dart
@@ -34,12 +34,18 @@ class PolicyListNotifier extends AutoDisposeAsyncNotifier<List<Policy>> {
 
   Future<List<Policy>> _fetchPolicies(String? region) async {
     try {
+      if (kDebugMode) {
+        debugPrint('[PolicyListNotifier] loading policy list...');
+      }
       final policies = await _repo.fetchPolicies(
         filter: PolicyFilter(
           searchRgnSe: region,
           searchPolicyNm: _lastQuery,
         ),
       );
+      if (kDebugMode) {
+        debugPrint('[PolicyListNotifier] fetched ${policies.length} policies');
+      }
       return policies;
     } catch (e, st) {
       if (kDebugMode) {

--- a/lib/data/sources/remote/policy_remote_source.dart
+++ b/lib/data/sources/remote/policy_remote_source.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import '../../models/policy_filter.dart';
 import '../../models/policy_model.dart';
 import '../../../core/constants/env.dart';
@@ -11,11 +12,32 @@ class PolicyRemoteSource {
   final String _apiKey;
 
   Future<List<PolicyModel>> fetchPolicies({PolicyFilter filter = const PolicyFilter()}) async {
-    if (_apiKey.isEmpty) {
+    if (kDebugMode) {
+      debugPrint('[PolicyRemoteSource] fetchPolicies called. filter: $filter');
+    }
+
+    if (_apiKey.isEmpty && !kDebugMode) {
       throw StateError('YOUTH_API_KEY is not provided');
     }
 
+    final effectiveKey = _apiKey.isEmpty && kDebugMode ? 'DEBUG-PLACEHOLDER-KEY' : _apiKey;
+
+    if (kDebugMode && _apiKey.isEmpty) {
+      debugPrint(
+        '[PolicyRemoteSource] YOUTH_API_KEY is empty. '
+        'Using debug placeholder key just to send HTTP request.',
+      );
+    }
+
     final query = _buildQuery(filter);
+    query['apiKey'] = effectiveKey;
+
+    if (kDebugMode) {
+      debugPrint(
+        '[PolicyRemoteSource] fetchPolicies -> URL=/openapi/policy/list.json '
+        'query=$query',
+      );
+    }
     final response = await _dio.get(
       'https://gbyouth.co.kr/openapi/policy/list.json',
       queryParameters: query,

--- a/lib/debug/debug_network_logger.dart
+++ b/lib/debug/debug_network_logger.dart
@@ -85,6 +85,12 @@ class _DebugNetworkInterceptor extends Interceptor {
         start != null ? DateTime.now().difference(start) : Duration.zero;
     final uri = Uri.parse(options.uri.toString());
     final path = uri.path;
+    if (kDebugMode) {
+      debugPrint(
+        '[DebugNetworkLogger] ${options.method} $path '
+        'status=$statusCode duration=${duration.inMilliseconds}ms',
+      );
+    }
     logger.add(
       NetworkLogEntry(
         method: options.method,


### PR DESCRIPTION
## Summary
- allow policy fetches to proceed in debug builds using a placeholder API key while keeping release validation
- add debug logging around policy fetch calls and notifier policy counts
- log network requests via DebugNetworkLogger for better visibility

## Testing
- Not run (dart SDK not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69230f7a977c832aaed897c35d85b151)