### PR TITLE
Refactor policy list notifier for SWR lifecycle

### DIFF
--- a/lib/application/policy/policy_list_notifier.dart
+++ b/lib/application/policy/policy_list_notifier.dart
@@ -52,19 +52,41 @@ class PolicyListNotifier extends AutoDisposeNotifier<PolicyListState> {
   static const String errorMessage = '정책을 불러오지 못했습니다.';
 
   String? _lastQuery;
+  bool _initialLoadScheduled = false;
 
-  SwrPolicyRepository get _repo => ref.read(policyRepositoryProvider);
+  PolicyRepository get _repo => ref.read(policyRepositoryInterfaceProvider);
 
   SearchHistorySource get _historySource => ref.read(searchHistorySourceProvider);
 
   @override
   PolicyListState build() {
-    _loadPolicies();
+    final region = ref.watch(regionProvider);
+    debugPrint('[PolicyListNotifier] build() with region=$region');
+
+    if (!_initialLoadScheduled) {
+      _initialLoadScheduled = true;
+      Future.microtask(() {
+        debugPrint('[PolicyListNotifier] scheduling initial load');
+        _loadPolicies(region: region);
+      });
+    }
+
+    ref.listen<String>(regionProvider, (previous, next) {
+      if (previous == next) return;
+      debugPrint(
+        '[PolicyListNotifier] region changed: $previous -> $next, reloading policies',
+      );
+      _loadPolicies(region: next, forceRefresh: false);
+    });
+
+    ref.onDispose(() {
+      debugPrint('[PolicyListNotifier] disposed');
+    });
+
     return const PolicyListState(isLoading: true);
   }
 
-  PolicyFilter _buildFilter() {
-    final region = ref.watch(regionProvider);
+  PolicyFilter _buildFilter({required String region}) {
     return PolicyFilter(
       searchRgnSe: region,
       searchText: _lastQuery,
@@ -72,11 +94,31 @@ class PolicyListNotifier extends AutoDisposeNotifier<PolicyListState> {
     );
   }
 
-  Future<void> _loadPolicies({bool forceRefresh = false}) async {
-    final filter = _buildFilter();
-    state = state.copyWith(isLoading: true, error: null, isStale: true);
+  Future<void> _loadPolicies({
+    required String region,
+    bool forceRefresh = false,
+  }) async {
+    if (kDebugMode) {
+      try {
+        // Accessing state to ensure provider is initialized.
+        // ignore: unused_local_variable
+        final _ = state;
+      } catch (e, st) {
+        debugPrint(
+          '[PolicyListNotifier] WARNING: _loadPolicies called before build completion: $e',
+        );
+        debugPrint('$st');
+      }
+    }
+
+    state = state.copyWith(
+      isLoading: true,
+      error: null,
+      isStale: true,
+    );
 
     try {
+      final filter = _buildFilter(region: region);
       final result = await _repo.getPolicies(
         filter: filter,
         forceRefresh: forceRefresh,
@@ -89,7 +131,8 @@ class PolicyListNotifier extends AutoDisposeNotifier<PolicyListState> {
         error: null,
       );
       debugPrint(
-          '[PolicyListNotifier] initial cache load done. count=${result.policies.length}');
+        '[PolicyListNotifier] initial cache load done. count=${result.policies.length}',
+      );
 
       final remoteFuture = result.remoteRefresh;
       if (remoteFuture != null) {
@@ -100,11 +143,15 @@ class PolicyListNotifier extends AutoDisposeNotifier<PolicyListState> {
             error: null,
           );
           debugPrint(
-              '[PolicyListNotifier] remote refresh success. count=${latest.length}');
+            '[PolicyListNotifier] remote refresh success. count=${latest.length}',
+          );
         }).catchError((error, stack) {
           debugPrint('[PolicyListNotifier] remote refresh failed: error=$error');
           debugPrint('$stack');
-          state = state.copyWith(error: error, isStale: true);
+          state = state.copyWith(
+            error: error,
+            isStale: state.policies.isNotEmpty,
+          );
         });
       }
     } catch (e, st) {
@@ -116,13 +163,22 @@ class PolicyListNotifier extends AutoDisposeNotifier<PolicyListState> {
         isStale: state.policies.isNotEmpty,
       );
     }
+
+    _debugLogState('after _loadPolicies');
   }
 
   Future<void> refresh() async {
-    state = state.copyWith(isRefreshing: true, error: null);
+    final region = ref.read(regionProvider);
+    debugPrint('[PolicyListNotifier] refresh() start with region=$region');
+
+    state = state.copyWith(
+      isRefreshing: true,
+      error: null,
+    );
+
     try {
       final policies = await _repo.refreshPolicies(
-        filter: _buildFilter(),
+        filter: _buildFilter(region: region),
       );
       state = state.copyWith(
         policies: policies,
@@ -131,7 +187,8 @@ class PolicyListNotifier extends AutoDisposeNotifier<PolicyListState> {
         error: null,
       );
       debugPrint(
-          '[PolicyListNotifier] remote refresh success. count=${policies.length}');
+        '[PolicyListNotifier] remote refresh success. count=${policies.length}',
+      );
     } catch (e, st) {
       debugPrint('[PolicyListNotifier] remote refresh failed: error=$e');
       debugPrint('$st');
@@ -141,15 +198,32 @@ class PolicyListNotifier extends AutoDisposeNotifier<PolicyListState> {
         isStale: state.policies.isNotEmpty,
       );
     }
+
+    _debugLogState('after refresh');
   }
 
   Future<void> search(String query) async {
     final normalized = query.trim();
     _lastQuery = normalized.isEmpty ? null : normalized;
+    debugPrint('[PolicyListNotifier] search() query="$normalized" lastQuery=$_lastQuery');
+
     if (_lastQuery != null) {
       await _historySource.saveQuery(_lastQuery!);
     }
+
     ref.invalidate(searchHistoryListProvider);
     await refresh();
+  }
+
+  void _debugLogState(String where) {
+    if (!kDebugMode) return;
+    debugPrint(
+      '[PolicyListNotifier][$where] '
+      'isLoading=${state.isLoading}, '
+      'isRefreshing=${state.isRefreshing}, '
+      'isStale=${state.isStale}, '
+      'policies=${state.policies.length}, '
+      'error=${state.error}',
+    );
   }
 }


### PR DESCRIPTION
## Summary
- refactor PolicyListNotifier to follow SWR-style lifecycle with scheduled initial load and region change handling
- switch to interface-based repository provider and add debug-oriented state logging
- ensure refresh and search flows use current region and robust error handling

## Testing
- bash: dart format lib/application/policy/policy_list_notifier.dart *(fails: dart command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c35e1295c8324aba29b9e85762ea4)