### PR TITLE
Refactor policy loading for cache-first initialization

### DIFF
--- a/lib/app/splash/splash_page.dart
+++ b/lib/app/splash/splash_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../features/policy/providers/policy_prefetch_provider.dart';
+import '../../application/policy/policy_prefetch_provider.dart';
 import '../../navigation/route_paths.dart';
 
 class SplashPage extends ConsumerStatefulWidget {
@@ -19,7 +19,7 @@ class _SplashPageState extends ConsumerState<SplashPage> {
   void initState() {
     super.initState();
     Future.microtask(() {
-      ref.read(policyPrefetchProvider.notifier).prefetchPolicies(); // ← ✔ 수정!
+      ref.read(policyPrefetchProvider.notifier).prefetchPolicies();
       if (mounted) {
         unawaited(_goHome());
       }

--- a/lib/application/policy/policy_list_notifier.dart
+++ b/lib/application/policy/policy_list_notifier.dart
@@ -1,4 +1,10 @@
 // FILE: lib/application/policy/policy_list_notifier.dart
+// 정책 리스트는 "UI 우선"을 지향한다. 첫 렌더링 시 로딩 스피너로 화면을 막지 않고
+// 바로 화면을 그린 뒤, Isar 캐시를 즉시 반영하고 원격 데이터는 백그라운드에서
+// 갱신하도록 설계했다.
+
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -64,6 +70,8 @@ class PolicyListNotifier extends AutoDisposeNotifier<PolicyListState> {
     final normalizedRegion = region?.trim() ?? '';
     debugPrint('[PolicyListNotifier] build() with region=$region');
 
+    // 초기 state는 isLoading=false로 두어 첫 프레임을 즉시 렌더링한다.
+    // 실제 로딩은 마이크로태스크로 밀어 UI 블로킹을 피한다.
     if (!_initialLoadScheduled) {
       _initialLoadScheduled = true;
       Future.microtask(() {
@@ -84,7 +92,7 @@ class PolicyListNotifier extends AutoDisposeNotifier<PolicyListState> {
       debugPrint('[PolicyListNotifier] disposed');
     });
 
-    return const PolicyListState(isLoading: true);
+    return const PolicyListState();
   }
 
   PolicyFilter _buildFilter({required String region}) {
@@ -93,6 +101,8 @@ class PolicyListNotifier extends AutoDisposeNotifier<PolicyListState> {
       searchRgnSe: normalizedRegion.isEmpty ? null : normalizedRegion,
       searchText: _lastQuery,
       availableOnly: true,
+      pagingYn: 'N',
+      recordCount: 2000,
     );
   }
 
@@ -113,6 +123,7 @@ class PolicyListNotifier extends AutoDisposeNotifier<PolicyListState> {
       }
     }
 
+    // isLoading=true로 표시하되 UI는 이미 그려진 상태이므로 블로킹되지 않는다.
     state = state.copyWith(
       isLoading: true,
       error: null,
@@ -132,37 +143,45 @@ class PolicyListNotifier extends AutoDisposeNotifier<PolicyListState> {
       state = state.copyWith(
         policies: result.policies,
         isLoading: false,
+        isRefreshing: false,
         isStale: shouldMarkStale,
         error: null,
       );
       debugPrint(
-        '[PolicyListNotifier] initial cache load done. count=${result.policies.length}',
+        '[PolicyListNotifier] cache load done. count=${result.policies.length}',
       );
 
       if (remoteFuture != null) {
-        remoteFuture.then((latest) {
-          state = state.copyWith(
-            policies: latest,
-            isStale: false,
-            error: null,
-          );
-          debugPrint(
-            '[PolicyListNotifier] remote refresh success. count=${latest.length}',
-          );
-        }).catchError((error, stack) {
-          debugPrint('[PolicyListNotifier] remote refresh failed: error=$error');
-          debugPrint('$stack');
-          state = state.copyWith(
-            error: error,
-            isStale: false,
-          );
-        });
+        unawaited(
+          remoteFuture.then((latest) {
+            if (!mounted) return;
+            state = state.copyWith(
+              policies: latest,
+              isStale: false,
+              isRefreshing: false,
+              error: null,
+            );
+            debugPrint(
+              '[PolicyListNotifier] remote refresh success. count=${latest.length}',
+            );
+          }).catchError((error, stack) {
+            if (!mounted) return;
+            debugPrint('[PolicyListNotifier] remote refresh failed: error=$error');
+            debugPrint('$stack');
+            state = state.copyWith(
+              error: error,
+              isStale: false,
+              isRefreshing: false,
+            );
+          }),
+        );
       }
     } catch (e, st) {
       debugPrint('[PolicyListNotifier] remote refresh failed: error=$e');
       debugPrint('$st');
       state = state.copyWith(
         isLoading: false,
+        isRefreshing: false,
         error: e,
         isStale: false,
       );
@@ -198,25 +217,29 @@ class PolicyListNotifier extends AutoDisposeNotifier<PolicyListState> {
       );
 
       if (remoteFuture != null) {
-        await remoteFuture.then((latest) {
-          state = state.copyWith(
-            policies: latest,
-            isStale: false,
-            isRefreshing: false,
-            error: null,
-          );
-          debugPrint(
-            '[PolicyListNotifier] refresh remote success. count=${latest.length}',
-          );
-        }).catchError((error, stack) {
-          debugPrint('[PolicyListNotifier] refresh remote failed: error=$error');
-          debugPrint('$stack');
-          state = state.copyWith(
-            isRefreshing: false,
-            error: error,
-            isStale: false,
-          );
-        });
+        unawaited(
+          remoteFuture.then((latest) {
+            if (!mounted) return;
+            state = state.copyWith(
+              policies: latest,
+              isStale: false,
+              isRefreshing: false,
+              error: null,
+            );
+            debugPrint(
+              '[PolicyListNotifier] refresh remote success. count=${latest.length}',
+            );
+          }).catchError((error, stack) {
+            if (!mounted) return;
+            debugPrint('[PolicyListNotifier] refresh remote failed: error=$error');
+            debugPrint('$stack');
+            state = state.copyWith(
+              isRefreshing: false,
+              error: error,
+              isStale: false,
+            );
+          }),
+        );
       } else {
         state = state.copyWith(
           isRefreshing: false,

--- a/lib/application/policy/policy_prefetch_provider.dart
+++ b/lib/application/policy/policy_prefetch_provider.dart
@@ -1,0 +1,78 @@
+// FILE: lib/application/policy/policy_prefetch_provider.dart
+// 앱 실행 직후 캐시 상태를 확인하고, 비어 있다면 전체 정책을 백그라운드에서
+// 받아오는 Provider. UI 스레드는 절대 블로킹하지 않도록 remote fetch를
+// 기다리지 않고 즉시 반환한다.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/repositories/policy_repository.dart';
+import '../di.dart';
+
+final policyPrefetchProvider =
+    AsyncNotifierProvider.autoDispose<PolicyPrefetchNotifier, void>(
+  PolicyPrefetchNotifier.new,
+);
+
+class PolicyPrefetchNotifier extends AutoDisposeAsyncNotifier<void> {
+  PolicyRepository get _repository => ref.read(policyRepositoryInterfaceProvider);
+
+  bool _started = false;
+
+  @override
+  Future<void> build() async {
+    // build에서 바로 시작하되, 호출자는 결과를 기다릴 필요가 없다.
+    _startPrefetchIfNeeded();
+  }
+
+  /// 외부에서 명시적으로 프리패치를 요청할 때 사용하는 메서드.
+  Future<void> prefetchPolicies() async {
+    _startPrefetchIfNeeded();
+  }
+
+  void _startPrefetchIfNeeded() {
+    if (_started) return;
+    _started = true;
+
+    // 비동기로 진행하여 UI를 블로킹하지 않는다.
+    unawaited(_prefetch());
+  }
+
+  Future<void> _prefetch() async {
+    // 두 단계: 캐시 확인 -> 필요 시 원격 전체 로딩
+    state = const AsyncLoading();
+
+    try {
+      final cached = await _repository.loadCachedPolicies();
+      if (cached.isNotEmpty) {
+        // 캐시에 데이터가 있으면 더 이상의 원격 로딩 없이 종료.
+        state = const AsyncData(null);
+        return;
+      }
+
+      final result = await _repository.getPolicies();
+      final remoteFuture = result.remoteRefresh;
+      if (remoteFuture == null) {
+        state = const AsyncData(null);
+        return;
+      }
+
+      // remote 결과는 백그라운드에서 Isar에 저장되고 자동 반영된다.
+      remoteFuture.then((_) {
+        if (!mounted) return;
+        state = const AsyncData(null);
+        debugPrint('[PolicyPrefetchNotifier] remote prefetch completed');
+      }).catchError((error, stack) {
+        if (!mounted) return;
+        debugPrint('[PolicyPrefetchNotifier] remote prefetch failed: $error');
+        debugPrint('$stack');
+        state = AsyncError(error, stack);
+      });
+    } catch (e, st) {
+      debugPrint('[PolicyPrefetchNotifier] cache preload failed: $e\n$st');
+      state = AsyncError(e, st);
+    }
+  }
+}

--- a/lib/application/policy/policy_providers.dart
+++ b/lib/application/policy/policy_providers.dart
@@ -1,0 +1,20 @@
+// FILE: lib/application/policy/policy_providers.dart
+// 정책 관련 Provider 모음. 앱 기동 시 [policyBootstrapProvider] 를 읽으면
+// 캐시 우선 UI 렌더링 + 백그라운드 프리패치 흐름이 자동으로 시작된다.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'policy_list_notifier.dart';
+import 'policy_prefetch_provider.dart';
+
+export 'policy_list_notifier.dart'
+    show policyListNotifierProvider, PolicyListNotifier, PolicyListState;
+export 'policy_prefetch_provider.dart'
+    show policyPrefetchProvider, PolicyPrefetchNotifier;
+
+/// 앱이 시작될 때 한번 읽어두면 정책 데이터의 프리패치를 즉시 시도한다.
+/// UI는 절대 블로킹되지 않고, 캐시가 이미 존재하면 조용히 종료된다.
+final policyBootstrapProvider = Provider<void>((ref) {
+  // Provider가 생성되는 시점에 프리패치 Notifier를 초기화한다.
+  ref.read(policyPrefetchProvider);
+});

--- a/lib/application/providers.dart
+++ b/lib/application/providers.dart
@@ -10,10 +10,14 @@ import 'notifiers/policy_paging_notifier.dart';
 export 'di.dart';
 export 'repository_providers.dart';
 export 'notifiers/region_notifier.dart' show regionProvider, RegionNotifier;
-export 'policy/policy_list_notifier.dart'
-    show policyListNotifierProvider, PolicyListNotifier, PolicyListState;
-export '../features/policy/providers/policy_prefetch_provider.dart'
-    show policyPrefetchProvider, PolicyPrefetchNotifier;
+export 'policy/policy_providers.dart'
+    show
+        policyBootstrapProvider,
+        policyListNotifierProvider,
+        PolicyListNotifier,
+        PolicyListState,
+        policyPrefetchProvider,
+        PolicyPrefetchNotifier;
 
 final policyPagingProvider =
     NotifierProvider.autoDispose<PolicyPagingNotifier, PolicyPagingState>(

--- a/lib/data/repositories/hybrid_policy_repository.dart
+++ b/lib/data/repositories/hybrid_policy_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 import '../../domain/entities/policy.dart';
@@ -6,8 +8,10 @@ import '../local/isar/isar_service.dart';
 import '../local/isar/policy_isar_model.dart';
 import '../models/policy_filter.dart';
 import '../models/policy_model.dart';
-import '../../data/sources/remote/policy_remote_source.dart';
+import '../sources/remote/policy_remote_source.dart';
 
+/// Repository that prioritizes locally cached policies first and then refreshes
+/// from the remote API in the background (Stale-While-Revalidate).
 class HybridPolicyRepository implements PolicyRepository {
   HybridPolicyRepository(this._remoteSource, this._isarService);
 
@@ -19,11 +23,13 @@ class HybridPolicyRepository implements PolicyRepository {
     PolicyFilter filter = const PolicyFilter(),
     bool forceRefresh = false,
   }) async {
+    // 1) Always return cached data immediately for instant UI rendering.
     final cached = await _safeLoadCache(filter);
     debugPrint(
-      '[HybridPolicyRepository] returning cached policies count=${cached.length}',
+      '[HybridPolicyRepository] cached policies count=${cached.length}',
     );
 
+    // 2) Trigger remote refresh in the background without awaiting.
     final remoteFuture = _refreshFromRemote(
       filter: filter,
       replaceExisting: forceRefresh || _isDefaultFilter(filter),
@@ -46,6 +52,7 @@ class HybridPolicyRepository implements PolicyRepository {
   Future<List<Policy>> refreshPolicies({
     PolicyFilter filter = const PolicyFilter(),
   }) async {
+    // Caller explicitly requested a refresh, so return the remote result.
     return _refreshFromRemote(
       filter: filter,
       replaceExisting: _isDefaultFilter(filter),
@@ -56,9 +63,7 @@ class HybridPolicyRepository implements PolicyRepository {
   Future<List<Policy>> fetchPolicies({
     PolicyFilter filter = const PolicyFilter(),
   }) async {
-    return refreshPolicies(
-      filter: filter,
-    );
+    return refreshPolicies(filter: filter);
   }
 
   @override
@@ -70,7 +75,8 @@ class HybridPolicyRepository implements PolicyRepository {
       }
     } catch (e, st) {
       debugPrint(
-          '[HybridPolicyRepository] cache lookup failed for $id: $e\n$st');
+        '[HybridPolicyRepository] cache lookup failed for $id: $e\n$st',
+      );
     }
 
     final model = await _remoteSource.fetchPolicyById(id);
@@ -118,6 +124,7 @@ class HybridPolicyRepository implements PolicyRepository {
     return models.map((model) => model.toEntity()).toList();
   }
 
+  /// Loads cached policies safely, swallowing cache errors so UI is not blocked.
   Future<List<Policy>> _safeLoadCache(PolicyFilter filter) async {
     try {
       final cached = await _isarService.getPolicies(filter: filter);
@@ -140,6 +147,12 @@ class HybridPolicyRepository implements PolicyRepository {
     await _isarService.putAllPolicies(isarModels);
   }
 
+  /// Refreshes from the remote API and saves results to Isar.
+  ///
+  /// The returned [Future] resolves with the freshly fetched domain models but
+  /// must not be awaited by UI callers. Errors are propagated so that the
+  /// optional listeners (e.g., notifiers) can surface them without blocking the
+  /// initial cached render.
   Future<List<Policy>> _refreshFromRemote({
     required PolicyFilter filter,
     bool replaceExisting = false,
@@ -147,7 +160,11 @@ class HybridPolicyRepository implements PolicyRepository {
     try {
       final remoteModels = await _remoteSource.fetchPolicies(filter: filter);
       await _persistPolicies(remoteModels, replaceExisting: replaceExisting);
-      return remoteModels.map((model) => model.toEntity()).toList();
+
+      // Reload from cache to keep filtering logic consistent with local-first
+      // behavior and to ensure Isar-derived fields are reflected.
+      final hydrated = await _safeLoadCache(filter);
+      return hydrated;
     } catch (e, st) {
       debugPrint('[HybridPolicyRepository] remote refresh failed: $e\n$st');
       rethrow;

--- a/lib/data/sources/remote/policy_remote_source.dart
+++ b/lib/data/sources/remote/policy_remote_source.dart
@@ -7,12 +7,10 @@ import '../../../core/constants/env.dart';
 import '../../models/policy_filter.dart';
 import '../../models/policy_model.dart';
 
-/// 올바른 정책 API 기본 URL
-/// 실제 정책 리스트 엔드포인트 예:
-///   GET https://www.gbyouth.co.kr/openapi/policy/list.json
+/// 올바른 정책 API 기본 URL (오타 주의: gbyouth.co.kr)
 const String kPolicyApiBaseUrl = String.fromEnvironment(
   'POLICY_API_BASE_URL',
-  defaultValue: 'https://www.gbyouth.co.kr/openapi',
+  defaultValue: 'https://gbyouth.co.kr/openapi',
 );
 
 class PolicyRemoteSource {
@@ -33,6 +31,9 @@ class PolicyRemoteSource {
   final String _baseUrl;
 
   /// 정책 리스트 불러오기 (GET)
+  ///
+  /// - 기본은 페이징 비활성화(pagingYn=N) + recordCount=2000으로 전체를 받아온다.
+  /// - JSON 파싱은 compute()를 사용해 별도의 isolate에서 처리한다.
   Future<List<PolicyModel>> fetchPolicies({
     PolicyFilter filter = const PolicyFilter(),
   }) async {

--- a/lib/features/policy/providers/policy_prefetch_provider.dart
+++ b/lib/features/policy/providers/policy_prefetch_provider.dart
@@ -1,49 +1,5 @@
-import 'package:flutter/foundation.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+// Deprecated wrapper kept for compatibility with feature-layer widgets.
+// New implementation lives in lib/application/policy/policy_prefetch_provider.dart
+// and follows the lazy-loading, cache-first strategy.
 
-import '../../../application/notifiers/policy_paging_notifier.dart'; // ← ★ 반드시 필요!!
-import '../../../application/providers.dart';
-import '../../../domain/repositories/policy_repository.dart';
-
-final policyPrefetchProvider =
-    AsyncNotifierProvider<PolicyPrefetchNotifier, void>(
-  PolicyPrefetchNotifier.new,
-);
-
-class PolicyPrefetchNotifier extends AsyncNotifier<void> {
-  PolicyRepository get _repository =>
-      ref.read(policyRepositoryInterfaceProvider);
-
-  PolicyPagingNotifier get _pagingNotifier =>
-      ref.read(policyPagingProvider.notifier); // ← 오류 해결됨!
-
-  @override
-  Future<void> build() async {}
-
-  Future<void> prefetchPolicies() async {
-    if (state.isLoading) return;
-    state = const AsyncValue.loading();
-
-    try {
-      final cached = await _repository.loadCachedPolicies(
-        filter: _pagingNotifier.currentFilter,
-      );
-      if (cached.isNotEmpty) {
-        _pagingNotifier.seedFromCache(cached);
-      }
-    } catch (e, st) {
-      debugPrint('[PolicyPrefetchNotifier] cache preload failed: $e\n$st');
-    }
-
-    try {
-      final remote = await _repository.refreshPolicies(
-        filter: _pagingNotifier.currentFilter,
-      );
-      _pagingNotifier.replaceWithFresh(remote);
-      state = const AsyncValue.data(null);
-    } catch (e, st) {
-      debugPrint('[PolicyPrefetchNotifier] remote prefetch failed: $e\n$st');
-      state = AsyncValue.error(e, st);
-    }
-  }
-}
+export '../../../application/policy/policy_prefetch_provider.dart';


### PR DESCRIPTION
## Summary
- implement cache-first policy repository with SWR-style background refresh and cache persistence
- refactor policy list notifier and bootstrap providers for lazy-loading UI with background prefetch when cache is empty
- update remote policy source configuration to the correct gbyouth.co.kr base URL and ensure splash triggers non-blocking prefetch

## Testing
- Not run (environment lacks Dart/Flutter tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c52943414832485c720b767d47dac)