### PR TITLE
Set default PolicyFilter paging parameters for YouthRoad v2

### DIFF
--- a/lib/data/models/policy_filter.dart
+++ b/lib/data/models/policy_filter.dart
@@ -11,12 +11,15 @@ class PolicyFilter {
     this.startDate,
     this.endDate,
     this.availableOnly,
-    this.pageIndex,
-    this.recordCount,
     this.pageSize,
-    this.pagingYn,
-    this.searchDsplyYn,
-  });
+    int? pageIndex,
+    int? recordCount,
+    String? pagingYn,
+    String? searchDsplyYn,
+  })  : pageIndex = pageIndex ?? 1,
+        recordCount = recordCount ?? 2000,
+        pagingYn = pagingYn ?? 'N',
+        searchDsplyYn = searchDsplyYn ?? 'all';
 
   final String? searchRgnSe;
   final String? searchPolicyType;


### PR DESCRIPTION
## Summary
- update PolicyFilter constructor defaults to align with YouthRoad v2 (pageIndex 1, recordCount 2000, pagingYn N, searchDsplyYn all)

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926e9cd2ebc8324a5f9bdc18e4d8e66)