### PR TITLE
Handle multiple AI response formats

### DIFF
--- a/lib/data/repositories/chat_repository.dart
+++ b/lib/data/repositories/chat_repository.dart
@@ -31,8 +31,41 @@ class ChatRepository {
       debugPrint('AI response raw: ${response.data}');
 
       final data = response.data;
+
+      // 1) Original format: {"reply": "..."}
       if (data is Map && data['reply'] is String) {
         return data['reply'] as String;
+      }
+
+      // 2) OpenAI / ChatCompletion-style format:
+      // {
+      //   "choices": [
+      //     {
+      //       "message": {
+      //         "content": "..."
+      //       }
+      //     }
+      //   ]
+      // }
+      if (data is Map &&
+          data['choices'] is List &&
+          (data['choices'] as List).isNotEmpty) {
+        final firstChoice = (data['choices'] as List).first;
+        if (firstChoice is Map &&
+            firstChoice['message'] is Map &&
+            firstChoice['message']['content'] is String) {
+          return firstChoice['message']['content'] as String;
+        }
+      }
+
+      // 3) Gateway-style: {"result": "..."}
+      if (data is Map && data['result'] is String) {
+        return data['result'] as String;
+      }
+
+      // 4) Plain string response
+      if (data is String) {
+        return data;
       }
 
       throw StateError('Invalid AI response format');


### PR DESCRIPTION
## Summary
- update ChatRepository sendMessage to accept multiple AI response shapes
- preserve existing endpoint and logging while parsing reply, ChatCompletion, gateway, or plain string formats

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925f38e87808324a98ed5ca9f51a541)