### PR TITLE
Improve Kakao map diagnostics

### DIFF
--- a/lib/ui/screens/map/kakao_map_html_builder.dart
+++ b/lib/ui/screens/map/kakao_map_html_builder.dart
@@ -63,7 +63,7 @@ class KakaoMapHtmlBuilder {
   <style>
     html, body, #map { width: 100%; height: 100%; margin: 0; padding: 0; }
   </style>
-  <script type="text/javascript" src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=$apiKey&autoload=true"></script>
+  <script type="text/javascript" src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=$apiKey&autoload=false"></script>
 </head>
 <body>
   <div id="map"></div>
@@ -109,13 +109,15 @@ class KakaoMapHtmlBuilder {
       notifyFlutter('ready');
     }
 
-    window.onload = function() {
-      if (kakao && kakao.maps) {
-        initMap();
+    function loadKakaoMap() {
+      if (window.kakao && kakao.maps && kakao.maps.load) {
+        kakao.maps.load(initMap);
       } else {
-        setTimeout(() => initMap(), 100);
+        setTimeout(loadKakaoMap, 100);
       }
-    };
+    }
+
+    window.onload = loadKakaoMap;
   </script>
 </body>
 </html>

--- a/lib/ui/screens/map/kakao_map_screen.dart
+++ b/lib/ui/screens/map/kakao_map_screen.dart
@@ -32,6 +32,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   @override
   void initState() {
     super.initState();
+    debugPrint('[KakaoMapScreen] Env.kakaoMapApiKey = ${Env.kakaoMapApiKey}');
     _regionSubscription =
         ref.listenManual<String?>(regionProvider, (_, __) => _reloadMap());
     _policySubscription = ref.listenManual<AsyncValue<List<Policy>>>(


### PR DESCRIPTION
## Summary
- log the injected Kakao map API key when the map screen initializes
- load the Kakao Maps SDK with autoload disabled and wait for the SDK before initializing the map

## Testing
- Not run (environment missing Dart SDK)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926ef2862b08324ad90a164bfeb6df4)