### PR TITLE
필터 변경 시 피드 강제 리로드

### DIFF
--- a/lib/features/policy_new/application/controllers/base_feed_controller.dart
+++ b/lib/features/policy_new/application/controllers/base_feed_controller.dart
@@ -18,11 +18,7 @@ abstract class BasePolicyFeedController
   }) : super(const PolicyPagingState.initial()) {
     ref.listen<PolicyFilterUiState>(
       policyFilterUiStateProvider,
-      (previous, next) {
-        if (_shouldRefreshForFilterChange(previous, next)) {
-          refresh();
-        }
-      },
+      (_, next) => forceReload(next),
     );
 
     ref.listen<String?>(
@@ -87,53 +83,6 @@ abstract class BasePolicyFeedController
       feedType == PolicyFeedType.region ||
       feedType == PolicyFeedType.search;
 
-  bool _shouldRefreshForFilterChange(
-    PolicyFilterUiState? previous,
-    PolicyFilterUiState next,
-  ) {
-    switch (feedType) {
-      case PolicyFeedType.recommend:
-        return previous == null ||
-            previous.region != next.region ||
-            previous.category != next.category ||
-            previous.showOnlyOnline != next.showOnlyOnline ||
-            previous.showOnlyOngoing != next.showOnlyOngoing ||
-            previous.institutionId != next.institutionId ||
-            previous.departmentId != next.departmentId ||
-            !listEquals(previous.tags, next.tags);
-      case PolicyFeedType.all:
-        return previous == null ||
-            previous.region != next.region ||
-            previous.category != next.category ||
-            previous.keyword != next.keyword ||
-            previous.sort != next.sort ||
-            previous.showOnlyOnline != next.showOnlyOnline ||
-            previous.showOnlyOngoing != next.showOnlyOngoing ||
-            !listEquals(previous.tags, next.tags) ||
-            previous.institutionId != next.institutionId ||
-            previous.departmentId != next.departmentId;
-      case PolicyFeedType.region:
-        return previous == null ||
-            previous.region != next.region ||
-            previous.category != next.category ||
-            previous.sort != next.sort ||
-            previous.showOnlyOnline != next.showOnlyOnline ||
-            previous.showOnlyOngoing != next.showOnlyOngoing;
-      case PolicyFeedType.search:
-        return previous == null ||
-            previous.keyword != next.keyword ||
-            previous.region != next.region ||
-            previous.category != next.category ||
-            previous.sort != next.sort ||
-            previous.showOnlyOnline != next.showOnlyOnline ||
-            previous.showOnlyOngoing != next.showOnlyOngoing ||
-            !listEquals(previous.tags, next.tags);
-      case PolicyFeedType.favorite:
-      case PolicyFeedType.compare:
-        return previous == null || previous.sort != next.sort;
-    }
-  }
-
   void _resetPaging() {
     _page = 1;
     _isLoading = false;
@@ -145,36 +94,8 @@ abstract class BasePolicyFeedController
     await loadFirstPage();
   }
 
-  Future<void> loadFirstPage() async {
-    final shouldFetch = _shouldFetchForFeedType();
-
-    if (!shouldFetch) {
-      _page = 1;
-      _isLoading = false;
-      state = const PolicyPagingState.initial();
-      return;
-    }
-
-    _page = 1;
-    _isLoading = true;
-    state = const PolicyPagingState.loading();
-
-    final result = await queryEngine.fetch(feedType, page: _page);
-
-    result.fold(
-      onSuccess: (list) {
-        state = PolicyPagingState.data(
-          items: list,
-          hasMore: list.length == queryEngine.pageSize,
-        );
-      },
-      onFailure: (failure) {
-        state = PolicyPagingState.error(failure);
-      },
-    );
-
-    _isLoading = false;
-  }
+  Future<void> loadFirstPage() async =>
+      reload(ref.read(policyFilterUiStateProvider));
 
   Future<void> loadNextPage() async {
     if (_isLoading) return;
@@ -182,7 +103,7 @@ abstract class BasePolicyFeedController
       debugPrint('[PAGING-LAST-PAGE:NO-OP] feed=${feedType.name}, page=$_page');
       return;
     }
-    if (!_shouldFetchForFeedType()) return;
+    if (!_shouldFetchForFeedType(ref.read(policyFilterUiStateProvider))) return;
 
     _isLoading = true;
     final nextPage = _page + 1;
@@ -207,24 +128,56 @@ abstract class BasePolicyFeedController
   }
 
   Future<void> refresh() async {
-    await loadFirstPage();
+    await reload(ref.read(policyFilterUiStateProvider));
   }
 
   /// 지역 등 주요 조건 변경 시 사용: 페이징 초기화 후 첫 페이지 재로딩
   Future<void> onRegionChanged() async {
-    _resetPaging();
-    await loadFirstPage();
+    await reload(ref.read(policyFilterUiStateProvider));
   }
 
-  bool _shouldFetchForFeedType() {
+  Future<void> reload(PolicyFilterUiState filter) async {
+    await forceReload(filter);
+  }
+
+  Future<void> forceReload(PolicyFilterUiState filter) async {
+    _page = 1;
+    _isLoading = true;
+    state = const PolicyPagingState.loading();
+
+    final shouldFetch = _shouldFetchForFeedType(filter);
+
+    if (!shouldFetch) {
+      _isLoading = false;
+      state = const PolicyPagingState.initial();
+      return;
+    }
+
+    final result = await queryEngine.fetch(feedType, page: _page);
+
+    result.fold(
+      onSuccess: (list) {
+        state = PolicyPagingState.data(
+          items: list,
+          hasMore: list.length == queryEngine.pageSize,
+        );
+      },
+      onFailure: (failure) {
+        state = PolicyPagingState.error(failure);
+      },
+    );
+
+    _isLoading = false;
+  }
+
+  bool _shouldFetchForFeedType(PolicyFilterUiState filter) {
     if (feedType != PolicyFeedType.search) {
       return true;
     }
 
-    final ui = ref.read(policyFilterUiStateProvider);
-    final keyword = ui.keyword.trim();
+    final keyword = filter.keyword.trim();
     final hasKeyword = keyword.length >= 2;
-    final hasTags = ui.tags.isNotEmpty;
+    final hasTags = filter.tags.isNotEmpty;
 
     return hasKeyword || hasTags;
   }

--- a/lib/features/policy_new/application/filters/policy_filter_ui_state.dart
+++ b/lib/features/policy_new/application/filters/policy_filter_ui_state.dart
@@ -55,6 +55,10 @@ class PolicyFilterUiState {
     String? departmentId,
     String? departmentName,
   }) {
+    final nextTags = tags != null
+        ? List<String>.unmodifiable(tags)
+        : List<String>.unmodifiable(this.tags);
+
     return PolicyFilterUiState(
       region: region ?? this.region,
       province: province ?? this.province,
@@ -63,7 +67,7 @@ class PolicyFilterUiState {
       category: category ?? this.category,
       sort: sort ?? this.sort,
       keyword: keyword ?? this.keyword,
-      tags: tags ?? this.tags,
+      tags: nextTags,
       showOnlyOnline: showOnlyOnline ?? this.showOnlyOnline,
       showOnlyOngoing: showOnlyOngoing ?? this.showOnlyOngoing,
       institutionId: institutionId ?? this.institutionId,


### PR DESCRIPTION
## Summary
- 필터 UI 상태의 copyWith에서 태그 리스트를 항상 새 인스턴스로 만들어 변경 알림을 보장했습니다.
- BasePolicyFeedController에 reload/forceReload를 추가하고 필터 변경 시 즉시 강제 리로드하도록 연결했습니다.
- 검색 요청 가능 여부 판단에 전달된 최신 필터 상태를 사용하도록 정리했습니다.

## Testing
- dart format lib/features/policy_new/application/filters/policy_filter_ui_state.dart lib/features/policy_new/application/controllers/base_feed_controller.dart (실패: 환경에 dart 명령어가 없음)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69347fd9f5d48324b2a6a92762a75963)