### PR TITLE
Stabilize Kakao map updates and provider lifecycle

### DIFF
--- a/lib/application/notifiers/policy_list_notifier.dart
+++ b/lib/application/notifiers/policy_list_notifier.dart
@@ -9,7 +9,7 @@ import '../di.dart';
 import '../../data/sources/local/search_history_source.dart';
 import 'region_notifier.dart';
 
-class PolicyListNotifier extends AutoDisposeAsyncNotifier<List<Policy>> {
+class PolicyListNotifier extends AsyncNotifier<List<Policy>> {
   static const String errorMessage = '정책을 불러오지 못했습니다.';
   String? _lastQuery;
 

--- a/lib/application/providers.dart
+++ b/lib/application/providers.dart
@@ -15,7 +15,7 @@ export 'repository_providers.dart';
 export 'notifiers/region_notifier.dart' show regionProvider, RegionNotifier;
 
 final policyListNotifierProvider =
-    AsyncNotifierProvider.autoDispose<PolicyListNotifier, List<Policy>>(
+    AsyncNotifierProvider<PolicyListNotifier, List<Policy>>(
   PolicyListNotifier.new,
 );
 

--- a/lib/ui/screens/map/kakao_map_html_builder.dart
+++ b/lib/ui/screens/map/kakao_map_html_builder.dart
@@ -69,6 +69,8 @@ class KakaoMapHtmlBuilder {
   <div id="map"></div>
   <script>
     var map;
+    var markers = [];
+    var markerData = [$markerJson];
 
     $notifyFlutter
 
@@ -78,12 +80,19 @@ class KakaoMapHtmlBuilder {
       map.setCenter(latlng);
     }
 
-    function createMarkers(map) {
-      var markers = [$markerJson];
-      markers.forEach(function(m) {
+    function clearMarkers() {
+      markers.forEach(function(marker) {
+        marker.setMap(null);
+      });
+      markers = [];
+    }
+
+    function renderMarkers(map) {
+      markerData.forEach(function(m) {
         var position = new kakao.maps.LatLng(m.lat, m.lng);
         var marker = new kakao.maps.Marker({ position: position });
         marker.setMap(map);
+        markers.push(marker);
 
         var infoWindow = new kakao.maps.InfoWindow({
           content: '<div style="padding:8px;font-size:13px;">' + m.title + '</div>'
@@ -95,6 +104,15 @@ class KakaoMapHtmlBuilder {
       });
     }
 
+    function updateMarkers(data) {
+      if (Array.isArray(data)) {
+        markerData = data;
+      }
+      if (!map) return;
+      clearMarkers();
+      renderMarkers(map);
+    }
+
     function initMap() {
       var container = document.getElementById('map');
       var options = {
@@ -102,7 +120,7 @@ class KakaoMapHtmlBuilder {
         level: 6
       };
       map = new kakao.maps.Map(container, options);
-      createMarkers(map);
+      renderMarkers(map);
       kakao.maps.event.addListener(map, 'click', function(mouseEvent) {
         notifyFlutter('region:' + mouseEvent.latLng.getLat() + ',' + mouseEvent.latLng.getLng());
       });

--- a/lib/ui/screens/map/kakao_map_screen.dart
+++ b/lib/ui/screens/map/kakao_map_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -23,6 +25,9 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   late final WebViewController _controller;
   bool _isLoading = true;
   bool _mapReady = false;
+  late KakaoMapLatLng _lastCenter;
+  String? _lastRegion;
+  List<KakaoMapPolicyMarker> _pendingMarkers = const [];
 
   static const _defaultCenter = KakaoMapLatLng(36.4919, 128.8889); // Gyeongbuk
   AsyncValue<List<Policy>>? _lastPolicies;
@@ -33,18 +38,26 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   void initState() {
     super.initState();
     debugPrint('[KakaoMapScreen] Env.kakaoMapApiKey = ${Env.kakaoMapApiKey}');
-    _regionSubscription =
-        ref.listenManual<String?>(regionProvider, (_, __) => _reloadMap());
+    _lastRegion = ref.read(regionProvider);
+    _lastCenter = _centerForRegion(_lastRegion);
+    _lastPolicies = ref.read(policyListNotifierProvider);
+    _pendingMarkers =
+        _policyMarkers(_lastCenter, _lastPolicies ?? const AsyncLoading());
+    _regionSubscription = ref.listenManual<String?>(regionProvider, (prev, next) {
+      if (next == _lastRegion) return;
+      _lastRegion = next;
+      _lastCenter = _centerForRegion(_lastRegion);
+      _pushMarkerUpdate();
+    });
     _policySubscription = ref.listenManual<AsyncValue<List<Policy>>>(
       policyListNotifierProvider,
       (prev, next) {
         if (next.hasValue && next.valueOrNull != prev?.valueOrNull) {
           _lastPolicies = next;
-          _reloadMap();
+          _pushMarkerUpdate();
         }
       },
     );
-    final center = _centerForRegion(ref.read(regionProvider));
     _controller = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..addJavaScriptChannel(_bridgeName, onMessageReceived: _onMapMessage)
@@ -60,8 +73,8 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
       ..loadHtmlString(
         _htmlBuilder.build(
           apiKey: Env.kakaoMapApiKey,
-          center: center,
-          markers: _policyMarkers(center, ref.read(policyListNotifierProvider)),
+          center: _lastCenter,
+          markers: _pendingMarkers,
           bridgeName: _bridgeName,
         ),
         baseUrl: 'https://gbyouth.co.kr',
@@ -95,28 +108,6 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         ],
       ),
     );
-  }
-
-  void _reloadMap() {
-    final center = _centerForRegion(ref.read(regionProvider));
-    final markers = _policyMarkers(center, ref.read(policyListNotifierProvider));
-
-    setState(() {
-      _isLoading = true;
-      _mapReady = false;
-    });
-
-    Future.delayed(const Duration(milliseconds: 50), () {
-      _controller.loadHtmlString(
-        _htmlBuilder.build(
-          apiKey: Env.kakaoMapApiKey,
-          center: center,
-          markers: markers,
-          bridgeName: _bridgeName,
-        ),
-        baseUrl: 'https://gbyouth.co.kr',
-      );
-    });
   }
 
   Widget _buildOverlay(AsyncValue<List<Policy>> policies) {
@@ -161,6 +152,49 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         lng: offset.lng,
       );
     });
+  }
+
+  void _pushMarkerUpdate() {
+    _pendingMarkers =
+        _policyMarkers(_lastCenter, _lastPolicies ?? const AsyncLoading());
+    if (_mapReady) {
+      _applyMarkers();
+    } else {
+      setState(() {
+        _isLoading = true;
+      });
+    }
+  }
+
+  Future<void> _applyMarkers() async {
+    if (!_mapReady) return;
+    final encodedMarkers = jsonEncode(
+      _pendingMarkers
+          .map(
+            (m) => {
+              'id': m.id,
+              'title': m.title,
+              'lat': m.lat,
+              'lng': m.lng,
+            },
+          )
+          .toList(),
+    );
+
+    final script = '''
+      try {
+        if (typeof moveTo === 'function') { moveTo(${_lastCenter.lat}, ${_lastCenter.lng}); }
+        if (typeof updateMarkers === 'function') { updateMarkers($encodedMarkers); }
+      } catch (e) { console.warn('applyMarkers failed', e); }
+    ''';
+
+    await _controller.runJavaScript(script);
+
+    if (mounted) {
+      setState(() {
+        _isLoading = false;
+      });
+    }
   }
 
   List<KakaoMapLatLng> _markerOffsets(KakaoMapLatLng base) {
@@ -208,6 +242,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         _mapReady = true;
         _isLoading = false;
       });
+      _applyMarkers();
       return;
     }
     if (content.startsWith('marker:')) {


### PR DESCRIPTION
## Summary
- keep the policy list provider alive to avoid repeated refetches across screens
- prevent Kakao map reloads by updating markers in-place and tracking the last region/center
- add JavaScript hooks for clearing/updating markers so map ready/indicator state stays stable

## Testing
- Not run (environment missing Dart/Flutter tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926f1fc6b34832497f975f9b22d99d6)