### PR TITLE
Fix region listener subscription handling

### DIFF
--- a/lib/ui/screens/policy/policy_list_v2_screen.dart
+++ b/lib/ui/screens/policy/policy_list_v2_screen.dart
@@ -21,7 +21,7 @@ class PolicyListV2Screen extends ConsumerStatefulWidget {
 class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
   late final TextEditingController _controller;
   late final ScrollController _scrollController;
-  late final void Function() _removeRegionListener;
+  late final ProviderSubscription<String?> _regionSubscription;
   String? _selectedCategory;
   String? _selectedYear;
   bool _availableOnly = false;
@@ -32,7 +32,7 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
     _controller = TextEditingController();
     _scrollController = ScrollController();
     _scrollController.addListener(_onScroll);
-    _removeRegionListener = ref.listenManual<String?>(regionProvider, (_, __) {
+    _regionSubscription = ref.listenManual<String?>(regionProvider, (prev, next) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _applyFilter();
       });
@@ -44,7 +44,7 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
 
   @override
   void dispose() {
-    _removeRegionListener();
+    _regionSubscription.close();
     _scrollController.dispose();
     _controller.dispose();
     super.dispose();


### PR DESCRIPTION
## Summary
- replace region listener storage with ProviderSubscription for Riverpod 2.6.1
- update region listener initialization to use listenManual subscription
- close subscription on dispose to avoid incorrect callback usage

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925f592ef008324a282301d8708a908)