### PR TITLE
Fix policy repository import and generator deps

### DIFF
--- a/lib/features/policy/providers/policy_prefetch_provider.dart
+++ b/lib/features/policy/providers/policy_prefetch_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../application/di.dart';
+import '../../../data/repositories/policy_repository_hybrid.dart';
 import '../../policy/providers/policy_list_provider.dart';
 
 final policyPrefetchProvider =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,8 +38,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  build_runner: ^2.4.13
-  isar_generator: ^3.1.0+1
+  build_runner: ^2.4.9
+  isar_generator: ^3.1.0
   freezed: ^2.5.7
   retrofit_generator: ^8.2.1
   json_serializable: ^6.9.0


### PR DESCRIPTION
## Summary
- add explicit import for HybridPolicyRepository in policy prefetch provider
- adjust generator dev dependency versions for policy isar model generation

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bcfe7af948324acdc6142be6daee7)