### PR TITLE
Add url_launcher dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   shared_preferences: ^2.1.1
 
   webview_flutter: ^4.10.0
+  url_launcher: ^6.3.1
 
   flutter_unity_widget: ^2022.1.1+5
 


### PR DESCRIPTION
## Summary
- add url_launcher package to pubspec to support URL launching from policy detail screen

## Testing
- not run (flutter not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925eae8886c83249eb38c82188b9cb0)