### PR TITLE
Fix duplicate policy fetches and clean query filters

### DIFF
--- a/lib/application/notifiers/policy_paging_notifier.dart
+++ b/lib/application/notifiers/policy_paging_notifier.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -55,15 +57,13 @@ class PolicyPagingNotifier extends AutoDisposeNotifier<PolicyPagingState> {
 
   bool _initialized = false;
   int _requestId = 0;
+  String? _inFlightKey;
 
   @override
   PolicyPagingState build() {
-    final region = ref.watch(regionProvider);
-
     if (!_initialized) {
       _initialized = true;
       final filter = PolicyFilter(
-        searchRgnSe: region,
         pageIndex: 1,
         recordCount: _pageSize,
         pagingYn: 'Y',
@@ -77,14 +77,8 @@ class PolicyPagingNotifier extends AutoDisposeNotifier<PolicyPagingState> {
         hasMore: true,
       );
       state = initialState;
-      loadInitial(filter);
       return initialState;
     }
-
-    if (state.filter.searchRgnSe != region) {
-      updateFilter(state.filter.copyWith(searchRgnSe: region, pageIndex: 1));
-    }
-
     return state;
   }
 
@@ -95,6 +89,12 @@ class PolicyPagingNotifier extends AutoDisposeNotifier<PolicyPagingState> {
       recordCount: _pageSize,
       pagingYn: 'Y',
     );
+
+    final requestKey = _buildRequestKey(mergedFilter);
+    if (state.isLoading && requestKey == _inFlightKey) {
+      return;
+    }
+    _inFlightKey = requestKey;
 
     state = state.copyWith(
       items: const [],
@@ -107,6 +107,7 @@ class PolicyPagingNotifier extends AutoDisposeNotifier<PolicyPagingState> {
     );
 
     await _fetch(pageIndex: 1, append: false, filter: mergedFilter);
+    _inFlightKey = null;
   }
 
   Future<void> loadMore() async {
@@ -170,5 +171,28 @@ class PolicyPagingNotifier extends AutoDisposeNotifier<PolicyPagingState> {
         error: errorMessage,
       );
     }
+  }
+
+  String _buildRequestKey(PolicyFilter filter) {
+    final normalized = PolicyFilter(
+      searchRgnSe: filter.searchRgnSe,
+      searchPolicyType: filter.searchPolicyType,
+      searchPolicyNm: filter.searchPolicyNm,
+      searchText: filter.searchText,
+      category: filter.category,
+      searchYear: filter.searchYear,
+      instNo: filter.instNo,
+      deptNo: filter.deptNo,
+      startDate: filter.startDate,
+      endDate: filter.endDate,
+      availableOnly: filter.availableOnly,
+      pageIndex: filter.pageIndex ?? 1,
+      recordCount: filter.recordCount ?? _pageSize,
+      pageSize: filter.pageSize,
+      pagingYn: filter.pagingYn ?? 'Y',
+      searchDsplyYn: filter.searchDsplyYn ?? 'all',
+    );
+
+    return jsonEncode(normalized.toJson());
   }
 }

--- a/lib/data/sources/remote/policy_remote_source.dart
+++ b/lib/data/sources/remote/policy_remote_source.dart
@@ -102,14 +102,24 @@ class PolicyRemoteSource {
     }
 
     put('searchYear', filter.searchYear);
-    put('searchPolicyNm', filter.searchPolicyNm ?? filter.searchText);
-    put('searchPolicyType', filter.searchPolicyType ?? filter.category);
-    put('searchRgnSe', filter.searchRgnSe);
-    put('instNo', filter.instNo);
-    put('deptNo', filter.deptNo);
+
+    if (filter.searchRgnSe == '전체' || filter.searchRgnSe == '경북 전체') {
+      // skip adding region filter
+    } else {
+      put('searchRgnSe', filter.searchRgnSe);
+    }
+
     if (filter.availableOnly == true) {
       put('aplyPsbltyYn', 'Y');
     }
+
+    if (filter.category != null && filter.category != '전체') {
+      put('searchPolicyType', filter.category);
+    }
+
+    put('searchPolicyNm', filter.searchText);
+    put('instNo', filter.instNo);
+    put('deptNo', filter.deptNo);
     if (filter.startDate != null) {
       put('policyBgngYmd', _formatDate(filter.startDate!));
     }

--- a/lib/ui/screens/policy/policy_list_v2_screen.dart
+++ b/lib/ui/screens/policy/policy_list_v2_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -25,6 +27,7 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
   String? _selectedCategory;
   String? _selectedYear;
   bool _availableOnly = false;
+  Timer? _debounce;
 
   @override
   void initState() {
@@ -32,9 +35,9 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
     _controller = TextEditingController();
     _scrollController = ScrollController();
     _scrollController.addListener(_onScroll);
-    _regionSubscription = ref.listenManual<String?>(regionProvider, (prev, next) {
+    _regionSubscription = ref.listen<String?>(regionProvider, (prev, next) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        _applyFilter();
+        _applyFilterDebounced();
       });
     });
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -44,6 +47,7 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
 
   @override
   void dispose() {
+    _debounce?.cancel();
     _regionSubscription.close();
     _scrollController.dispose();
     _controller.dispose();
@@ -77,10 +81,13 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
     ref.read(policyPagingProvider.notifier).updateFilter(_buildFilter());
   }
 
+  void _applyFilterDebounced() {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 150), _applyFilter);
+  }
+
   Future<void> _performSearch(PolicyPagingNotifier notifier) async {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      notifier.updateFilter(_buildFilter());
-    });
+    _applyFilterDebounced();
   }
 
   @override
@@ -159,7 +166,7 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
                         onPressed: () {
                           _controller.text = e.query;
                           WidgetsBinding.instance.addPostFrameCallback((_) {
-                            pagingNotifier.updateFilter(_buildFilter());
+                            _applyFilterDebounced();
                           });
                         },
                       ),
@@ -212,7 +219,7 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
                         selected: _selectedCategory == null,
                         onSelected: (_) {
                           setState(() => _selectedCategory = null);
-                          _applyFilter();
+                          _applyFilterDebounced();
                         },
                       ),
                       ChoiceChip(
@@ -220,7 +227,7 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
                         selected: _selectedCategory == '취업',
                         onSelected: (_) {
                           setState(() => _selectedCategory = '취업');
-                          _applyFilter();
+                          _applyFilterDebounced();
                         },
                       ),
                       ChoiceChip(
@@ -228,7 +235,7 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
                         selected: _selectedCategory == '창업',
                         onSelected: (_) {
                           setState(() => _selectedCategory = '창업');
-                          _applyFilter();
+                          _applyFilterDebounced();
                         },
                       ),
                     ],
@@ -247,7 +254,7 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
                       .toList(),
                   onChanged: (value) {
                     setState(() => _selectedYear = value);
-                    _applyFilter();
+                    _applyFilterDebounced();
                   },
                 ),
                 const SizedBox(width: 8),
@@ -258,7 +265,7 @@ class _PolicyListV2ScreenState extends ConsumerState<PolicyListV2Screen> {
                       value: _availableOnly,
                       onChanged: (value) {
                         setState(() => _availableOnly = value);
-                        _applyFilter();
+                        _applyFilterDebounced();
                       },
                     ),
                   ],

--- a/lib/ui/widgets/policy_card_v2.dart
+++ b/lib/ui/widgets/policy_card_v2.dart
@@ -254,6 +254,8 @@ class _HeaderRow extends ConsumerWidget {
   final Policy policy;
   final _StatusBadge? status;
 
+  static const double _actionSize = 40;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final favorites = ref.watch(favoritesProvider);
@@ -281,35 +283,43 @@ class _HeaderRow extends ConsumerWidget {
         const SizedBox(width: 4),
 
         /// 즐겨찾기 버튼
-        IconButton(
-          icon: Icon(
-            isFavorite ? Icons.favorite : Icons.favorite_border,
-            color: isFavorite ? Colors.redAccent : null,
+        SizedBox(
+          width: _actionSize,
+          height: _actionSize,
+          child: IconButton(
+            icon: Icon(
+              isFavorite ? Icons.favorite : Icons.favorite_border,
+              color: isFavorite ? Colors.redAccent : null,
+            ),
+            onPressed: () =>
+                ref.read(favoritesProvider.notifier).toggle(policy.id),
+            constraints: const BoxConstraints(),
+            padding: EdgeInsets.zero,
           ),
-          onPressed: () =>
-              ref.read(favoritesProvider.notifier).toggle(policy.id),
-          constraints: const BoxConstraints(),
-          padding: EdgeInsets.zero,
         ),
 
         /// 비교 버튼
         CompareBadge(
-          child: IconButton(
-            icon: Icon(
-              isInCompare ? Icons.balance : Icons.balance_outlined,
-              color: isInCompare ? Colors.teal : null,
+          child: SizedBox(
+            width: _actionSize,
+            height: _actionSize,
+            child: IconButton(
+              icon: Icon(
+                isInCompare ? Icons.balance : Icons.balance_outlined,
+                color: isInCompare ? Colors.teal : null,
+              ),
+              onPressed: () =>
+                  ref.read(compareProvider.notifier).toggle(policy.id),
+              constraints: const BoxConstraints(),
+              padding: EdgeInsets.zero,
             ),
-            onPressed: () =>
-                ref.read(compareProvider.notifier).toggle(policy.id),
-            constraints: const BoxConstraints(),
-            padding: EdgeInsets.zero,
           ),
         ),
 
         /// 상태 뱃지
         if (status != null) ...[
           const SizedBox(width: 4),
-          status!.toChip(Theme.of(context)),
+          Flexible(child: status!.toChip(Theme.of(context))),
         ],
       ],
     );


### PR DESCRIPTION
## Summary
- prevent notifier from auto-fetching and debounce UI-triggered filter changes to avoid duplicate requests
- normalize policy query parameters for region, availability, category, and search text to avoid empty results
- keep policy card header actions fixed-size with flexible status chip to prevent overflow

## Testing
- Not run (environment lacks Dart/Flutter tooling)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926ec4bf8408324bef9f927366b30eb)