### PR TITLE
Implement stale-while-revalidate policy loading via worker proxy

### DIFF
--- a/lib/application/controllers/unity_map_controller.dart
+++ b/lib/application/controllers/unity_map_controller.dart
@@ -100,9 +100,8 @@ class UnityMapController {
   }
 
   void _sendCurrentPolicies() {
-    final asyncPolicies = _ref.read(policyListNotifierProvider);
-    final policies = asyncPolicies.valueOrNull;
-    if (policies == null || policies.isEmpty) return;
+    final policies = _ref.read(policyListNotifierProvider).policies;
+    if (policies.isEmpty) return;
 
     _sendMarkers(policies);
   }
@@ -130,8 +129,7 @@ class UnityMapController {
   }
 
   void _handleMarkerTap(String policyId) {
-    final policies =
-        _ref.read(policyListNotifierProvider).valueOrNull ?? const <Policy>[];
+    final policies = _ref.read(policyListNotifierProvider).policies;
 
     Policy? tapped;
     for (final policy in policies) {

--- a/lib/application/di.dart
+++ b/lib/application/di.dart
@@ -7,10 +7,11 @@ import 'package:youth_road_app/data/local/isar/isar_service.dart';
 
 // Core & Sources
 import '../core/constants/env.dart';
-import '../data/sources/remote/policy_remote_source.dart';
+import '../data/policy/policy_cache_source.dart';
+import '../data/policy/policy_remote_source.dart';
+import '../data/policy/policy_repository.dart';
 
 // Repositories
-import '../data/repositories/hybrid_policy_repository.dart';
 import '../data/repositories/chat_repository.dart';
 import '../data/repositories/institution_repository.dart';
 
@@ -43,24 +44,35 @@ final isarServiceProvider = Provider<IsarService>((ref) {
 });
 
 /// Remote Source Provider
-final remotePolicySourceProvider = Provider<PolicyRemoteSource>((ref) {
+final policyRemoteSourceProvider = Provider<PolicyRemoteSource>((ref) {
   final dio = ref.watch(dioProvider);
-  return PolicyRemoteSource(dio, apiKey: Env.youthApiKey);
+  return PolicyRemoteSource(
+    dio,
+    apiKey: Env.youthApiKey,
+    baseUrl: Env.policyApiBaseUrl,
+  );
 });
 
-/// Hybrid Policy Repository (Cache + API)
-final policyRepositoryProvider = Provider<PolicyRepository>((ref) {
-  final remote = ref.watch(remotePolicySourceProvider);
+final policyCacheSourceProvider = Provider<PolicyCacheSource>((ref) {
   final isar = ref.watch(isarServiceProvider);
-  return HybridPolicyRepository(remote, isar);
+  return PolicyCacheSource(isar);
 });
 
-/// Guarantee Hybrid type for internal use
-final hybridPolicyRepositoryProvider = Provider<HybridPolicyRepository>((ref) {
-  final repo = ref.watch(policyRepositoryProvider);
-  if (repo is HybridPolicyRepository) return repo;
+/// Stale-while-revalidate Policy Repository (Cache + API)
+final policyRepositoryProvider = Provider<SwrPolicyRepository>((ref) {
+  final remote = ref.watch(policyRemoteSourceProvider);
+  final cache = ref.watch(policyCacheSourceProvider);
+  return SwrPolicyRepository(remote, cache);
+});
 
-  throw StateError('policyRepositoryProvider is not HybridPolicyRepository');
+/// For components expecting the abstract interface
+final policyRepositoryInterfaceProvider = Provider<PolicyRepository>((ref) {
+  return ref.watch(policyRepositoryProvider);
+});
+
+/// Backward-compatible provider name for cache-aware operations
+final hybridPolicyRepositoryProvider = Provider<SwrPolicyRepository>((ref) {
+  return ref.watch(policyRepositoryProvider);
 });
 
 /// Chat repo

--- a/lib/application/policy/policy_list_notifier.dart
+++ b/lib/application/policy/policy_list_notifier.dart
@@ -1,0 +1,155 @@
+// FILE: lib/application/policy/policy_list_notifier.dart
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/models/policy_filter.dart';
+import '../../data/policy/policy_repository.dart';
+import '../../data/sources/local/search_history_source.dart';
+import '../../domain/entities/policy.dart';
+import '../di.dart';
+import '../notifiers/region_notifier.dart';
+
+class PolicyListState {
+  const PolicyListState({
+    this.policies = const [],
+    this.isLoading = false,
+    this.isRefreshing = false,
+    this.error,
+    this.isStale = false,
+  });
+
+  final List<Policy> policies;
+  final bool isLoading;
+  final bool isRefreshing;
+  final Object? error;
+  final bool isStale;
+
+  PolicyListState copyWith({
+    List<Policy>? policies,
+    bool? isLoading,
+    bool? isRefreshing,
+    Object? error = _noUpdate,
+    bool? isStale,
+  }) {
+    return PolicyListState(
+      policies: policies ?? this.policies,
+      isLoading: isLoading ?? this.isLoading,
+      isRefreshing: isRefreshing ?? this.isRefreshing,
+      error: error == _noUpdate ? this.error : error,
+      isStale: isStale ?? this.isStale,
+    );
+  }
+
+  static const _noUpdate = Object();
+}
+
+final policyListNotifierProvider =
+    NotifierProvider.autoDispose<PolicyListNotifier, PolicyListState>(
+  PolicyListNotifier.new,
+);
+
+class PolicyListNotifier extends AutoDisposeNotifier<PolicyListState> {
+  static const String errorMessage = '정책을 불러오지 못했습니다.';
+
+  String? _lastQuery;
+
+  SwrPolicyRepository get _repo => ref.read(policyRepositoryProvider);
+
+  SearchHistorySource get _historySource => ref.read(searchHistorySourceProvider);
+
+  @override
+  PolicyListState build() {
+    _loadPolicies();
+    return const PolicyListState(isLoading: true);
+  }
+
+  PolicyFilter _buildFilter() {
+    final region = ref.watch(regionProvider);
+    return PolicyFilter(
+      searchRgnSe: region,
+      searchText: _lastQuery,
+      availableOnly: true,
+    );
+  }
+
+  Future<void> _loadPolicies({bool forceRefresh = false}) async {
+    final filter = _buildFilter();
+    state = state.copyWith(isLoading: true, error: null, isStale: true);
+
+    try {
+      final result = await _repo.getPolicies(
+        filter: filter,
+        forceRefresh: forceRefresh,
+      );
+
+      state = state.copyWith(
+        policies: result.policies,
+        isLoading: false,
+        isStale: true,
+        error: null,
+      );
+      debugPrint(
+          '[PolicyListNotifier] initial cache load done. count=${result.policies.length}');
+
+      final remoteFuture = result.remoteRefresh;
+      if (remoteFuture != null) {
+        remoteFuture.then((latest) {
+          state = state.copyWith(
+            policies: latest,
+            isStale: false,
+            error: null,
+          );
+          debugPrint(
+              '[PolicyListNotifier] remote refresh success. count=${latest.length}');
+        }).catchError((error, stack) {
+          debugPrint('[PolicyListNotifier] remote refresh failed: error=$error');
+          debugPrint('$stack');
+          state = state.copyWith(error: error, isStale: true);
+        });
+      }
+    } catch (e, st) {
+      debugPrint('[PolicyListNotifier] remote refresh failed: error=$e');
+      debugPrint('$st');
+      state = state.copyWith(
+        isLoading: false,
+        error: e,
+        isStale: state.policies.isNotEmpty,
+      );
+    }
+  }
+
+  Future<void> refresh() async {
+    state = state.copyWith(isRefreshing: true, error: null);
+    try {
+      final policies = await _repo.refreshPolicies(
+        filter: _buildFilter(),
+      );
+      state = state.copyWith(
+        policies: policies,
+        isRefreshing: false,
+        isStale: false,
+        error: null,
+      );
+      debugPrint(
+          '[PolicyListNotifier] remote refresh success. count=${policies.length}');
+    } catch (e, st) {
+      debugPrint('[PolicyListNotifier] remote refresh failed: error=$e');
+      debugPrint('$st');
+      state = state.copyWith(
+        isRefreshing: false,
+        error: e,
+        isStale: state.policies.isNotEmpty,
+      );
+    }
+  }
+
+  Future<void> search(String query) async {
+    final normalized = query.trim();
+    _lastQuery = normalized.isEmpty ? null : normalized;
+    if (_lastQuery != null) {
+      await _historySource.saveQuery(_lastQuery!);
+    }
+    ref.invalidate(searchHistoryListProvider);
+    await refresh();
+  }
+}

--- a/lib/application/providers.dart
+++ b/lib/application/providers.dart
@@ -7,19 +7,16 @@ import 'notifiers/chat_notifier.dart';
 import 'notifiers/compare_notifier.dart';
 import 'notifiers/favorites_notifier.dart';
 import 'notifiers/policy_detail_notifier.dart';
-import 'notifiers/policy_list_notifier.dart';
+import 'policy/policy_list_notifier.dart';
 import 'notifiers/policy_paging_notifier.dart';
 
 export 'di.dart';
 export 'repository_providers.dart';
 export 'notifiers/region_notifier.dart' show regionProvider, RegionNotifier;
+export 'policy/policy_list_notifier.dart'
+    show policyListNotifierProvider, PolicyListNotifier, PolicyListState;
 export '../features/policy/providers/policy_prefetch_provider.dart'
     show policyPrefetchProvider, PolicyPrefetchNotifier;
-
-final policyListNotifierProvider =
-    AsyncNotifierProvider<PolicyListNotifier, List<Policy>>(
-  PolicyListNotifier.new,
-);
 
 final policyPagingProvider =
     NotifierProvider.autoDispose<PolicyPagingNotifier, PolicyPagingState>(

--- a/lib/core/constants/env.dart
+++ b/lib/core/constants/env.dart
@@ -15,4 +15,9 @@ class Env {
     'YOUTH_API_KEY',
     defaultValue: '',
   );
+
+  static const policyApiBaseUrl = String.fromEnvironment(
+    'POLICY_API_BASE_URL',
+    defaultValue: 'https://worker.youthroad-policy.workers.dev',
+  );
 }

--- a/lib/data/policy/policy_cache_source.dart
+++ b/lib/data/policy/policy_cache_source.dart
@@ -1,0 +1,45 @@
+// FILE: lib/data/policy/policy_cache_source.dart
+import 'package:flutter/foundation.dart';
+
+import '../../domain/entities/policy.dart';
+import '../local/isar/isar_service.dart';
+import '../local/isar/policy_isar_model.dart';
+import '../models/policy_filter.dart';
+
+class PolicyCacheSource {
+  PolicyCacheSource(this._isarService);
+
+  final IsarService _isarService;
+
+  Future<List<Policy>> loadCachedPolicies({
+    PolicyFilter filter = const PolicyFilter(),
+  }) async {
+    debugPrint('[PolicyCacheSource] loadCachedPolicies called');
+    final cached = await _isarService.getPolicies(filter: filter);
+    final policies = cached.map((model) => model.toDomain()).toList();
+    debugPrint('[PolicyCacheSource] loaded ${policies.length} policies from cache');
+    return policies;
+  }
+
+  Future<List<Policy>> loadAllPolicies() async {
+    final cached = await _isarService.getAllPolicies();
+    return cached.map((model) => model.toDomain()).toList();
+  }
+
+  Future<Policy?> getPolicyById(String id) async {
+    final cached = await _isarService.getPolicyById(id);
+    return cached?.toDomain();
+  }
+
+  Future<void> savePolicies(
+    List<Policy> policies, {
+    bool replaceExisting = false,
+  }) async {
+    if (policies.isEmpty) return;
+    final isarModels = policies.map(PolicyIsarModel.fromDomain).toList();
+    if (replaceExisting) {
+      await _isarService.clearPolicies();
+    }
+    await _isarService.putAllPolicies(isarModels);
+  }
+}

--- a/lib/data/policy/policy_remote_source.dart
+++ b/lib/data/policy/policy_remote_source.dart
@@ -1,0 +1,154 @@
+// FILE: lib/data/policy/policy_remote_source.dart
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../core/constants/env.dart';
+import '../models/policy_filter.dart';
+import '../models/policy_model.dart';
+
+const String kPolicyApiBaseUrl = String.fromEnvironment(
+  'POLICY_API_BASE_URL',
+  defaultValue: 'https://worker.youthroad-policy.workers.dev',
+);
+
+class PolicyRemoteSource {
+  PolicyRemoteSource(
+    this._dio, {
+    String? apiKey,
+    String? baseUrl,
+  })  : _apiKey = apiKey ?? Env.youthApiKey,
+        _baseUrl =
+            baseUrl ?? (Env.policyApiBaseUrl.isNotEmpty ? Env.policyApiBaseUrl : kPolicyApiBaseUrl);
+
+  final Dio _dio;
+  final String _apiKey;
+  final String _baseUrl;
+
+  Future<List<PolicyModel>> fetchPolicies({
+    PolicyFilter filter = const PolicyFilter(),
+  }) async {
+    final query = _buildQuery(filter);
+    if (kDebugMode) {
+      debugPrint(
+        '[PolicyRemoteSource] fetchPolicies -> URL=$_baseUrl/policy/list query=$query',
+      );
+    }
+
+    final response = await _dio.get<String>(
+      '$_baseUrl/policy/list',
+      queryParameters: query,
+      options: Options(responseType: ResponseType.plain),
+    );
+
+    final rawJson = response.data;
+    if (rawJson == null) {
+      throw StateError('Empty response from policy endpoint');
+    }
+
+    return compute(parsePoliciesJson, rawJson);
+  }
+
+  Future<PolicyModel> fetchPolicyById(String id) async {
+    final list = await fetchPolicies(
+      filter: const PolicyFilter(
+        pagingYn: 'N',
+        searchDsplyYn: 'all',
+        recordCount: 2000,
+      ),
+    );
+
+    final match = list.firstWhere(
+      (policy) => policy.id == id,
+      orElse: () => throw StateError('Policy not found for id: $id'),
+    );
+
+    return match;
+  }
+
+  Future<List<PolicyModel>> fetchSimilar(String id) async {
+    final base = await fetchPolicyById(id);
+    final filter = PolicyFilter(
+      searchRgnSe: base.regionName,
+      searchPolicyType: base.typeName,
+      pageIndex: 1,
+      recordCount: 10,
+    );
+    final list = await fetchPolicies(filter: filter);
+    return list.where((item) => item.id != id).toList();
+  }
+
+  Map<String, dynamic> _buildQuery(PolicyFilter filter) {
+    final query = <String, dynamic>{
+      'pageIndex': filter.pageIndex ?? 1,
+      'recordCount': filter.recordCount ?? 2000,
+      'pageSize': filter.pageSize,
+      'pagingYn': filter.pagingYn ?? 'N',
+      'searchDsplyYn': filter.searchDsplyYn ?? 'all',
+    };
+
+    if (_apiKey.isNotEmpty) {
+      query['apiKey'] = _apiKey;
+    }
+
+    void put(String key, dynamic value) {
+      if (value != null && value.toString().isNotEmpty) {
+        query[key] = value;
+      }
+    }
+
+    put('searchYear', filter.searchYear);
+
+    if (filter.searchRgnSe != null &&
+        filter.searchRgnSe!.isNotEmpty &&
+        filter.searchRgnSe != '전체' &&
+        filter.searchRgnSe != '경북 전체') {
+      put('searchRgnSe', filter.searchRgnSe);
+    }
+
+    if (filter.availableOnly == true) {
+      put('aplyPsbltyYn', 'Y');
+    }
+
+    if (filter.category != null && filter.category != '전체') {
+      put('searchPolicyType', filter.category);
+    }
+
+    put('searchPolicyNm', filter.searchText ?? filter.searchPolicyNm);
+    put('instNo', filter.instNo);
+    put('deptNo', filter.deptNo);
+    if (filter.startDate != null) {
+      put('policyBgngYmd', _formatDate(filter.startDate!));
+    }
+    if (filter.endDate != null) {
+      put('policyEndYmd', _formatDate(filter.endDate!));
+    }
+
+    return query;
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.year.toString().padLeft(4, '0')}'
+        '${date.month.toString().padLeft(2, '0')}'
+        '${date.day.toString().padLeft(2, '0')}';
+  }
+}
+
+List<PolicyModel> parsePoliciesJson(String rawJson) {
+  final decoded = json.decode(rawJson);
+  if (decoded is! Map<String, dynamic>) {
+    throw StateError('Invalid policy list response');
+  }
+
+  final resultList = decoded['resultList'];
+  if (resultList is! List) {
+    throw StateError('Missing resultList in response');
+  }
+
+  return resultList
+      .map(
+        (item) => PolicyModel.fromJson((item as Map).cast<String, dynamic>()),
+      )
+      .toList();
+}

--- a/lib/data/policy/policy_repository.dart
+++ b/lib/data/policy/policy_repository.dart
@@ -1,0 +1,173 @@
+// FILE: lib/data/policy/policy_repository.dart
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../../domain/entities/policy.dart';
+import '../../domain/repositories/policy_repository.dart';
+import '../models/policy_filter.dart';
+import 'policy_cache_source.dart';
+import 'policy_remote_source.dart';
+
+class PolicyFetchResult {
+  const PolicyFetchResult({
+    required this.policies,
+    this.remoteRefresh,
+  });
+
+  final List<Policy> policies;
+  final Future<List<Policy>>? remoteRefresh;
+}
+
+class SwrPolicyRepository implements PolicyRepository {
+  SwrPolicyRepository(this._remoteSource, this._cacheSource);
+
+  final PolicyRemoteSource _remoteSource;
+  final PolicyCacheSource _cacheSource;
+
+  Future<PolicyFetchResult> getPolicies({
+    PolicyFilter filter = const PolicyFilter(),
+    bool forceRefresh = false,
+  }) async {
+    final cached = await _safeLoadCache(filter);
+    debugPrint('[PolicyRepository] returning cached policies count=${cached.length}');
+
+    debugPrint('[PolicyRepository] refreshing policies from remote...');
+    final remoteFuture = _refreshFromRemote(
+      filter: filter,
+      replaceExisting: forceRefresh || _isDefaultFilter(filter),
+    );
+
+    return PolicyFetchResult(
+      policies: cached,
+      remoteRefresh: remoteFuture,
+    );
+  }
+
+  Future<List<Policy>> loadCachedPolicies({
+    PolicyFilter filter = const PolicyFilter(),
+  }) {
+    return _cacheSource.loadCachedPolicies(filter: filter);
+  }
+
+  Future<List<Policy>> refreshPolicies({
+    PolicyFilter filter = const PolicyFilter(),
+    bool replaceExisting = false,
+  }) {
+    debugPrint('[PolicyRepository] refreshing policies from remote...');
+    return _refreshFromRemote(
+      filter: filter,
+      replaceExisting: replaceExisting || _isDefaultFilter(filter),
+    );
+  }
+
+  Future<List<Policy>> _safeLoadCache(PolicyFilter filter) async {
+    try {
+      return await _cacheSource.loadCachedPolicies(filter: filter);
+    } catch (e, st) {
+      debugPrint('[PolicyRepository] cache load failed: $e\n$st');
+      return const [];
+    }
+  }
+
+  Future<List<Policy>> _refreshFromRemote({
+    required PolicyFilter filter,
+    bool replaceExisting = false,
+  }) async {
+    final remoteModels = await _remoteSource.fetchPolicies(filter: filter);
+    final policies = remoteModels.map((model) => model.toEntity()).toList();
+    await _cacheSource.savePolicies(policies, replaceExisting: replaceExisting);
+    return policies;
+  }
+
+  bool _isDefaultFilter(PolicyFilter filter) {
+    return filter.searchRgnSe == null &&
+        filter.searchPolicyType == null &&
+        filter.searchPolicyNm == null &&
+        filter.searchText == null &&
+        filter.category == null &&
+        filter.searchYear == null &&
+        filter.instNo == null &&
+        filter.deptNo == null &&
+        filter.startDate == null &&
+        filter.endDate == null &&
+        filter.availableOnly == null &&
+        (filter.pageIndex == null || filter.pageIndex == 1) &&
+        (filter.recordCount == null || filter.recordCount == 2000) &&
+        (filter.pagingYn == null || filter.pagingYn == 'N') &&
+        (filter.searchDsplyYn == null || filter.searchDsplyYn == 'all');
+  }
+
+  @override
+  Future<List<Policy>> fetchPolicies({
+    PolicyFilter filter = const PolicyFilter(),
+  }) async {
+    return _refreshFromRemote(
+      filter: filter,
+      replaceExisting: _isDefaultFilter(filter),
+    );
+  }
+
+  @override
+  Future<Policy> fetchPolicyById(String id) async {
+    final cached = await _cacheSource.getPolicyById(id);
+    if (cached != null) {
+      return cached;
+    }
+
+    final list = await _remoteSource.fetchPolicies(
+      filter: const PolicyFilter(
+        pagingYn: 'N',
+        searchDsplyYn: 'all',
+        recordCount: 2000,
+      ),
+    );
+
+    final match = list.firstWhere(
+      (policy) => policy.id == id,
+      orElse: () => throw StateError('Policy not found for id: $id'),
+    );
+
+    await _cacheSource.savePolicies([
+      match.toEntity(),
+    ]);
+    return match.toEntity();
+  }
+
+  @override
+  Future<List<Policy>> fetchSimilarPolicies(String id) async {
+    try {
+      final cached = await _cacheSource.loadAllPolicies();
+      if (cached.isNotEmpty) {
+        final base = cached.firstWhere(
+          (item) => item.id == id,
+          orElse: () => const Policy(id: '', policyNm: ''),
+        );
+
+        if (base.id.isNotEmpty) {
+          final similar = cached
+              .where(
+                (item) =>
+                    item.id != id &&
+                    ((base.policyTypeNm != null &&
+                            item.policyTypeNm == base.policyTypeNm) ||
+                        (base.rgnSeNm != null && item.rgnSeNm == base.rgnSeNm)),
+              )
+              .take(10)
+              .toList();
+
+          if (similar.isNotEmpty) {
+            return similar;
+          }
+        }
+      }
+    } catch (e, st) {
+      debugPrint('[PolicyRepository] similar cache failed: $e\n$st');
+    }
+
+    final models = await _remoteSource.fetchSimilar(id);
+    final policies = models.map((model) => model.toEntity()).toList();
+    await _cacheSource.savePolicies(policies);
+    return policies;
+  }
+}

--- a/lib/features/policy/providers/policy_prefetch_provider.dart
+++ b/lib/features/policy/providers/policy_prefetch_provider.dart
@@ -5,7 +5,7 @@ import '../../../application/di.dart';
 import '../../../application/notifiers/policy_paging_notifier.dart'; // ← ★ 반드시 필요!!
 import '../../../application/providers.dart';
 
-import '../../../data/repositories/hybrid_policy_repository.dart';
+import '../../../data/policy/policy_repository.dart';
 
 final policyPrefetchProvider =
     AsyncNotifierProvider<PolicyPrefetchNotifier, void>(
@@ -13,7 +13,7 @@ final policyPrefetchProvider =
 );
 
 class PolicyPrefetchNotifier extends AsyncNotifier<void> {
-  HybridPolicyRepository get _repository =>
+  SwrPolicyRepository get _repository =>
       ref.read(hybridPolicyRepositoryProvider);
 
   PolicyPagingNotifier get _pagingNotifier =>

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../../application/notifiers/policy_list_notifier.dart';
 import '../../../application/providers.dart';
+import '../../../application/policy/policy_list_notifier.dart';
 import '../../../navigation/route_paths.dart';
 import '../../widgets/app_appbar.dart';
 import '../../widgets/global_error_view.dart';
@@ -14,40 +14,55 @@ class HomeScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final policies = ref.watch(policyListNotifierProvider);
+    final state = ref.watch(policyListNotifierProvider);
+    final notifier = ref.read(policyListNotifierProvider.notifier);
     final region = ref.watch(regionProvider) ?? '지역을 선택해주세요';
 
-    return Scaffold(
-      appBar: const AppAppBar(title: '청년 정책 추천'),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          _RegionBanner(region: region),
-          const SizedBox(height: 12),
-          _QuickActions(),
-          const SizedBox(height: 16),
-          Text('추천 정책', style: Theme.of(context).textTheme.titleLarge),
-          const SizedBox(height: 8),
-          policies.when(
-            data: (list) => ListView.separated(
+    final policies = state.policies;
+
+    Widget body;
+    if (state.isLoading && policies.isEmpty) {
+      body = const Center(child: CircularProgressIndicator());
+    } else if (state.error != null && policies.isEmpty) {
+      body = GlobalErrorView(
+        message: PolicyListNotifier.errorMessage,
+        onRetry: notifier.refresh,
+      );
+    } else {
+      body = RefreshIndicator(
+        onRefresh: notifier.refresh,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            _RegionBanner(region: region),
+            const SizedBox(height: 12),
+            _QuickActions(),
+            const SizedBox(height: 16),
+            Text('추천 정책', style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: 8),
+            if (state.isStale)
+              const Padding(
+                padding: EdgeInsets.only(bottom: 8),
+                child: Text('캐시된 데이터 표시 중... 최신 정보를 불러오는 중입니다.'),
+              ),
+            ListView.separated(
               physics: const NeverScrollableScrollPhysics(),
               shrinkWrap: true,
               itemBuilder: (_, i) => PolicyCardV2(
-                policy: list[i],
-                onTap: () =>
-                    context.push(RoutePaths.policyDetail(list[i].id)),
+                policy: policies[i],
+                onTap: () => context.push(RoutePaths.policyDetail(policies[i].id)),
               ),
               separatorBuilder: (_, __) => const SizedBox(height: 12),
-              itemCount: list.length,
+              itemCount: policies.length,
             ),
-            loading: () => const Center(child: CircularProgressIndicator()),
-            error: (e, st) => GlobalErrorView(
-              message: PolicyListNotifier.errorMessage,
-              onRetry: () => ref.invalidate(policyListNotifierProvider),
-            ),
-          ),
-        ],
-      ),
+          ],
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: const AppAppBar(title: '청년 정책 추천'),
+      body: body,
     );
   }
 }

--- a/lib/ui/screens/map/kakao_map_screen.dart
+++ b/lib/ui/screens/map/kakao_map_screen.dart
@@ -30,9 +30,9 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   List<KakaoMapPolicyMarker> _pendingMarkers = const [];
 
   static const _defaultCenter = KakaoMapLatLng(36.4919, 128.8889); // Gyeongbuk
-  AsyncValue<List<Policy>>? _lastPolicies;
+  PolicyListState? _lastPolicies;
   ProviderSubscription<String?>? _regionSubscription;
-  ProviderSubscription<AsyncValue<List<Policy>>>? _policySubscription;
+  ProviderSubscription<PolicyListState>? _policySubscription;
 
   @override
   void initState() {
@@ -42,7 +42,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     _lastCenter = _centerForRegion(_lastRegion);
     _lastPolicies = ref.read(policyListNotifierProvider);
     _pendingMarkers =
-        _policyMarkers(_lastCenter, _lastPolicies ?? const AsyncLoading());
+        _policyMarkers(_lastCenter, _lastPolicies ?? const PolicyListState());
     _regionSubscription =
         ref.listenManual<String?>(regionProvider, (prev, next) {
       if (next == _lastRegion) return;
@@ -50,10 +50,10 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
       _lastCenter = _centerForRegion(_lastRegion);
       _pushMarkerUpdate();
     });
-    _policySubscription = ref.listenManual<AsyncValue<List<Policy>>>(
+    _policySubscription = ref.listenManual<PolicyListState>(
       policyListNotifierProvider,
       (prev, next) {
-        if (next.hasValue && next.valueOrNull != prev?.valueOrNull) {
+        if (next.policies != prev?.policies) {
           _lastPolicies = next;
           _pushMarkerUpdate();
         }
@@ -122,11 +122,13 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     );
   }
 
-  Widget _buildOverlay(AsyncValue<List<Policy>> policies) {
-    return policies.when(
-      data: (_) => const SizedBox.shrink(),
-      loading: () => const Center(child: CircularProgressIndicator()),
-      error: (e, __) => Center(
+  Widget _buildOverlay(PolicyListState state) {
+    if (state.isLoading && state.policies.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (state.error != null && state.policies.isEmpty) {
+      return Center(
         child: Container(
           padding: const EdgeInsets.all(12),
           margin: const EdgeInsets.symmetric(horizontal: 24),
@@ -140,16 +142,18 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
             textAlign: TextAlign.center,
           ),
         ),
-      ),
-    );
+      );
+    }
+
+    return const SizedBox.shrink();
   }
 
   List<KakaoMapPolicyMarker> _policyMarkers(
     KakaoMapLatLng center,
-    AsyncValue<List<Policy>> asyncPolicies,
+    PolicyListState asyncPolicies,
   ) {
-    final policies = asyncPolicies.valueOrNull ?? _lastPolicies?.valueOrNull;
-    if (policies == null || policies.isEmpty) return const [];
+    final policies = asyncPolicies.policies;
+    if (policies.isEmpty) return const [];
 
     final markerOffsets = _markerOffsets(center);
     final limitedPolicies = policies.take(markerOffsets.length).toList();
@@ -168,7 +172,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
 
   void _pushMarkerUpdate() {
     _pendingMarkers =
-        _policyMarkers(_lastCenter, _lastPolicies ?? const AsyncLoading());
+        _policyMarkers(_lastCenter, _lastPolicies ?? const PolicyListState());
     if (_mapReady) {
       _applyMarkers();
     } else {

--- a/lib/ui/screens/map/map_with_list_screen.dart
+++ b/lib/ui/screens/map/map_with_list_screen.dart
@@ -5,8 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
-import '../../../application/notifiers/policy_list_notifier.dart';
 import '../../../application/providers.dart';
+import '../../../application/policy/policy_list_notifier.dart';
 import '../../../core/constants/env.dart';
 import '../../../domain/entities/policy.dart';
 import '../../../navigation/route_paths.dart';
@@ -31,7 +31,7 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
   late final ScrollController _listController;
   late final WebViewController _mapController;
   ProviderSubscription<String?>? _regionSubscription;
-  ProviderSubscription<AsyncValue<List<Policy>>>? _policySubscription;
+  ProviderSubscription<PolicyListState>? _policySubscription;
   bool _isLoading = true;
   bool _mapReady = false;
   bool _isMapUpdating = false;
@@ -58,7 +58,8 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final policies = ref.watch(policyListNotifierProvider);
+    final state = ref.watch(policyListNotifierProvider);
+    final policies = state.policies;
     return Scaffold(
       appBar: const AppAppBar(title: '지도 + 리스트'),
       body: SafeArea(
@@ -77,35 +78,35 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
                     left: 0,
                     right: 0,
                     bottom: 12,
-                    child: _buildOverlay(policies),
+                    child: _buildOverlay(state),
                   ),
                 ],
               ),
             ),
             Expanded(
-              child: policies.when(
-                data: (data) => ListView.separated(
-                  controller: _listController,
-                  padding: const EdgeInsets.all(16),
-                  itemBuilder: (_, i) {
-                    final policy = data[i];
-                    return PolicyCardV2(
-                      policy: policy,
-                      onTap: () => _onPolicyTap(policy),
-                    );
-                  },
-                  separatorBuilder: (_, __) => const SizedBox(height: 12),
-                  itemCount: data.length,
-                ),
-                loading: () => const Center(child: CircularProgressIndicator()),
-                error: (e, st) => GlobalErrorView(
-                  message: PolicyListNotifier.errorMessage,
-                  onRetry: () {
-                    ref.invalidate(policyListNotifierProvider);
-                    ref.read(policyListNotifierProvider);
-                  },
-                ),
-              ),
+              child: state.isLoading && policies.isEmpty
+                  ? const Center(child: CircularProgressIndicator())
+                  : state.error != null && policies.isEmpty
+                      ? GlobalErrorView(
+                          message: PolicyListNotifier.errorMessage,
+                          onRetry: () {
+                            ref.invalidate(policyListNotifierProvider);
+                            ref.read(policyListNotifierProvider);
+                          },
+                        )
+                      : ListView.separated(
+                          controller: _listController,
+                          padding: const EdgeInsets.all(16),
+                          itemBuilder: (_, i) {
+                            final policy = policies[i];
+                            return PolicyCardV2(
+                              policy: policy,
+                              onTap: () => _onPolicyTap(policy),
+                            );
+                          },
+                          separatorBuilder: (_, __) => const SizedBox(height: 12),
+                          itemCount: policies.length,
+                        ),
             ),
           ],
         ),
@@ -136,10 +137,10 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
   void _setupListeners() {
     _regionSubscription =
         ref.listenManual<String?>(regionProvider, (_, __) => _reloadMap());
-    _policySubscription = ref.listenManual<AsyncValue<List<Policy>>>(
+    _policySubscription = ref.listenManual<PolicyListState>(
       policyListNotifierProvider,
       (prev, next) {
-        if (next.hasValue && next.valueOrNull != prev?.valueOrNull) {
+        if (next.policies != prev?.policies) {
           _reloadMap();
         }
       },
@@ -166,11 +167,13 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
     );
   }
 
-  Widget _buildOverlay(AsyncValue<List<Policy>> policies) {
-    return policies.when(
-      data: (_) => const SizedBox.shrink(),
-      loading: () => const Center(child: CircularProgressIndicator()),
-      error: (e, __) => Container(
+  Widget _buildOverlay(PolicyListState state) {
+    if (state.isLoading && state.policies.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (state.error != null && state.policies.isEmpty) {
+      return Container(
         margin: const EdgeInsets.symmetric(horizontal: 16),
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
@@ -182,8 +185,10 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
           style: TextStyle(color: Colors.white),
           textAlign: TextAlign.center,
         ),
-      ),
-    );
+      );
+    }
+
+    return const SizedBox.shrink();
   }
 
   void _onPolicyTap(Policy policy) {
@@ -204,8 +209,8 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
     if (_isMapUpdating || !_mapReady) return;
     if (!_listController.hasClients) return;
 
-    final policies = ref.read(policyListNotifierProvider).valueOrNull;
-    if (policies == null || policies.isEmpty) return;
+    final policies = ref.read(policyListNotifierProvider).policies;
+    if (policies.isEmpty) return;
 
     final index = (_listController.offset / _estimatedItemHeight)
         .floor()
@@ -247,8 +252,8 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
   }
 
   void _highlightPolicy(String policyId) {
-    final policies = ref.read(policyListNotifierProvider).valueOrNull;
-    if (policies == null) return;
+    final policies = ref.read(policyListNotifierProvider).policies;
+    if (policies.isEmpty) return;
     final index = policies.indexWhere((p) => p.id == policyId);
     if (index == -1) return;
 
@@ -301,10 +306,10 @@ class _MapWithListScreenState extends ConsumerState<MapWithListScreen> {
 
   List<KakaoMapPolicyMarker> _policyMarkers(
     KakaoMapLatLng center,
-    AsyncValue<List<Policy>> asyncPolicies,
+    PolicyListState state,
   ) {
-    final policies = asyncPolicies.valueOrNull;
-    if (policies == null || policies.isEmpty) return const [];
+    final policies = state.policies;
+    if (policies.isEmpty) return const [];
 
     final markerOffsets = _markerOffsets(center);
     final limitedPolicies = policies.take(markerOffsets.length).toList();

--- a/lib/ui/screens/policy/policy_list_legacy_screen.dart
+++ b/lib/ui/screens/policy/policy_list_legacy_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../application/notifiers/policy_list_notifier.dart';
 import '../../../application/providers.dart';
+import '../../../application/policy/policy_list_notifier.dart';
 import '../../widgets/global_error_view.dart';
 import '../../widgets/app_appbar.dart';
 import '../../widgets/policy_card.dart';
@@ -12,23 +12,26 @@ class PolicyListLegacyScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final policies = ref.watch(policyListNotifierProvider);
+    final state = ref.watch(policyListNotifierProvider);
     final notifier = ref.read(policyListNotifierProvider.notifier);
     return Scaffold(
       appBar: const AppAppBar(title: '레거시 정책 목록'),
-      body: policies.when(
-        data: (list) => ListView.separated(
-          padding: const EdgeInsets.all(16),
-          itemBuilder: (_, i) => PolicyCard(policy: list[i]),
-          separatorBuilder: (_, __) => const SizedBox(height: 12),
-          itemCount: list.length,
-        ),
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, st) => GlobalErrorView(
-          message: PolicyListNotifier.errorMessage,
-          onRetry: notifier.refreshPolicies,
-        ),
-      ),
+      body: state.isLoading && state.policies.isEmpty
+          ? const Center(child: CircularProgressIndicator())
+          : state.error != null && state.policies.isEmpty
+              ? GlobalErrorView(
+                  message: PolicyListNotifier.errorMessage,
+                  onRetry: notifier.refresh,
+                )
+              : RefreshIndicator(
+                  onRefresh: notifier.refresh,
+                  child: ListView.separated(
+                    padding: const EdgeInsets.all(16),
+                    itemBuilder: (_, i) => PolicyCard(policy: state.policies[i]),
+                    separatorBuilder: (_, __) => const SizedBox(height: 12),
+                    itemCount: state.policies.length,
+                  ),
+                ),
     );
   }
 }

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,0 +1,100 @@
+// FILE: worker/index.js
+const API_BASE = 'https://gbyouth.co.kr';
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * In-memory cache structure: { key: { timestamp: number, body: string } }
+ */
+const memoryCache = new Map();
+
+export default {
+  async fetch(request) {
+    try {
+      const url = new URL(request.url);
+      if (url.pathname === '/policy/list') {
+        return await handlePolicyList(url);
+      }
+
+      return new Response(
+        JSON.stringify({ message: 'Not Found' }),
+        {
+          status: 404,
+          headers: { 'content-type': 'application/json;charset=UTF-8' },
+        },
+      );
+    } catch (error) {
+      return new Response(
+        JSON.stringify({ message: 'Internal Error', error: String(error) }),
+        {
+          status: 500,
+          headers: { 'content-type': 'application/json;charset=UTF-8' },
+        },
+      );
+    }
+  },
+};
+
+async function handlePolicyList(url) {
+  const cacheKey = url.search || 'default';
+  const now = Date.now();
+  const cached = memoryCache.get(cacheKey);
+
+  if (cached && now - cached.timestamp < CACHE_TTL_MS) {
+    return new Response(cached.body, {
+      status: 200,
+      headers: {
+        'content-type': 'application/json;charset=UTF-8',
+        'x-cache': 'HIT',
+      },
+    });
+  }
+
+  const upstreamUrl = new URL('/openapi/policy/list.json', API_BASE);
+  upstreamUrl.search = url.searchParams.toString();
+
+  try {
+    const upstream = await fetch(upstreamUrl.toString(), {
+      method: 'GET',
+      headers: {
+        accept: 'application/json',
+      },
+    });
+
+    if (!upstream.ok) {
+      const message = await upstream.text();
+      return new Response(
+        JSON.stringify({
+          message: 'Upstream request failed',
+          status: upstream.status,
+          body: message,
+        }),
+        {
+          status: 500,
+          headers: { 'content-type': 'application/json;charset=UTF-8' },
+        },
+      );
+    }
+
+    const body = await upstream.text();
+    memoryCache.set(cacheKey, { timestamp: now, body });
+
+    return new Response(body, {
+      status: 200,
+      headers: {
+        'content-type': 'application/json;charset=UTF-8',
+        'x-cache': 'MISS',
+      },
+    });
+  } catch (error) {
+    return new Response(
+      JSON.stringify({
+        message: 'Failed to fetch upstream',
+        error: String(error),
+      }),
+      {
+        status: 502,
+        headers: { 'content-type': 'application/json;charset=UTF-8' },
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add policy remote, cache, and repository layers that request the Cloudflare worker proxy and persist results to Isar for stale-while-revalidate loading
- update the policy list notifier and UI consumers to surface cached data immediately while refreshing in the background
- provide a Cloudflare Worker script that proxies and caches the policy list endpoint

## Testing
- not run (flutter/dart tooling unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c2d2eee2083248c23e5b35c7edac3)