### PR TITLE
Resolve policy repository type conflicts

### DIFF
--- a/lib/application/providers.dart
+++ b/lib/application/providers.dart
@@ -1,13 +1,10 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../domain/entities/policy.dart';
-import 'di.dart';
-import 'repository_providers.dart';
 import 'notifiers/chat_notifier.dart';
 import 'notifiers/compare_notifier.dart';
 import 'notifiers/favorites_notifier.dart';
 import 'notifiers/policy_detail_notifier.dart';
-import 'policy/policy_list_notifier.dart';
 import 'notifiers/policy_paging_notifier.dart';
 
 export 'di.dart';

--- a/lib/core/api/youth_api_service.dart
+++ b/lib/core/api/youth_api_service.dart
@@ -10,10 +10,10 @@ import 'models/policy_list_response.dart';
 
 part 'youth_api_service.g.dart';
 
-const YouthApiServiceBaseUrl = "https://api.youthroad.kr/v1";
+const youthApiServiceBaseUrl = "https://api.youthroad.kr/v1";
 const String apiKey = "yAlMhwGFZps7vHtbsjnbsL6Cpha6bHqaPDSScV6pgU0";
 
-@RestApi(baseUrl: YouthApiServiceBaseUrl)
+@RestApi(baseUrl: youthApiServiceBaseUrl)
 abstract class YouthApiService {
   factory YouthApiService(Dio dio, {String? baseUrl}) {
     if (kDebugMode) {
@@ -21,7 +21,7 @@ abstract class YouthApiService {
     }
     return _YouthApiService(
       dio,
-      baseUrl: baseUrl ?? YouthApiServiceBaseUrl,
+      baseUrl: baseUrl ?? youthApiServiceBaseUrl,
     );
   }
 

--- a/lib/data/repositories/hybrid_policy_repository.dart
+++ b/lib/data/repositories/hybrid_policy_repository.dart
@@ -6,8 +6,8 @@ import '../local/isar/isar_service.dart';
 import '../local/isar/policy_isar_model.dart';
 import '../models/policy_filter.dart';
 import '../models/policy_model.dart';
+import '../policy/policy_remote_source.dart';
 import '../policy/policy_repository.dart';
-import '../sources/remote/policy_remote_source.dart';
 
 class HybridPolicyRepository implements PolicyRepository {
   HybridPolicyRepository(this._remoteSource, this._isarService);

--- a/lib/debug/debug_overlay.dart
+++ b/lib/debug/debug_overlay.dart
@@ -25,7 +25,10 @@ class _DebugOverlayState extends State<DebugOverlay> {
             length: 4,
             child: Builder(
               builder: (context) {
-                final tabController = DefaultTabController.of(context)!;
+                final tabController = DefaultTabController.of(context);
+                if (tabController == null) {
+                  return const SizedBox.shrink();
+                }
                 return Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [

--- a/lib/domain/repositories/policy_repository.dart
+++ b/lib/domain/repositories/policy_repository.dart
@@ -24,18 +24,4 @@ abstract class PolicyRepository {
   Future<Policy> fetchPolicyById(String id);
 
   Future<List<Policy>> fetchSimilarPolicies(String id);
-
-  Future<PolicyFetchResult> getPolicies({
-    PolicyFilter filter = const PolicyFilter(),
-    bool forceRefresh = false,
-  });
-
-  Future<List<Policy>> refreshPolicies({
-    PolicyFilter filter = const PolicyFilter(),
-    bool replaceExisting = false,
-  });
-
-  Future<List<Policy>> loadCachedPolicies({
-    PolicyFilter filter = const PolicyFilter(),
-  });
 }

--- a/lib/features/policy/providers/policy_prefetch_provider.dart
+++ b/lib/features/policy/providers/policy_prefetch_provider.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../application/di.dart';
 import '../../../application/notifiers/policy_paging_notifier.dart'; // ← ★ 반드시 필요!!
 import '../../../application/providers.dart';
-
-import '../../../data/policy/policy_repository.dart';
+import '../../../domain/repositories/policy_repository.dart';
 
 final policyPrefetchProvider =
     AsyncNotifierProvider<PolicyPrefetchNotifier, void>(
@@ -13,8 +11,8 @@ final policyPrefetchProvider =
 );
 
 class PolicyPrefetchNotifier extends AsyncNotifier<void> {
-  SwrPolicyRepository get _repository =>
-      ref.read(hybridPolicyRepositoryProvider);
+  PolicyRepository get _repository =>
+      ref.read(policyRepositoryInterfaceProvider);
 
   PolicyPagingNotifier get _pagingNotifier =>
       ref.read(policyPagingProvider.notifier); // ← 오류 해결됨!

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../application/providers.dart';
-import '../../../application/policy/policy_list_notifier.dart';
 import '../../../navigation/route_paths.dart';
 import '../../widgets/app_appbar.dart';
 import '../../widgets/global_error_view.dart';

--- a/lib/ui/screens/map/kakao_map_screen.dart
+++ b/lib/ui/screens/map/kakao_map_screen.dart
@@ -7,7 +7,6 @@ import 'package:webview_flutter/webview_flutter.dart';
 
 import '../../../application/providers.dart';
 import '../../../core/constants/env.dart';
-import '../../../domain/entities/policy.dart';
 import '../../../navigation/route_paths.dart';
 import '../../widgets/app_appbar.dart';
 import 'kakao_map_html_builder.dart';

--- a/lib/ui/screens/map/map_with_list_screen.dart
+++ b/lib/ui/screens/map/map_with_list_screen.dart
@@ -6,7 +6,6 @@ import 'package:go_router/go_router.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 import '../../../application/providers.dart';
-import '../../../application/policy/policy_list_notifier.dart';
 import '../../../core/constants/env.dart';
 import '../../../domain/entities/policy.dart';
 import '../../../navigation/route_paths.dart';

--- a/lib/ui/screens/policy/policy_detail_screen.dart
+++ b/lib/ui/screens/policy/policy_detail_screen.dart
@@ -6,7 +6,6 @@ import '../../../application/notifiers/policy_detail_notifier.dart';
 import '../../../application/providers.dart';
 import '../../../application/services/memo_repository.dart';
 import '../../../application/services/eligibility_service.dart';
-import '../../../domain/entities/policy.dart';
 import '../../../navigation/route_paths.dart';
 import '../../widgets/app_appbar.dart';
 import '../../widgets/global_error_view.dart';

--- a/lib/ui/widgets/policy_detail_metadata.dart
+++ b/lib/ui/widgets/policy_detail_metadata.dart
@@ -33,7 +33,7 @@ class PolicyDetailMetadata extends StatelessWidget {
                     ),
                   ),
                 ),
-                OptionalBadge(badge: badge),
+                _OptionalBadge(badge: badge),
               ],
             ),
             const SizedBox(height: 12),
@@ -136,8 +136,8 @@ class MetadataRow extends StatelessWidget {
   }
 }
 
-class OptionalBadge extends StatelessWidget {
-  const OptionalBadge({super.key, this.badge});
+class _OptionalBadge extends StatelessWidget {
+  const _OptionalBadge({super.key, this.badge});
 
   final _StatusBadge? badge;
 
@@ -209,8 +209,8 @@ String _formatRegion(String? region) {
 String _formatPeriod(DateTime? start, DateTime? end) {
   final startText = _formatDate(start);
   final endText = _formatDate(end);
-  final hasStart = startText != null && startText.isNotEmpty;
-  final hasEnd = endText != null && endText.isNotEmpty;
+  final hasStart = startText.isNotEmpty;
+  final hasEnd = endText.isNotEmpty;
 
   if (!hasStart && !hasEnd) return '정보 없음';
   if (hasStart && hasEnd) return '$startText ~ $endText';

--- a/test/compare_notifier_test.dart
+++ b/test/compare_notifier_test.dart
@@ -13,6 +13,30 @@ class _FakePolicyRepository implements PolicyRepository {
   final Map<String, Policy> _policies;
 
   @override
+  Future<PolicyFetchResult> getPolicies({
+    PolicyFilter filter = const PolicyFilter(),
+    bool forceRefresh = false,
+  }) async {
+    final policies = _policies.values.toList();
+    return PolicyFetchResult(policies: policies);
+  }
+
+  @override
+  Future<List<Policy>> loadCachedPolicies({
+    PolicyFilter filter = const PolicyFilter(),
+  }) async {
+    return _policies.values.toList();
+  }
+
+  @override
+  Future<List<Policy>> refreshPolicies({
+    PolicyFilter filter = const PolicyFilter(),
+    bool replaceExisting = false,
+  }) async {
+    return _policies.values.toList();
+  }
+
+  @override
   Future<Policy> fetchPolicyById(String id) async {
     final policy = _policies[id];
     if (policy == null) {

--- a/test/favorites_notifier_test.dart
+++ b/test/favorites_notifier_test.dart
@@ -1,8 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:riverpod/riverpod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:youth_road_app/application/notifiers/favorites_notifier.dart';
 import 'package:youth_road_app/application/providers.dart';
 
 void main() {


### PR DESCRIPTION
## Summary
- align the hybrid policy repository and dependency injection on a single PolicyRemoteSource implementation
- clean up the PolicyRepository interface, providers, and tests to use the shared contract and resolve analyzer complaints
- address miscellaneous analyzer warnings in UI utilities and API constants

## Testing
- dart analyze *(fails: dart command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c3c90c43c8324aecd1da8436910ad)