### PR TITLE
Add manual provider listener cleanup to map screens

### DIFF
--- a/lib/ui/screens/map/kakao_map_screen.dart
+++ b/lib/ui/screens/map/kakao_map_screen.dart
@@ -26,18 +26,23 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
 
   static const _defaultCenter = KakaoMapLatLng(36.4919, 128.8889); // Gyeongbuk
   AsyncValue<List<Policy>>? _lastPolicies;
+  ProviderSubscription<String?>? _regionSubscription;
+  ProviderSubscription<AsyncValue<List<Policy>>>? _policySubscription;
 
   @override
   void initState() {
     super.initState();
-    ref.listen<String?>(regionProvider, (_, __) => _reloadMap());
-    ref.listen<AsyncValue<List<Policy>>>(policyListNotifierProvider,
-        (prev, next) {
-      if (next.hasValue && next.valueOrNull != prev?.valueOrNull) {
-        _lastPolicies = next;
-        _reloadMap();
-      }
-    });
+    _regionSubscription =
+        ref.listenManual<String?>(regionProvider, (_, __) => _reloadMap());
+    _policySubscription = ref.listenManual<AsyncValue<List<Policy>>>(
+      policyListNotifierProvider,
+      (prev, next) {
+        if (next.hasValue && next.valueOrNull != prev?.valueOrNull) {
+          _lastPolicies = next;
+          _reloadMap();
+        }
+      },
+    );
     final center = _centerForRegion(ref.read(regionProvider));
     _controller = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
@@ -59,6 +64,13 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
           bridgeName: _bridgeName,
         ),
       );
+  }
+
+  @override
+  void dispose() {
+    _regionSubscription?.close();
+    _policySubscription?.close();
+    super.dispose();
   }
 
   @override

--- a/lib/ui/screens/map/map_with_list_screen.dart
+++ b/lib/ui/screens/map/map_with_list_screen.dart
@@ -30,6 +30,8 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
 
   late final ScrollController _listController;
   late final WebViewController _mapController;
+  ProviderSubscription<String?>? _regionSubscription;
+  ProviderSubscription<AsyncValue<List<Policy>>>? _policySubscription;
   bool _isLoading = true;
   bool _mapReady = false;
   bool _isMapUpdating = false;
@@ -49,6 +51,8 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
   void dispose() {
     _listController.removeListener(_onListScroll);
     _listController.dispose();
+    _regionSubscription?.close();
+    _policySubscription?.close();
     super.dispose();
   }
 
@@ -130,13 +134,16 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
   }
 
   void _setupListeners() {
-    ref.listen<String?>(regionProvider, (_, __) => _reloadMap());
-    ref.listen<AsyncValue<List<Policy>>>(policyListNotifierProvider,
-        (prev, next) {
-      if (next.hasValue && next.valueOrNull != prev?.valueOrNull) {
-        _reloadMap();
-      }
-    });
+    _regionSubscription =
+        ref.listenManual<String?>(regionProvider, (_, __) => _reloadMap());
+    _policySubscription = ref.listenManual<AsyncValue<List<Policy>>>(
+      policyListNotifierProvider,
+      (prev, next) {
+        if (next.hasValue && next.valueOrNull != prev?.valueOrNull) {
+          _reloadMap();
+        }
+      },
+    );
   }
 
   void _reloadMap() {


### PR DESCRIPTION
## Summary
- add manual provider subscriptions for Kakao map screens
- ensure region and policy listeners are closed on dispose

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925eea483f48324a5427a6124e6613d)