### PR TITLE
Fix Kakao map WebView loading

### DIFF
--- a/lib/ui/screens/map/kakao_map_html_builder.dart
+++ b/lib/ui/screens/map/kakao_map_html_builder.dart
@@ -63,7 +63,7 @@ class KakaoMapHtmlBuilder {
   <style>
     html, body, #map { width: 100%; height: 100%; margin: 0; padding: 0; }
   </style>
-  <script type="text/javascript" src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=$apiKey&autoload=false"></script>
+  <script type="text/javascript" src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=$apiKey&autoload=true"></script>
 </head>
 <body>
   <div id="map"></div>
@@ -109,7 +109,13 @@ class KakaoMapHtmlBuilder {
       notifyFlutter('ready');
     }
 
-    kakao.maps.load(initMap);
+    window.onload = function() {
+      if (kakao && kakao.maps) {
+        initMap();
+      } else {
+        setTimeout(() => initMap(), 100);
+      }
+    };
   </script>
 </body>
 </html>

--- a/lib/ui/screens/map/kakao_map_screen.dart
+++ b/lib/ui/screens/map/kakao_map_screen.dart
@@ -53,7 +53,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
             _isLoading = true;
             _mapReady = false;
           }),
-          onPageFinished: (_) => setState(() => _isLoading = false),
+          onPageFinished: (_) {},
         ),
       )
       ..loadHtmlString(
@@ -63,6 +63,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
           markers: _policyMarkers(center, ref.read(policyListNotifierProvider)),
           bridgeName: _bridgeName,
         ),
+        baseUrl: 'https://gbyouth.co.kr',
       );
   }
 
@@ -104,14 +105,17 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
       _mapReady = false;
     });
 
-    _controller.loadHtmlString(
-      _htmlBuilder.build(
-        apiKey: Env.kakaoMapApiKey,
-        center: center,
-        markers: markers,
-        bridgeName: _bridgeName,
-      ),
-    );
+    Future.delayed(const Duration(milliseconds: 50), () {
+      _controller.loadHtmlString(
+        _htmlBuilder.build(
+          apiKey: Env.kakaoMapApiKey,
+          center: center,
+          markers: markers,
+          bridgeName: _bridgeName,
+        ),
+        baseUrl: 'https://gbyouth.co.kr',
+      );
+    });
   }
 
   Widget _buildOverlay(AsyncValue<List<Policy>> policies) {


### PR DESCRIPTION
## Summary
- enable Kakao Maps SDK autoload and wait for window load before initializing the map
- provide a base URL and small delay when loading the WebView HTML to prevent blocked scripts and frame starvation
- remove premature loading state updates from the WebView page-finished callback

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926e7c8a1a483248e24b4ef78710cd8)