### PR TITLE
Fix namespace for flutter_unity_widget module

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,4 +34,14 @@ subprojects { subproject ->
             }
         }
     }
+
+    // 🔵 flutter_unity_widget는 AGP 8.x 이상에서 namespace를 요구함
+    if (subproject.name == "flutter_unity_widget") {
+        subproject.plugins.withId("com.android.library") {
+            def androidExt = subproject.extensions.findByName("android")
+            if (androidExt?.hasProperty("namespace") && !androidExt.namespace) {
+                androidExt.namespace = "com.xraph.plugin.flutter_unity_widget"
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- configure the flutter_unity_widget Android library module with the proper namespace when using AGP 8+
- keep existing app APK output customization unchanged

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927ccfdee508324a97d974c070be8de)