### PR TITLE
Add debug logging for Kakao map WebView

### DIFF
--- a/lib/ui/screens/map/kakao_map_html_builder.dart
+++ b/lib/ui/screens/map/kakao_map_html_builder.dart
@@ -54,7 +54,7 @@ class KakaoMapHtmlBuilder {
           """
         : "function notifyFlutter(message) {}";
 
-    return '''
+  return '''
 <!DOCTYPE html>
 <html>
 <head>
@@ -68,6 +68,9 @@ class KakaoMapHtmlBuilder {
 <body>
   <div id="map"></div>
   <script>
+    console.log("HTML LOADED");
+    console.log("API KEY =", "$apiKey");
+
     var map;
     var markers = [];
     var markerData = [$markerJson];
@@ -114,6 +117,7 @@ class KakaoMapHtmlBuilder {
     }
 
     function initMap() {
+      console.log("initMap START");
       var container = document.getElementById('map');
       var options = {
         center: new kakao.maps.LatLng(${center.lat}, ${center.lng}),

--- a/lib/ui/screens/map/kakao_map_screen.dart
+++ b/lib/ui/screens/map/kakao_map_screen.dart
@@ -61,6 +61,9 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     _controller = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..addJavaScriptChannel(_bridgeName, onMessageReceived: _onMapMessage)
+      ..setOnConsoleMessage((JavaScriptConsoleMessage message) {
+        debugPrint('[WEBVIEW][${message.level}] ${message.message}');
+      })
       ..setNavigationDelegate(
         NavigationDelegate(
           onPageStarted: (_) => setState(() {


### PR DESCRIPTION
## Summary
- add WebView console message handler to surface JavaScript console output in Flutter logs
- add JavaScript console logging to Kakao map HTML to trace initialization and API key usage

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926f8b9752c83248d7919f156da812c)