### PR TITLE
Improve policy filtering and region refresh

### DIFF
--- a/lib/application/notifiers/policy_list_notifier.dart
+++ b/lib/application/notifiers/policy_list_notifier.dart
@@ -40,7 +40,8 @@ class PolicyListNotifier extends AutoDisposeAsyncNotifier<List<Policy>> {
       final policies = await _repo.fetchPolicies(
         filter: PolicyFilter(
           searchRgnSe: region,
-          searchPolicyNm: _lastQuery,
+          searchText: _lastQuery,
+          availableOnly: true,
         ),
       );
       if (kDebugMode) {

--- a/lib/data/models/policy_filter.dart
+++ b/lib/data/models/policy_filter.dart
@@ -3,9 +3,14 @@ class PolicyFilter {
     this.searchRgnSe,
     this.searchPolicyType,
     this.searchPolicyNm,
+    this.searchText,
+    this.category,
     this.searchYear,
     this.instNo,
     this.deptNo,
+    this.startDate,
+    this.endDate,
+    this.availableOnly,
     this.pageIndex,
     this.recordCount,
     this.pageSize,
@@ -16,9 +21,14 @@ class PolicyFilter {
   final String? searchRgnSe;
   final String? searchPolicyType;
   final String? searchPolicyNm;
+  final String? searchText;
+  final String? category;
   final String? searchYear;
   final String? instNo;
   final String? deptNo;
+  final DateTime? startDate;
+  final DateTime? endDate;
+  final bool? availableOnly;
   final int? pageIndex;
   final int? recordCount;
   final int? pageSize;
@@ -29,9 +39,14 @@ class PolicyFilter {
     String? searchRgnSe,
     String? searchPolicyType,
     String? searchPolicyNm,
+    String? searchText,
+    String? category,
     String? searchYear,
     String? instNo,
     String? deptNo,
+    DateTime? startDate,
+    DateTime? endDate,
+    bool? availableOnly,
     int? pageIndex,
     int? recordCount,
     int? pageSize,
@@ -42,9 +57,14 @@ class PolicyFilter {
       searchRgnSe: searchRgnSe ?? this.searchRgnSe,
       searchPolicyType: searchPolicyType ?? this.searchPolicyType,
       searchPolicyNm: searchPolicyNm ?? this.searchPolicyNm,
+      searchText: searchText ?? this.searchText,
+      category: category ?? this.category,
       searchYear: searchYear ?? this.searchYear,
       instNo: instNo ?? this.instNo,
       deptNo: deptNo ?? this.deptNo,
+      startDate: startDate ?? this.startDate,
+      endDate: endDate ?? this.endDate,
+      availableOnly: availableOnly ?? this.availableOnly,
       pageIndex: pageIndex ?? this.pageIndex,
       recordCount: recordCount ?? this.recordCount,
       pageSize: pageSize ?? this.pageSize,
@@ -58,9 +78,14 @@ class PolicyFilter {
       searchRgnSe: json['searchRgnSe'] as String?,
       searchPolicyType: json['searchPolicyType'] as String?,
       searchPolicyNm: json['searchPolicyNm'] as String?,
+      searchText: json['searchText'] as String?,
+      category: json['category'] as String?,
       searchYear: json['searchYear'] as String?,
       instNo: json['instNo'] as String?,
       deptNo: json['deptNo'] as String?,
+      startDate: _parseDate(json['startDate'] as String?),
+      endDate: _parseDate(json['endDate'] as String?),
+      availableOnly: json['availableOnly'] as bool?,
       pageIndex: (json['pageIndex'] as num?)?.toInt(),
       recordCount: (json['recordCount'] as num?)?.toInt(),
       pageSize: (json['pageSize'] as num?)?.toInt(),
@@ -81,9 +106,14 @@ class PolicyFilter {
     put('searchRgnSe', searchRgnSe);
     put('searchPolicyType', searchPolicyType);
     put('searchPolicyNm', searchPolicyNm);
+    put('searchText', searchText);
+    put('category', category);
     put('searchYear', searchYear);
     put('instNo', instNo);
     put('deptNo', deptNo);
+    put('startDate', _formatDate(startDate));
+    put('endDate', _formatDate(endDate));
+    put('availableOnly', availableOnly);
     put('pageIndex', pageIndex);
     put('recordCount', recordCount);
     put('pageSize', pageSize);
@@ -91,5 +121,15 @@ class PolicyFilter {
     put('searchDsplyYn', searchDsplyYn);
 
     return data;
+  }
+
+  static DateTime? _parseDate(String? value) {
+    if (value == null || value.isEmpty) return null;
+    return DateTime.tryParse(value);
+  }
+
+  static String? _formatDate(DateTime? date) {
+    if (date == null) return null;
+    return date.toIso8601String();
   }
 }

--- a/lib/data/sources/remote/policy_remote_source.dart
+++ b/lib/data/sources/remote/policy_remote_source.dart
@@ -102,12 +102,27 @@ class PolicyRemoteSource {
     }
 
     put('searchYear', filter.searchYear);
-    put('searchPolicyNm', filter.searchPolicyNm);
-    put('searchPolicyType', filter.searchPolicyType);
+    put('searchPolicyNm', filter.searchPolicyNm ?? filter.searchText);
+    put('searchPolicyType', filter.searchPolicyType ?? filter.category);
     put('searchRgnSe', filter.searchRgnSe);
     put('instNo', filter.instNo);
     put('deptNo', filter.deptNo);
+    if (filter.availableOnly == true) {
+      put('aplyPsbltyYn', 'Y');
+    }
+    if (filter.startDate != null) {
+      put('policyBgngYmd', _formatDate(filter.startDate!));
+    }
+    if (filter.endDate != null) {
+      put('policyEndYmd', _formatDate(filter.endDate!));
+    }
 
     return query;
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.year.toString().padLeft(4, '0')}'
+        '${date.month.toString().padLeft(2, '0')}'
+        '${date.day.toString().padLeft(2, '0')}';
   }
 }

--- a/lib/ui/screens/region/region_select_screen.dart
+++ b/lib/ui/screens/region/region_select_screen.dart
@@ -26,19 +26,21 @@ class RegionSelectScreen extends ConsumerWidget {
       body: ListView.separated(
         padding: const EdgeInsets.all(16),
         itemBuilder: (_, i) {
-          final region = regions[i];
-          final isSelected = selected == region;
-          return ListTile(
-            title: Text(region),
-            trailing:
-                isSelected ? const Icon(Icons.check_circle) : const SizedBox(),
-            onTap: () {
-              ref.read(regionProvider.notifier).select(region);
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('$region 지역이 저장되었습니다.')),
-              );
-              context.go(RoutePaths.home);
-            },
+              final region = regions[i];
+              final isSelected = selected == region;
+              return ListTile(
+                title: Text(region),
+                trailing:
+                    isSelected ? const Icon(Icons.check_circle) : const SizedBox(),
+                onTap: () {
+                  ref.read(regionProvider.notifier).select(region);
+                  ref.invalidate(policyListNotifierProvider);
+                  ref.invalidate(policyPagingProvider);
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('$region 지역이 저장되었습니다.')),
+                  );
+                  context.go(RoutePaths.home);
+                },
           );
         },
         separatorBuilder: (_, __) => const Divider(),


### PR DESCRIPTION
## Summary
- add richer policy filter fields including availability and date range mapping
- forward new filters to policy remote source and default list fetch
- refresh policy list and paging providers when region selection changes

## Testing
- flutter clean (fails: flutter missing)
- flutter pub get (fails: flutter missing)
- flutter analyze --fatal-infos (fails: flutter missing)
- dart fix --apply (fails: dart missing)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69231662e9988324af725f7e364b0436)