### PR TITLE
Implement map binding, compare flow, favorites UI, and paging upgrades

### DIFF
--- a/lib/application/controllers/unity_map_controller.dart
+++ b/lib/application/controllers/unity_map_controller.dart
@@ -42,6 +42,8 @@ class UnityMapController {
 
   bool get isUnityReady => _unityController != null;
 
+  String? get _selectedRegion => _ref.read(regionProvider);
+
   void onUnityCreated(UnityWidgetController controller) {
     _unityController = controller;
     _sendCurrentPolicies();
@@ -69,6 +71,10 @@ class UnityMapController {
   }
 
   void sendMarkersForPolicies(List<Policy> policies) {
+    _sendMarkers(policies);
+  }
+
+  void refreshPolicies(List<Policy> policies) {
     _sendMarkers(policies);
   }
 
@@ -111,6 +117,7 @@ class UnityMapController {
           .map((policy) => {
                 'id': policy.id,
                 'title': policy.policyNm,
+                'region': _selectedRegion,
               })
           .toList(),
     };

--- a/lib/application/notifiers/policy_paging_notifier.dart
+++ b/lib/application/notifiers/policy_paging_notifier.dart
@@ -2,7 +2,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/models/policy_filter.dart';
-import '../../data/sources/local/search_history_source.dart';
 import '../../domain/entities/policy.dart';
 import '../../domain/repositories/policy_repository.dart';
 import '../di.dart';
@@ -11,46 +10,51 @@ import 'region_notifier.dart';
 class PolicyPagingState {
   const PolicyPagingState({
     required this.items,
-    required this.page,
+    required this.pageIndex,
+    required this.filter,
     this.isLoading = false,
+    this.isLoadingMore = false,
     this.hasMore = true,
     this.error,
-    this.initialLoaded = false,
   });
 
   final List<Policy> items;
-  final int page;
+  final int pageIndex;
+  final PolicyFilter filter;
   final bool isLoading;
+  final bool isLoadingMore;
   final bool hasMore;
   final String? error;
-  final bool initialLoaded;
 
   PolicyPagingState copyWith({
     List<Policy>? items,
-    int? page,
+    int? pageIndex,
+    PolicyFilter? filter,
     bool? isLoading,
+    bool? isLoadingMore,
     bool? hasMore,
     String? error,
-    bool? initialLoaded,
   }) {
     return PolicyPagingState(
       items: items ?? this.items,
-      page: page ?? this.page,
+      pageIndex: pageIndex ?? this.pageIndex,
+      filter: filter ?? this.filter,
       isLoading: isLoading ?? this.isLoading,
+      isLoadingMore: isLoadingMore ?? this.isLoadingMore,
       hasMore: hasMore ?? this.hasMore,
       error: error,
-      initialLoaded: initialLoaded ?? this.initialLoaded,
     );
   }
 }
 
 class PolicyPagingNotifier extends AutoDisposeNotifier<PolicyPagingState> {
   PolicyRepository get _repo => ref.read(policyRepositoryProvider);
-  int _requestId = 0;
-  String? _currentRegion;
-  String? _searchQuery;
-  bool _initialized = false;
+
   static const String errorMessage = '정책을 불러오지 못했습니다. 다시 시도해 주세요.';
+  static const int _pageSize = 10;
+
+  bool _initialized = false;
+  int _requestId = 0;
 
   @override
   PolicyPagingState build() {
@@ -58,99 +62,113 @@ class PolicyPagingNotifier extends AutoDisposeNotifier<PolicyPagingState> {
 
     if (!_initialized) {
       _initialized = true;
-      _currentRegion = region;
-      const initialState = PolicyPagingState(
-        items: [],
-        page: 1,
+      final filter = PolicyFilter(
+        searchRgnSe: region,
+        pageIndex: 1,
+        recordCount: _pageSize,
+        pagingYn: 'Y',
+      );
+      final initialState = PolicyPagingState(
+        items: const [],
+        pageIndex: 1,
+        filter: filter,
         isLoading: false,
+        isLoadingMore: false,
         hasMore: true,
-        initialLoaded: false,
       );
       state = initialState;
-      _resetAndLoad();
+      loadInitial(filter);
       return initialState;
     }
 
-    if (_currentRegion != region) {
-      _currentRegion = region;
-      _resetAndLoad();
+    if (state.filter.searchRgnSe != region) {
+      updateFilter(state.filter.copyWith(searchRgnSe: region, pageIndex: 1));
     }
 
     return state;
   }
 
-  void _resetAndLoad() {
+  Future<void> loadInitial(PolicyFilter filter) async {
+    final mergedFilter = filter.copyWith(
+      searchRgnSe: filter.searchRgnSe ?? ref.read(regionProvider),
+      pageIndex: 1,
+      recordCount: _pageSize,
+      pagingYn: 'Y',
+    );
+
     state = state.copyWith(
       items: const [],
-      page: 1,
+      pageIndex: 1,
+      filter: mergedFilter,
+      isLoading: true,
+      isLoadingMore: false,
       hasMore: true,
       error: null,
-      isLoading: false,
-      initialLoaded: false,
     );
-    loadMore(reset: true);
+
+    await _fetch(pageIndex: 1, append: false, filter: mergedFilter);
   }
 
-  Future<void> loadMore({bool reset = false}) async {
-    if (state.isLoading || (!reset && !state.hasMore)) return;
+  Future<void> loadMore() async {
+    if (state.isLoadingMore || state.isLoading || !state.hasMore) return;
+    final nextPage = state.pageIndex + 1;
+    await _fetch(pageIndex: nextPage, append: true, filter: state.filter);
+  }
 
-    final nextPage = reset ? 1 : state.page + 1;
-    final currentRegion = _currentRegion ?? ref.read(regionProvider);
-    final currentRequestId = ++_requestId;
-    final previousItems = reset ? <Policy>[] : state.items;
+  void updateFilter(PolicyFilter filter) {
+    final normalized = filter.copyWith(
+      searchRgnSe: filter.searchRgnSe ?? ref.read(regionProvider),
+      pageIndex: 1,
+      recordCount: _pageSize,
+      pagingYn: 'Y',
+    );
+    loadInitial(normalized);
+  }
 
+  Future<void> _fetch({
+    required int pageIndex,
+    required bool append,
+    required PolicyFilter filter,
+  }) async {
+    final requestId = ++_requestId;
     state = state.copyWith(
-      items: reset ? const [] : state.items,
-      page: nextPage,
-      isLoading: true,
+      isLoading: !append,
+      isLoadingMore: append,
       error: null,
-      hasMore: reset ? true : state.hasMore,
-      initialLoaded: reset ? false : state.initialLoaded,
     );
 
     try {
-      final List<Policy> newItems = await _repo.fetchPolicies(
-        filter: PolicyFilter(
-          searchRgnSe: currentRegion,
-          searchPolicyNm: _searchQuery,
-          pageIndex: nextPage,
-          recordCount: 10,
+      final policies = await _repo.fetchPolicies(
+        filter: filter.copyWith(
+          pageIndex: pageIndex,
+          recordCount: _pageSize,
+          pagingYn: 'Y',
         ),
       );
-      if (_requestId != currentRequestId) return;
 
-      final merged = <Policy>[...previousItems, ...newItems];
+      if (requestId != _requestId) return;
+
+      final mergedItems = append ? [...state.items, ...policies] : policies;
+      final hasMore = policies.length >= _pageSize;
+
       state = state.copyWith(
-        items: merged,
-        page: nextPage,
+        items: mergedItems,
+        pageIndex: pageIndex,
+        filter: filter.copyWith(pageIndex: pageIndex),
         isLoading: false,
-        hasMore: newItems.isNotEmpty,
-        initialLoaded: true,
+        isLoadingMore: false,
+        hasMore: hasMore,
+        error: null,
       );
     } catch (e, st) {
-      debugPrint('Failed to load policy list: $e');
+      debugPrint('Failed to load policies: $e');
       debugPrint('$st');
-      if (_requestId != currentRequestId) return;
+      if (requestId != _requestId) return;
       state = state.copyWith(
-        items: previousItems,
-        page: reset ? 1 : state.page,
         isLoading: false,
-        hasMore: reset ? true : state.hasMore,
+        isLoadingMore: false,
         error: errorMessage,
-        initialLoaded: reset ? false : state.initialLoaded,
       );
     }
-  }
-
-  Future<void> search(String query) async {
-    final normalized = query.trim();
-    _searchQuery = normalized.isEmpty ? null : normalized;
-    // === 보완 패치: 검색 히스토리 저장 ===
-    if (_searchQuery != null) {
-      final history = ref.read(searchHistorySourceProvider);
-      await history.saveQuery(_searchQuery!);
-      ref.invalidate(searchHistoryListProvider);
-    }
-    await loadMore(reset: true);
   }
 }

--- a/lib/navigation/app_router.dart
+++ b/lib/navigation/app_router.dart
@@ -9,8 +9,9 @@ import '../ui/screens/institution/department_list_screen.dart';
 import '../ui/screens/institution/institution_list_screen.dart';
 import '../ui/screens/map/kakao_map_screen.dart';
 import '../ui/screens/map/map_with_list_screen.dart';
+import '../ui/screens/compare/compare_screen.dart';
 import '../ui/screens/policy/policy_compare_screen.dart';
-import '../ui/screens/policy/policy_detail_screen.dart';
+import '../ui/screens/policy/policy_detail_v2_screen.dart';
 import '../ui/screens/policy/policy_list_legacy_screen.dart';
 import '../ui/screens/policy/policy_list_v2_screen.dart';
 import '../ui/screens/policy/policy_webview_page.dart';
@@ -111,6 +112,10 @@ class AppRouter {
           builder: (context, state) => const PolicyCompareScreen(),
         ),
         GoRoute(
+          path: RoutePaths.compare,
+          builder: (context, state) => const CompareScreen(),
+        ),
+        GoRoute(
           path: RoutePaths.unity,
           builder: (context, state) => const UnityScreen(),
         ),
@@ -142,7 +147,7 @@ class AppRouter {
           path: '/policy/:id',
           builder: (context, state) {
             final id = state.pathParameters['id'] ?? '';
-            return PolicyDetailScreen(id: id);
+            return PolicyDetailV2Screen(id: id);
           },
         ),
         GoRoute(

--- a/lib/navigation/route_paths.dart
+++ b/lib/navigation/route_paths.dart
@@ -12,6 +12,7 @@ class RoutePaths {
   static const policyListV2 = '/policy/list/v2';
   static const policyLegacyList = '/policy/list';
   static const policyCompare = '/policy/compare';
+  static const compare = '/compare';
   static const favorites = '/favorites';
   static const instList = '/inst/list';
   static const deptList = '/inst/:instNo/dept/list';

--- a/lib/ui/screens/compare/compare_screen.dart
+++ b/lib/ui/screens/compare/compare_screen.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../application/providers.dart';
+import '../../../domain/entities/policy.dart';
+import '../../widgets/app_appbar.dart';
+import '../../widgets/policy_card_v2.dart';
+
+class CompareScreen extends ConsumerWidget {
+  const CompareScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final compareAsync = ref.watch(compareProvider);
+
+    return Scaffold(
+      appBar: const AppAppBar(title: '정책 비교함'),
+      body: compareAsync.when(
+        data: (policies) {
+          if (policies.isEmpty) {
+            return const _EmptyView(message: '비교함에 담긴 정책이 없습니다');
+          }
+          if (policies.length == 1) {
+            return Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  Expanded(child: PolicyCardV2(policy: policies.first)),
+                  const SizedBox(width: 12),
+                  const Expanded(
+                    child: _EmptyView(
+                      message: '비교할 정책을 하나 더 담아주세요',
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+          final first = policies[0];
+          final second = policies[1];
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Expanded(child: PolicyCardV2(policy: first)),
+                    const SizedBox(width: 12),
+                    Expanded(child: PolicyCardV2(policy: second)),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                _buildCompareTable(first, second),
+              ],
+            ),
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, st) => const Center(child: Text('비교 정보를 불러올 수 없습니다.')),
+      ),
+    );
+  }
+
+  Widget _buildCompareTable(Policy a, Policy b) {
+    final rows = <_CompareRowInfo>[
+      _CompareRowInfo('제목', a.policyNm, b.policyNm),
+      _CompareRowInfo('기관', a.sprvsnInstNm ?? a.operInstNm ?? '-',
+          b.sprvsnInstNm ?? b.operInstNm ?? '-'),
+      _CompareRowInfo('유형', a.policyTypeNm ?? '-', b.policyTypeNm ?? '-'),
+      _CompareRowInfo('지원 규모', a.policyScl ?? '-', b.policyScl ?? '-'),
+      _CompareRowInfo('지원 내용', a.policyCn ?? '-', b.policyCn ?? '-'),
+      _CompareRowInfo('연령/지역', _regionAge(a), _regionAge(b)),
+      _CompareRowInfo(
+        '신청 기간',
+        _formatPeriod(a.applyStart, a.applyEnd, a.policyBgngYmd, a.policyEndYmd),
+        _formatPeriod(b.applyStart, b.applyEnd, b.policyBgngYmd, b.policyEndYmd),
+      ),
+      _CompareRowInfo('링크', a.dtlLinkUrl ?? '-', b.dtlLinkUrl ?? '-'),
+    ];
+
+    return Table(
+      columnWidths: const {0: IntrinsicColumnWidth()},
+      defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+      children: rows
+          .map(
+            (row) => TableRow(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  child: Text(
+                    row.label,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text(row.left, maxLines: 3, overflow: TextOverflow.ellipsis),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text(row.right,
+                      maxLines: 3, overflow: TextOverflow.ellipsis),
+                ),
+              ],
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  static String _regionAge(Policy policy) {
+    final region = (policy.rgnSeNm ?? '').trim();
+    final regionText = region.isEmpty ? '지역 전체' : region;
+    final age = policy.policyScl ?? '연령 정보 없음';
+    return '$regionText / $age';
+  }
+
+  static String _formatPeriod(
+    DateTime? applyStart,
+    DateTime? applyEnd,
+    DateTime? policyStart,
+    DateTime? policyEnd,
+  ) {
+    String? start =
+        applyStart?.toIso8601String().split('T').first ?? policyStart?.toIso8601String().split('T').first;
+    String? end =
+        applyEnd?.toIso8601String().split('T').first ?? policyEnd?.toIso8601String().split('T').first;
+    start = (start == null || start.isEmpty) ? null : start;
+    end = (end == null || end.isEmpty) ? null : end;
+    if (start == null && end == null) return '-';
+    if (start != null && end != null) return '$start ~ $end';
+    if (start != null) return '$start 시작';
+    return '~ $end';
+  }
+}
+
+class _EmptyView extends StatelessWidget {
+  const _EmptyView({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.balance_outlined, size: 48, color: Colors.grey),
+          const SizedBox(height: 8),
+          Text(
+            message,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CompareRowInfo {
+  const _CompareRowInfo(this.label, this.left, this.right);
+
+  final String label;
+  final String left;
+  final String right;
+}

--- a/lib/ui/screens/favorites/favorites_screen.dart
+++ b/lib/ui/screens/favorites/favorites_screen.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../application/providers.dart';
 import '../../../domain/entities/policy.dart';
 import '../../../domain/repositories/policy_repository.dart';
+import '../../../navigation/route_paths.dart';
 import '../../widgets/policy_card_v2.dart';
 
 class FavoritesScreen extends ConsumerWidget {
@@ -13,16 +15,24 @@ class FavoritesScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final favorites = ref.watch(favoritesProvider);
     final policyRepository = ref.watch(policyRepositoryProvider);
+    final compareCount = ref.watch(
+      compareProvider.select((value) => value.valueOrNull?.length ?? 0),
+    );
     final favoriteIds = favorites.toList()..sort();
 
     return Scaffold(
       appBar: AppBar(
         title: const Text('즐겨찾기'),
+        actions: [
+          if (compareCount > 0)
+            TextButton(
+              onPressed: () => context.push(RoutePaths.compare),
+              child: Text('비교함 보기 ($compareCount)'),
+            ),
+        ],
       ),
       body: favoriteIds.isEmpty
-          ? const Center(
-              child: Text('즐겨찾기한 정책이 없습니다.'),
-            )
+          ? const _FavoritesEmptyView()
           : FutureBuilder<List<Policy>>(
               key: ValueKey(favoriteIds.join(',')),
               future: _loadPolicies(favoriteIds, policyRepository),
@@ -32,20 +42,15 @@ class FavoritesScreen extends ConsumerWidget {
                 }
 
                 if (snapshot.hasError) {
-                  return Center(
-                    child: Text(
-                      '데이터를 불러오지 못했습니다.\n${snapshot.error}',
-                      textAlign: TextAlign.center,
-                    ),
+                  return const _FavoritesEmptyView(
+                    message: '데이터를 불러오지 못했습니다.',
                   );
                 }
 
                 final policies = snapshot.data ?? [];
 
                 if (policies.isEmpty) {
-                  return const Center(
-                    child: Text('즐겨찾기한 정책이 없습니다.'),
-                  );
+                  return const _FavoritesEmptyView();
                 }
 
                 return ListView.separated(
@@ -54,11 +59,55 @@ class FavoritesScreen extends ConsumerWidget {
                   separatorBuilder: (_, __) => const SizedBox(height: 12),
                   itemBuilder: (context, index) {
                     final policy = policies[index];
-                    return PolicyCardV2(policy: policy);
+                    return Dismissible(
+                      key: ValueKey(policy.id),
+                      direction: DismissDirection.horizontal,
+                      onDismissed: (_) =>
+                          ref.read(favoritesProvider.notifier).remove(policy.id),
+                      background: Container(
+                        color: Colors.redAccent.withOpacity(0.2),
+                        alignment: Alignment.centerLeft,
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: const Icon(Icons.delete_outline),
+                      ),
+                      secondaryBackground: Container(
+                        color: Colors.redAccent.withOpacity(0.2),
+                        alignment: Alignment.centerRight,
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: const Icon(Icons.delete_outline),
+                      ),
+                      child: PolicyCardV2(
+                        policy: policy,
+                        onTap: () =>
+                            context.push(RoutePaths.policyDetail(policy.id)),
+                      ),
+                    );
                   },
                 );
               },
             ),
+    );
+  }
+}
+
+class _FavoritesEmptyView extends StatelessWidget {
+  const _FavoritesEmptyView({
+    this.message = '찜한 정책이 아직 없습니다.',
+  });
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.favorite_border, size: 64, color: Colors.grey),
+          const SizedBox(height: 12),
+          Text(message, style: Theme.of(context).textTheme.bodyLarge),
+        ],
+      ),
     );
   }
 }

--- a/lib/ui/screens/map/kakao_map_screen.dart
+++ b/lib/ui/screens/map/kakao_map_screen.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 import '../../../application/providers.dart';
 import '../../../core/constants/env.dart';
 import '../../../domain/entities/policy.dart';
+import '../../../navigation/route_paths.dart';
 import '../../widgets/app_appbar.dart';
 import 'kakao_map_html_builder.dart';
 
@@ -17,46 +19,35 @@ class KakaoMapScreen extends ConsumerStatefulWidget {
 
 class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   static const _htmlBuilder = KakaoMapHtmlBuilder();
+  static const _bridgeName = 'KakaoBridge';
   late final WebViewController _controller;
   bool _isLoading = true;
+  bool _mapReady = false;
 
-  static const _defaultCenter = KakaoMapLatLng(35.8714, 128.6014); // Daegu
-  static const _mockPolicies = <KakaoMapPolicyMarker>[
-    KakaoMapPolicyMarker(
-      id: 'mock-1',
-      title: '청년 취업 지원',
-      lat: 35.872,
-      lng: 128.602,
-    ),
-    KakaoMapPolicyMarker(
-      id: 'mock-2',
-      title: '창업 보육 프로그램',
-      lat: 35.876,
-      lng: 128.61,
-    ),
-    KakaoMapPolicyMarker(
-      id: 'mock-3',
-      title: '주거 지원 시범사업',
-      lat: 35.868,
-      lng: 128.595,
-    ),
-    KakaoMapPolicyMarker(
-      id: 'mock-4',
-      title: '문화 체험 바우처',
-      lat: 35.865,
-      lng: 128.59,
-    ),
-  ];
+  static const _defaultCenter = KakaoMapLatLng(36.4919, 128.8889); // Gyeongbuk
+  AsyncValue<List<Policy>>? _lastPolicies;
 
   @override
   void initState() {
     super.initState();
-    final center = _centerFromRegion(ref.read(regionProvider));
+    ref.listen<String?>(regionProvider, (_, __) => _reloadMap());
+    ref.listen<AsyncValue<List<Policy>>>(policyListNotifierProvider,
+        (prev, next) {
+      if (next.hasValue && next.valueOrNull != prev?.valueOrNull) {
+        _lastPolicies = next;
+        _reloadMap();
+      }
+    });
+    final center = _centerForRegion(ref.read(regionProvider));
     _controller = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..addJavaScriptChannel(_bridgeName, onMessageReceived: _onMapMessage)
       ..setNavigationDelegate(
         NavigationDelegate(
-          onPageStarted: (_) => setState(() => _isLoading = true),
+          onPageStarted: (_) => setState(() {
+            _isLoading = true;
+            _mapReady = false;
+          }),
           onPageFinished: (_) => setState(() => _isLoading = false),
         ),
       )
@@ -65,22 +56,13 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
           apiKey: Env.kakaoMapApiKey,
           center: center,
           markers: _policyMarkers(center, ref.read(policyListNotifierProvider)),
+          bridgeName: _bridgeName,
         ),
       );
   }
 
   @override
   Widget build(BuildContext context) {
-    ref.listen<String?>(regionProvider, (_, __) {
-      _reloadMap();
-    });
-
-    ref.listen<AsyncValue<List<Policy>>>(policyListNotifierProvider, (prev, next) {
-      if (next.hasValue && next.valueOrNull != prev?.valueOrNull) {
-        _reloadMap();
-      }
-    });
-
     return Scaffold(
       appBar: const AppAppBar(title: '카카오맵 보기'),
       body: Stack(
@@ -90,17 +72,24 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
             const Center(
               child: CircularProgressIndicator(),
             ),
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 16,
+            child: _buildOverlay(ref.watch(policyListNotifierProvider)),
+          ),
         ],
       ),
     );
   }
 
   void _reloadMap() {
-    final center = _centerFromRegion(ref.read(regionProvider));
+    final center = _centerForRegion(ref.read(regionProvider));
     final markers = _policyMarkers(center, ref.read(policyListNotifierProvider));
 
     setState(() {
       _isLoading = true;
+      _mapReady = false;
     });
 
     _controller.loadHtmlString(
@@ -108,6 +97,29 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         apiKey: Env.kakaoMapApiKey,
         center: center,
         markers: markers,
+        bridgeName: _bridgeName,
+      ),
+    );
+  }
+
+  Widget _buildOverlay(AsyncValue<List<Policy>> policies) {
+    return policies.when(
+      data: (_) => const SizedBox.shrink(),
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, __) => Center(
+        child: Container(
+          padding: const EdgeInsets.all(12),
+          margin: const EdgeInsets.symmetric(horizontal: 24),
+          decoration: BoxDecoration(
+            color: Colors.black.withOpacity(0.6),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: const Text(
+            '정책을 불러오지 못했습니다.',
+            style: TextStyle(color: Colors.white),
+            textAlign: TextAlign.center,
+          ),
+        ),
       ),
     );
   }
@@ -116,10 +128,8 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     KakaoMapLatLng center,
     AsyncValue<List<Policy>> asyncPolicies,
   ) {
-    final policies = asyncPolicies.valueOrNull;
-    if (policies == null || policies.isEmpty) {
-      return _mockPolicies;
-    }
+    final policies = asyncPolicies.valueOrNull ?? _lastPolicies?.valueOrNull;
+    if (policies == null || policies.isEmpty) return const [];
 
     final markerOffsets = _markerOffsets(center);
     final limitedPolicies = policies.take(markerOffsets.length).toList();
@@ -153,45 +163,42 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         .toList();
   }
 
-  KakaoMapLatLng _centerFromRegion(String? region) {
-    if (region == null || region.isEmpty) {
-      return _defaultCenter;
+  KakaoMapLatLng _centerForRegion(String? regionName) {
+    final normalized = (regionName ?? '').trim();
+    switch (normalized) {
+      case '포항시':
+        return const KakaoMapLatLng(36.0190, 129.3435);
+      case '구미시':
+        return const KakaoMapLatLng(36.1195, 128.3446);
+      case '경산시':
+        return const KakaoMapLatLng(35.8252, 128.7415);
+      case '안동시':
+        return const KakaoMapLatLng(36.5684, 128.7294);
+      case '김천시':
+        return const KakaoMapLatLng(36.1398, 128.1136);
+      case '경북 전체':
+        return _defaultCenter;
+      default:
+        if (normalized.isEmpty) return _defaultCenter;
+        return _defaultCenter;
     }
-    final normalized = region.replaceAll(' ', '');
-    if (normalized.contains('경상북')) {
-      return const KakaoMapLatLng(36.4919, 128.8889);
-    }
-    if (normalized.contains('대구')) {
-      return const KakaoMapLatLng(35.8714, 128.6014);
-    }
-    return _defaultCenter;
   }
 
-  String _missingApiKeyPage() {
-    return '''
-<!DOCTYPE html>
-<html>
-<body>
-  <p style="padding:16px;font-size:16px;">
-    카카오맵 API 키가 설정되지 않았습니다. KAKAO_MAP_API_KEY 환경 변수를 추가해주세요.
-  </p>
-</body>
-</html>
-''';
+  void _onMapMessage(JavaScriptMessage message) {
+    final content = message.message;
+    if (content == 'ready') {
+      setState(() {
+        _mapReady = true;
+        _isLoading = false;
+      });
+      return;
+    }
+    if (content.startsWith('marker:')) {
+      if (!_mapReady) return;
+      final policyId = content.replaceFirst('marker:', '');
+      if (policyId.isNotEmpty && mounted) {
+        context.push(RoutePaths.policyDetail(policyId));
+      }
+    }
   }
-}
-
-class _LatLng {
-  const _LatLng(this.lat, this.lng);
-
-  final double lat;
-  final double lng;
-}
-
-class _PolicyMarker {
-  const _PolicyMarker({required this.title, required this.lat, required this.lng});
-
-  final String title;
-  final double lat;
-  final double lng;
 }

--- a/lib/ui/screens/map/map_with_list_screen.dart
+++ b/lib/ui/screens/map/map_with_list_screen.dart
@@ -2,15 +2,17 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 import '../../../application/notifiers/policy_list_notifier.dart';
 import '../../../application/providers.dart';
 import '../../../core/constants/env.dart';
 import '../../../domain/entities/policy.dart';
+import '../../../navigation/route_paths.dart';
 import '../../widgets/app_appbar.dart';
-import '../../widgets/policy_card_v2.dart';
 import '../../widgets/global_error_view.dart';
+import '../../widgets/policy_card_v2.dart';
 import 'kakao_map_html_builder.dart';
 
 class MapWithListScreen extends ConsumerStatefulWidget {
@@ -23,49 +25,23 @@ class MapWithListScreen extends ConsumerStatefulWidget {
 class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
   static const _htmlBuilder = KakaoMapHtmlBuilder();
   static const _bridgeName = 'MapBridge';
-  static const _estimatedItemHeight = 220.0;
-
-  static const _defaultCenter = KakaoMapLatLng(35.8714, 128.6014); // Daegu
-  static const _mockPolicies = <KakaoMapPolicyMarker>[
-    KakaoMapPolicyMarker(
-      id: 'mock-1',
-      title: '청년 취업 지원',
-      lat: 35.872,
-      lng: 128.602,
-    ),
-    KakaoMapPolicyMarker(
-      id: 'mock-2',
-      title: '창업 보육 프로그램',
-      lat: 35.876,
-      lng: 128.61,
-    ),
-    KakaoMapPolicyMarker(
-      id: 'mock-3',
-      title: '주거 지원 시범사업',
-      lat: 35.868,
-      lng: 128.595,
-    ),
-    KakaoMapPolicyMarker(
-      id: 'mock-4',
-      title: '문화 체험 바우처',
-      lat: 35.865,
-      lng: 128.59,
-    ),
-  ];
+  static const _estimatedItemHeight = 240.0;
+  static const _defaultCenter = KakaoMapLatLng(36.4919, 128.8889);
 
   late final ScrollController _listController;
   late final WebViewController _mapController;
   bool _isLoading = true;
   bool _mapReady = false;
   bool _isMapUpdating = false;
-  bool _isRegionUpdating = false;
   String? _selectedPolicyId;
+  String? _lastMarkerTapId;
   Map<String, KakaoMapPolicyMarker> _markerLookup = {};
 
   @override
   void initState() {
     super.initState();
     _listController = ScrollController()..addListener(_onListScroll);
+    _setupListeners();
     _initWebView();
   }
 
@@ -78,16 +54,6 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
 
   @override
   Widget build(BuildContext context) {
-    ref.listen<String?>(regionProvider, (_, __) {
-      _reloadMap();
-    });
-
-    ref.listen<AsyncValue<List<Policy>>>(policyListNotifierProvider, (prev, next) {
-      if (next.hasValue && next.valueOrNull != prev?.valueOrNull) {
-        _reloadMap();
-      }
-    });
-
     final policies = ref.watch(policyListNotifierProvider);
     return Scaffold(
       appBar: const AppAppBar(title: '지도 + 리스트'),
@@ -95,7 +61,7 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
         child: Column(
           children: [
             SizedBox(
-              height: 220,
+              height: 240,
               child: Stack(
                 children: [
                   WebViewWidget(controller: _mapController),
@@ -103,6 +69,12 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
                     const Center(
                       child: CircularProgressIndicator(),
                     ),
+                  Positioned(
+                    left: 0,
+                    right: 0,
+                    bottom: 12,
+                    child: _buildOverlay(policies),
+                  ),
                 ],
               ),
             ),
@@ -126,7 +98,7 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
                   message: PolicyListNotifier.errorMessage,
                   onRetry: () {
                     ref.invalidate(policyListNotifierProvider);
-                    ref.read(policyListNotifierProvider); // trigger reload
+                    ref.read(policyListNotifierProvider);
                   },
                 ),
               ),
@@ -146,7 +118,10 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
       )
       ..setNavigationDelegate(
         NavigationDelegate(
-          onPageStarted: (_) => setState(() => _isLoading = true),
+          onPageStarted: (_) => setState(() {
+            _isLoading = true;
+            _mapReady = false;
+          }),
           onPageFinished: (_) => setState(() => _isLoading = false),
         ),
       );
@@ -154,8 +129,18 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
     _reloadMap();
   }
 
+  void _setupListeners() {
+    ref.listen<String?>(regionProvider, (_, __) => _reloadMap());
+    ref.listen<AsyncValue<List<Policy>>>(policyListNotifierProvider,
+        (prev, next) {
+      if (next.hasValue && next.valueOrNull != prev?.valueOrNull) {
+        _reloadMap();
+      }
+    });
+  }
+
   void _reloadMap() {
-    final center = _centerFromRegion(ref.read(regionProvider));
+    final center = _centerForRegion(ref.read(regionProvider));
     final markers = _policyMarkers(center, ref.read(policyListNotifierProvider));
     _markerLookup = {for (final marker in markers) marker.id: marker};
 
@@ -174,9 +159,30 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
     );
   }
 
+  Widget _buildOverlay(AsyncValue<List<Policy>> policies) {
+    return policies.when(
+      data: (_) => const SizedBox.shrink(),
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, __) => Container(
+        margin: const EdgeInsets.symmetric(horizontal: 16),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Colors.black.withOpacity(0.65),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: const Text(
+          '정책을 불러오지 못했습니다.',
+          style: TextStyle(color: Colors.white),
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+
   void _onPolicyTap(Policy policy) {
     _selectedPolicyId = policy.id;
     _moveMapToPolicy(policy.id);
+    context.push(RoutePaths.policyDetail(policy.id));
   }
 
   void _moveMapToPolicy(String policyId) {
@@ -214,8 +220,12 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
     }
     if (content.startsWith('marker:')) {
       final markerId = content.replaceFirst('marker:', '');
+      if (_lastMarkerTapId == markerId) {
+        context.push(RoutePaths.policyDetail(markerId));
+        return;
+      }
+      _lastMarkerTapId = markerId;
       _highlightPolicy(markerId);
-      return;
     }
     if (content.startsWith('region:')) {
       final coords = content.replaceFirst('region:', '').split(',');
@@ -223,7 +233,6 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
         final lat = double.tryParse(coords[0]);
         final lng = double.tryParse(coords[1]);
         if (lat != null && lng != null) {
-          _updateRegionFilter(lat, lng);
           _highlightNearestPolicy(lat, lng);
         }
       }
@@ -262,40 +271,25 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
     _highlightPolicy(nearest.id);
   }
 
-  void _updateRegionFilter(double lat, double lng) {
-    if (_isRegionUpdating) return;
-    final current = ref.read(regionProvider);
-    final region = _regionNameFromLatLng(lat, lng);
-    if (region == null || region == current) return;
-    _isRegionUpdating = true;
-    ref.read(regionProvider.notifier).select(region);
-    Future.delayed(const Duration(milliseconds: 200), () {
-      _isRegionUpdating = false;
-    });
-  }
-
-  KakaoMapLatLng _centerFromRegion(String? region) {
-    if (region == null || region.isEmpty) {
-      return _defaultCenter;
+  KakaoMapLatLng _centerForRegion(String? regionName) {
+    final normalized = (regionName ?? '').trim();
+    switch (normalized) {
+      case '포항시':
+        return const KakaoMapLatLng(36.0190, 129.3435);
+      case '구미시':
+        return const KakaoMapLatLng(36.1195, 128.3446);
+      case '경산시':
+        return const KakaoMapLatLng(35.8252, 128.7415);
+      case '안동시':
+        return const KakaoMapLatLng(36.5684, 128.7294);
+      case '김천시':
+        return const KakaoMapLatLng(36.1398, 128.1136);
+      case '경북 전체':
+        return _defaultCenter;
+      default:
+        if (normalized.isEmpty) return _defaultCenter;
+        return _defaultCenter;
     }
-    final normalized = region.replaceAll(' ', '');
-    if (normalized.contains('경상북')) {
-      return const KakaoMapLatLng(36.4919, 128.8889);
-    }
-    if (normalized.contains('대구')) {
-      return const KakaoMapLatLng(35.8714, 128.6014);
-    }
-    return _defaultCenter;
-  }
-
-  String? _regionNameFromLatLng(double lat, double lng) {
-    if (lat >= 36.2) {
-      return '경상북도';
-    }
-    if (lat >= 35.7 && lng >= 128.4 && lng <= 128.9) {
-      return '대구광역시';
-    }
-    return null;
   }
 
   List<KakaoMapPolicyMarker> _policyMarkers(
@@ -303,9 +297,7 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
     AsyncValue<List<Policy>> asyncPolicies,
   ) {
     final policies = asyncPolicies.valueOrNull;
-    if (policies == null || policies.isEmpty) {
-      return _mockPolicies;
-    }
+    if (policies == null || policies.isEmpty) return const [];
 
     final markerOffsets = _markerOffsets(center);
     final limitedPolicies = policies.take(markerOffsets.length).toList();

--- a/lib/ui/screens/policy/policy_detail_v2_screen.dart
+++ b/lib/ui/screens/policy/policy_detail_v2_screen.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:url_launcher/url_launcher_string.dart';
+
+import '../../../application/notifiers/policy_detail_notifier.dart';
+import '../../../application/providers.dart';
+import '../../../domain/entities/policy.dart';
+import '../../../navigation/route_paths.dart';
+import '../../widgets/app_appbar.dart';
+import '../../widgets/global_error_view.dart';
+import '../../widgets/policy_card_v2.dart';
+
+class PolicyDetailV2Screen extends ConsumerStatefulWidget {
+  const PolicyDetailV2Screen({super.key, required this.id});
+
+  final String id;
+
+  @override
+  ConsumerState<PolicyDetailV2Screen> createState() => _PolicyDetailV2ScreenState();
+}
+
+class _PolicyDetailV2ScreenState extends ConsumerState<PolicyDetailV2Screen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  void _load() {
+    ref.read(policyDetailProvider.notifier).load(widget.id);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final detailState = ref.watch(policyDetailProvider);
+    final policy = detailState.policy;
+
+    Widget body() {
+      if (detailState.isLoading && policy == null) {
+        return const Center(child: CircularProgressIndicator());
+      }
+      if (detailState.error != null && policy == null) {
+        return GlobalErrorView(
+          message: PolicyDetailNotifier.errorMessage,
+          onRetry: _load,
+        );
+      }
+      if (policy == null) {
+        return GlobalErrorView(
+          message: PolicyDetailNotifier.errorMessage,
+          onRetry: _load,
+        );
+      }
+      return _buildDetail(context, policy, detailState.similar);
+    }
+
+    return Scaffold(
+      appBar: const AppAppBar(title: '정책 상세'),
+      body: body(),
+    );
+  }
+
+  Widget _buildDetail(BuildContext context, Policy policy, List<Policy> similar) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final region = (policy.rgnSeNm ?? '').trim().isEmpty ? '지역 전체' : policy.rgnSeNm!.trim();
+    final ddayText = _formatDday(policy.dday);
+    final periodText = _formatPeriod(policy.policyBgngYmd, policy.policyEndYmd,
+        policy.applyStart, policy.applyEnd);
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            policy.policyNm,
+            style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 4,
+            children: [
+              if (policy.policyTypeNm != null)
+                Chip(label: Text(policy.policyTypeNm!)),
+              Chip(label: Text(region)),
+              if (ddayText != null)
+                Chip(
+                  backgroundColor: colorScheme.primaryContainer,
+                  label: Text(ddayText),
+                ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          _Section(
+            title: '요약',
+            child: Text(_cleanText(policy.policyScl) ?? '정보 없음'),
+          ),
+          const SizedBox(height: 16),
+          _Section(
+            title: '지원 내용',
+            child: Text(_cleanText(policy.policyCn) ?? '지원 내용이 제공되지 않았습니다.'),
+          ),
+          const SizedBox(height: 16),
+          _Section(
+            title: '문의',
+            child: Text(_cleanText(policy.policyEnq) ?? '문의처 정보가 없습니다.'),
+          ),
+          const SizedBox(height: 16),
+          _Section(
+            title: '신청 기간',
+            child: Text(periodText ?? '기간 정보 없음'),
+          ),
+          const SizedBox(height: 16),
+          if ((policy.dtlLinkUrl ?? '').isNotEmpty)
+            FilledButton.icon(
+              onPressed: () => _openLink(context, policy.dtlLinkUrl!),
+              icon: const Icon(Icons.open_in_new),
+              label: const Text('홈페이지에서 자세히 보기'),
+            ),
+          if (similar.isNotEmpty) ...[
+            const SizedBox(height: 24),
+            Text('유사 정책', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            ...similar.take(3).map(
+              (p) => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 6),
+                child: PolicyCardV2(
+                  policy: p,
+                  onTap: () =>
+                      context.pushReplacement(RoutePaths.policyDetail(p.id)),
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Future<void> _openLink(BuildContext context, String url) async {
+    final normalized = url.trim();
+    if (normalized.isEmpty) return;
+    final launched = await launchUrlString(normalized);
+    if (!launched && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('링크를 열 수 없습니다.')),
+      );
+    }
+  }
+
+  String? _cleanText(String? value) {
+    if (value == null) return null;
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return null;
+    return trimmed.replaceAll(RegExp(r'\n{3,}', multiLine: true), '\n\n');
+  }
+
+  String? _formatPeriod(
+    DateTime? start,
+    DateTime? end,
+    DateTime? applyStart,
+    DateTime? applyEnd,
+  ) {
+    final startText = _formatDate(applyStart ?? start);
+    final endText = _formatDate(applyEnd ?? end);
+    if (startText == null && endText == null) return null;
+    if (startText != null && endText != null) return '$startText ~ $endText';
+    if (startText != null) return '$startText 시작';
+    return '~ $endText';
+  }
+
+  String? _formatDate(DateTime? date) {
+    if (date == null) return null;
+    return date.toIso8601String().split('T').first;
+  }
+
+  String? _formatDday(int? dday) {
+    if (dday == null) return null;
+    if (dday == 0) return 'D-Day';
+    if (dday > 0) return 'D-$dday';
+    return 'D+${dday.abs()}';
+  }
+}
+
+class _Section extends StatelessWidget {
+  const _Section({required this.title, required this.child});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 8),
+        child,
+      ],
+    );
+  }
+}

--- a/lib/ui/screens/policy/policy_list_v2_screen.dart
+++ b/lib/ui/screens/policy/policy_list_v2_screen.dart
@@ -2,10 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../../application/providers.dart';
 import '../../../application/notifiers/policy_paging_notifier.dart';
-import '../../../navigation/route_paths.dart';
+import '../../../application/providers.dart';
+import '../../../data/models/policy_filter.dart';
 import '../../../data/sources/local/search_history_source.dart';
+import '../../../navigation/route_paths.dart';
 import '../../widgets/app_appbar.dart';
 import '../../widgets/global_error_view.dart';
 import '../../widgets/policy_card_v2.dart';
@@ -20,6 +21,9 @@ class PolicyListV2Screen extends ConsumerStatefulWidget {
 class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
   late final TextEditingController _controller;
   late final ScrollController _scrollController;
+  String? _selectedCategory;
+  String? _selectedYear;
+  bool _availableOnly = false;
 
   @override
   void initState() {
@@ -27,6 +31,10 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
     _controller = TextEditingController();
     _scrollController = ScrollController();
     _scrollController.addListener(_onScroll);
+    ref.listen<String?>(regionProvider, (_, __) => _applyFilter());
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(policyPagingProvider.notifier).loadInitial(_buildFilter());
+    });
   }
 
   @override
@@ -38,17 +46,34 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
 
   void _onScroll() {
     final state = ref.read(policyPagingProvider);
-    if (!state.hasMore || state.isLoading) return;
+    if (!state.hasMore || state.isLoadingMore || state.isLoading) return;
     final position = _scrollController.position;
     if (position.pixels >= position.maxScrollExtent - 200) {
       ref.read(policyPagingProvider.notifier).loadMore();
     }
   }
 
+  PolicyFilter _buildFilter() {
+    final region = ref.read(regionProvider);
+    return PolicyFilter(
+      searchRgnSe: region,
+      searchPolicyNm: _controller.text.trim().isEmpty ? null : _controller.text.trim(),
+      category: _selectedCategory,
+      searchYear: _selectedYear,
+      availableOnly: _availableOnly,
+      pageIndex: 1,
+      recordCount: 10,
+      pagingYn: 'Y',
+    );
+  }
+
+  void _applyFilter() {
+    ref.read(policyPagingProvider.notifier).updateFilter(_buildFilter());
+  }
+
   Future<void> _performSearch(PolicyPagingNotifier notifier) async {
-    // === 보완 패치: 검색 실행 타이밍 안정화 ===
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      notifier.search(_controller.text);
+      notifier.updateFilter(_buildFilter());
     });
   }
 
@@ -57,33 +82,42 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
     final pagingState = ref.watch(policyPagingProvider);
     final pagingNotifier = ref.read(policyPagingProvider.notifier);
     final history = ref.watch(searchHistoryListProvider);
+    final compareCount = ref.watch(
+      compareProvider.select((value) => value.valueOrNull?.length ?? 0),
+    );
 
     Widget buildList() {
       if (pagingState.error != null && pagingState.items.isEmpty) {
         return GlobalErrorView(
           message: pagingState.error!,
-          onRetry: () => pagingNotifier.loadMore(reset: true),
+          onRetry: () => pagingNotifier.loadInitial(_buildFilter()),
         );
       }
 
-      if (!pagingState.initialLoaded && pagingState.isLoading) {
+      if (pagingState.items.isEmpty && pagingState.isLoading) {
         return const Center(child: CircularProgressIndicator());
       }
 
       if (pagingState.items.isEmpty) {
         return GlobalErrorView(
           message: '표시할 정책이 없습니다.',
-          onRetry: () => pagingNotifier.loadMore(reset: true),
+          onRetry: () => pagingNotifier.loadInitial(_buildFilter()),
         );
       }
 
       return RefreshIndicator(
-        onRefresh: () => pagingNotifier.loadMore(reset: true),
+        onRefresh: () => pagingNotifier.loadInitial(_buildFilter()),
         child: ListView.separated(
           controller: _scrollController,
           padding: const EdgeInsets.all(16),
           itemBuilder: (_, i) {
             if (i >= pagingState.items.length) {
+              if (!pagingState.hasMore) {
+                return const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 16),
+                  child: Center(child: Text('마지막 정책까지 모두 불러왔습니다.')),
+                );
+              }
               return const Padding(
                 padding: EdgeInsets.symmetric(vertical: 16),
                 child: Center(child: CircularProgressIndicator()),
@@ -96,7 +130,8 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
             );
           },
           separatorBuilder: (_, __) => const SizedBox(height: 12),
-          itemCount: pagingState.items.length + (pagingState.isLoading ? 1 : 0),
+          itemCount:
+              pagingState.items.length + (pagingState.isLoadingMore || pagingState.hasMore ? 1 : 0),
         ),
       );
     }
@@ -117,9 +152,8 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
                         label: Text(e.query),
                         onPressed: () {
                           _controller.text = e.query;
-                          // === 보완 패치: 검색 호출 + 타이밍 보강 ===
                           WidgetsBinding.instance.addPostFrameCallback((_) {
-                            pagingNotifier.search(e.query);
+                            pagingNotifier.updateFilter(_buildFilter());
                           });
                         },
                       ),
@@ -136,6 +170,13 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
 
     return Scaffold(
       appBar: const AppAppBar(title: '정책 목록'),
+      floatingActionButton: compareCount == 0
+          ? null
+          : FloatingActionButton.extended(
+              onPressed: () => context.push(RoutePaths.compare),
+              icon: const Icon(Icons.balance),
+              label: Text('비교하기 ($compareCount)'),
+            ),
       body: Column(
         children: [
           Padding(
@@ -150,6 +191,73 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
                 ),
               ),
               onSubmitted: (_) => _performSearch(pagingNotifier),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Wrap(
+                    spacing: 8,
+                    children: [
+                      ChoiceChip(
+                        label: const Text('전체'),
+                        selected: _selectedCategory == null,
+                        onSelected: (_) {
+                          setState(() => _selectedCategory = null);
+                          _applyFilter();
+                        },
+                      ),
+                      ChoiceChip(
+                        label: const Text('취업'),
+                        selected: _selectedCategory == '취업',
+                        onSelected: (_) {
+                          setState(() => _selectedCategory = '취업');
+                          _applyFilter();
+                        },
+                      ),
+                      ChoiceChip(
+                        label: const Text('창업'),
+                        selected: _selectedCategory == '창업',
+                        onSelected: (_) {
+                          setState(() => _selectedCategory = '창업');
+                          _applyFilter();
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+                DropdownButton<String?>(
+                  value: _selectedYear,
+                  hint: const Text('연도'),
+                  items: const [null, '2024', '2023']
+                      .map(
+                        (e) => DropdownMenuItem<String?>(
+                          value: e,
+                          child: Text(e ?? '전체'),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (value) {
+                    setState(() => _selectedYear = value);
+                    _applyFilter();
+                  },
+                ),
+                const SizedBox(width: 8),
+                Row(
+                  children: [
+                    const Text('신청가능'),
+                    Switch(
+                      value: _availableOnly,
+                      onChanged: (value) {
+                        setState(() => _availableOnly = value);
+                        _applyFilter();
+                      },
+                    ),
+                  ],
+                ),
+              ],
             ),
           ),
           Padding(

--- a/lib/ui/widgets/policy_card_v2.dart
+++ b/lib/ui/widgets/policy_card_v2.dart
@@ -56,8 +56,8 @@ class PolicyCardV2 extends ConsumerWidget {
     final tags = getPolicyTags(policy);
     final regionText = (policy.rgnSeNm == null || policy.rgnSeNm!.trim().isEmpty)
         ? '지역 전체'
-        : policy.rgnSeNm!;
-    final ageText = '연령 정보 없음';
+        : policy.rgnSeNm!.trim();
+    final ageText = _buildAgeText(policy);
 
     final periodText = _formatPeriod(policy.policyBgngYmd, policy.policyEndYmd);
     final ddayText = _formatDday(policy.dday);
@@ -159,6 +159,7 @@ class PolicyCardV2 extends ConsumerWidget {
 
   String? _formatDday(int? dday) {
     if (dday == null) return null;
+    if (dday == 0) return 'D-Day';
     if (dday >= 0) return 'D-$dday';
     return 'D+${dday.abs()}';
   }
@@ -166,6 +167,26 @@ class PolicyCardV2 extends ConsumerWidget {
   String? _formatDate(DateTime? date) {
     if (date == null) return null;
     return date.toIso8601String().split('T').first;
+  }
+
+  String _buildAgeText(Policy policy) {
+    final candidates = [policy.policyScl, policy.policyCn];
+    final rangePattern = RegExp(r'(만\s*)?\d{1,2}\s*~\s*\d{1,2}\s*세');
+    final singlePattern = RegExp(r'(만\s*)?\d{1,2}\s*세');
+
+    for (final text in candidates) {
+      if (text == null) continue;
+      final rangeMatch = rangePattern.firstMatch(text);
+      if (rangeMatch != null) {
+        return rangeMatch.group(0)!.replaceAll(RegExp(r'\s+'), ' ').trim();
+      }
+      final singleMatch = singlePattern.firstMatch(text);
+      if (singleMatch != null) {
+        return singleMatch.group(0)!.replaceAll(RegExp(r'\s+'), ' ').trim();
+      }
+    }
+
+    return '연령 정보 없음';
   }
 }
 


### PR DESCRIPTION
## Summary
- Bind map screens to region and policy list state with marker interactions and updated centers
- Add full compare screen flow with navigation entries from list and favorites
- Refresh favorites UI, policy detail layout, card info accuracy, and paging/filter behavior

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692319eb5ac0832483289437a5967d8e)