### PR TITLE
Adjust region listener timing in policy list screen

### DIFF
--- a/lib/ui/screens/policy/policy_list_v2_screen.dart
+++ b/lib/ui/screens/policy/policy_list_v2_screen.dart
@@ -32,8 +32,11 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
     _controller = TextEditingController();
     _scrollController = ScrollController();
     _scrollController.addListener(_onScroll);
-    _regionSubscription =
-        ref.listenManual<String?>(regionProvider, (_, __) => _applyFilter());
+    _regionSubscription = ref.listenManual<String?>(regionProvider, (_, __) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _applyFilter();
+      });
+    });
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref.read(policyPagingProvider.notifier).loadInitial(_buildFilter());
     });


### PR DESCRIPTION
## Summary
- wrap the region provider listener callback in a post-frame callback before applying filters to avoid build-time assertions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925f12a3c1c8324b7db322f6525ecdd)