### PR TITLE
feat: 알림 실패 코드와 취소 이력 강화

### DIFF
--- a/lib/features/policy_new/application/controllers/notification_center_controller.dart
+++ b/lib/features/policy_new/application/controllers/notification_center_controller.dart
@@ -138,12 +138,12 @@ class NotificationCenterController
   Future<void> cancelReminder(String reminderId) async {
     final previous = state.value ?? NotificationCenterState.initial;
     final actionId = ++_actionCounter;
-    final optimisticState = _removeReminder(previous, reminderId);
+    final optimisticState = _applyCanceledReminder(previous, reminderId);
     _optimisticActions.add(
       _OptimisticAction(
         id: actionId,
         rollbackState: previous,
-        reducer: (state) => _removeReminder(state, reminderId),
+        reducer: (state) => _applyCanceledReminder(state, reminderId),
       ),
     );
 
@@ -159,13 +159,16 @@ class NotificationCenterController
     await _enqueue(() async {
       try {
         await _service.cancelReminder(reminderId);
-        await ref
+        final updated = await ref
             .read(policyReminderRepositoryProvider)
-            .deleteReminderById(reminderId);
+            .getReminder(reminderId);
         _removeOptimisticAction(actionId);
-        final current = _applyOptimisticReducers(
+        final optimisticMerged = _applyOptimisticReducers(
           state.value ?? optimisticState.copyWith(pendingActions: 0),
         );
+        final current = updated == null
+            ? _applyCanceledReminder(optimisticMerged, reminderId)
+            : _mergeReminders(optimisticMerged, [updated]);
         state = AsyncData(
           current.copyWith(
             status: NotificationCenterStatus.success,
@@ -236,12 +239,12 @@ class NotificationCenterController
   Future<void> deleteReminder(String reminderId) async {
     final previous = state.value ?? NotificationCenterState.initial;
     final actionId = ++_actionCounter;
-    final optimisticState = _removeReminder(previous, reminderId);
+    final optimisticState = _applyCanceledReminder(previous, reminderId);
     _optimisticActions.add(
       _OptimisticAction(
         id: actionId,
         rollbackState: previous,
-        reducer: (state) => _removeReminder(state, reminderId),
+        reducer: (state) => _applyCanceledReminder(state, reminderId),
       ),
     );
 
@@ -257,13 +260,16 @@ class NotificationCenterController
     await _enqueue(() async {
       try {
         await _service.cancelReminder(reminderId);
-        await ref
+        final updated = await ref
             .read(policyReminderRepositoryProvider)
-            .deleteReminderById(reminderId);
+            .getReminder(reminderId);
         _removeOptimisticAction(actionId);
-        final current = _applyOptimisticReducers(
+        final optimisticMerged = _applyOptimisticReducers(
           state.value ?? optimisticState.copyWith(pendingActions: 0),
         );
+        final current = updated == null
+            ? _applyCanceledReminder(optimisticMerged, reminderId)
+            : _mergeReminders(optimisticMerged, [updated]);
         state = AsyncData(
           current.copyWith(
             status: NotificationCenterStatus.success,
@@ -340,20 +346,30 @@ class NotificationCenterController
     }
   }
 
-  NotificationCenterState _removeReminder(
+  NotificationCenterState _applyCanceledReminder(
     NotificationCenterState state,
     String reminderId,
   ) {
-    final upcoming = [
-      for (final reminder in state.upcoming)
-        if (reminder.reminderId != reminderId) reminder,
-    ];
-    final past = [
-      for (final reminder in state.past)
-        if (reminder.reminderId != reminderId) reminder,
-    ];
+    final allReminders = [...state.upcoming, ...state.past];
+    PolicyReminder? target;
+    for (final reminder in allReminders) {
+      if (reminder.reminderId == reminderId) {
+        target = reminder;
+        break;
+      }
+    }
 
-    return state.copyWith(upcoming: upcoming, past: past);
+    if (target == null) return state;
+
+    final now = DateTime.now().toUtc();
+    final canceledReminder = target.copyWith(
+      status: PolicyReminderStatus.canceled,
+      isActive: false,
+      canceledAt: target.canceledAt ?? now,
+      updatedAt: now,
+    );
+
+    return _mergeReminders(state, [canceledReminder]);
   }
 
   NotificationCenterState _mergeReminders(

--- a/lib/features/policy_new/application/controllers/policy_reminder_controller.dart
+++ b/lib/features/policy_new/application/controllers/policy_reminder_controller.dart
@@ -237,21 +237,27 @@ class PolicyReminderController
   }
 
   String _messageForFailure(ScheduleFailure failure) {
+    final codeLabel = failure.code?.label;
+    String withCode(String message) {
+      if (codeLabel == null) return message;
+      return '[$codeLabel] $message';
+    }
+
     switch (failure.type) {
       case ScheduleFailureType.permissionDenied:
-        return '알림 권한이 꺼져 있어 예약에 실패했어요. 설정에서 권한을 허용해주세요.';
+        return withCode('알림 권한이 꺼져 있어 예약에 실패했어요. 설정에서 권한을 허용해주세요.');
       case ScheduleFailureType.invalidDate:
         if (failure.message.isNotEmpty) {
-          return failure.message;
+          return withCode(failure.message);
         }
-        return '이미 지난 시각에는 알림을 설정할 수 없습니다.';
+        return withCode('이미 지난 시각에는 알림을 설정할 수 없습니다.');
       case ScheduleFailureType.gatewayError:
       case ScheduleFailureType.idCollision:
       case ScheduleFailureType.unknown:
         if (failure.message.isNotEmpty) {
-          return failure.message;
+          return withCode(failure.message);
         }
-        return '알 수 없는 이유로 알림을 예약하지 못했어요. 잠시 후 다시 시도해주세요.';
+        return withCode('알 수 없는 이유로 알림을 예약하지 못했어요. 잠시 후 다시 시도해주세요.');
     }
   }
 

--- a/lib/features/policy_new/application/gateways/notification_gateway_impl.dart
+++ b/lib/features/policy_new/application/gateways/notification_gateway_impl.dart
@@ -151,6 +151,7 @@ class FlutterLocalNotificationGateway implements NotificationGateway {
         const ScheduleFailure(
           type: ScheduleFailureType.permissionDenied,
           message: 'Notification permission denied',
+          code: ScheduleFailureCode.permissionDenied,
         ),
         isDuplicate: hadExisting,
       );
@@ -165,6 +166,7 @@ class FlutterLocalNotificationGateway implements NotificationGateway {
         const ScheduleFailure(
           type: ScheduleFailureType.invalidDate,
           message: 'Scheduled time is already in the past',
+          code: ScheduleFailureCode.pastTime,
         ),
         isDuplicate: hadExisting,
       );
@@ -202,6 +204,7 @@ class FlutterLocalNotificationGateway implements NotificationGateway {
         ScheduleFailure(
           type: ScheduleFailureType.gatewayError,
           message: 'Failed to schedule notification: $error',
+          code: ScheduleFailureCode.internalException,
         ),
       );
     }
@@ -224,6 +227,7 @@ class FlutterLocalNotificationGateway implements NotificationGateway {
         ScheduleFailure(
           type: ScheduleFailureType.gatewayError,
           message: 'Failed to cancel notification: $error',
+          code: ScheduleFailureCode.internalException,
         ),
       );
     }
@@ -247,6 +251,7 @@ class FlutterLocalNotificationGateway implements NotificationGateway {
         ScheduleFailure(
           type: ScheduleFailureType.gatewayError,
           message: 'Failed to cancel notifications: $error',
+          code: ScheduleFailureCode.internalException,
         ),
       );
     }

--- a/lib/features/policy_new/application/services/policy_reminder_service.dart
+++ b/lib/features/policy_new/application/services/policy_reminder_service.dart
@@ -79,6 +79,7 @@ class PolicyReminderService {
             type: ScheduleFailureType.unknown,
             message:
                 '알림 예약 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요. ($e)',
+            code: ScheduleFailureCode.internalException,
           ),
         );
       }
@@ -103,6 +104,7 @@ class PolicyReminderService {
       ScheduleFailure(
         type: ScheduleFailureType.unknown,
         message: 'Scheduling failed with no result',
+        code: ScheduleFailureCode.internalException,
       ),
     );
     final failure = result ?? fallback;
@@ -145,6 +147,7 @@ class PolicyReminderService {
             failure: const ScheduleFailure(
               type: ScheduleFailureType.invalidDate,
               message: '마감된 정책은 알림을 설정할 수 없어요.',
+              code: ScheduleFailureCode.pastTime,
             ),
           ),
         );
@@ -161,6 +164,7 @@ class PolicyReminderService {
             failure: const ScheduleFailure(
               type: ScheduleFailureType.permissionDenied,
               message: 'Notification environment not ready',
+              code: ScheduleFailureCode.permissionDenied,
             ),
           ),
         );
@@ -194,6 +198,7 @@ class PolicyReminderService {
         final failure = ScheduleFailure(
           type: ScheduleFailureType.invalidDate,
           message: '신청 기간 정보가 없어 알림을 설정할 수 없습니다.',
+          code: ScheduleFailureCode.invalidPolicy,
         );
         failures.add(
           ReminderMutationFailure(
@@ -212,6 +217,7 @@ class PolicyReminderService {
             failure: const ScheduleFailure(
               type: ScheduleFailureType.invalidDate,
               message: '이미 지난 시각이라 알림을 설정할 수 없어요.',
+              code: ScheduleFailureCode.pastTime,
             ),
           ),
         );
@@ -242,6 +248,7 @@ class PolicyReminderService {
           const ScheduleFailure(
             type: ScheduleFailureType.unknown,
             message: '알림 예약 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+            code: ScheduleFailureCode.internalException,
           ),
         );
         logger.warn(
@@ -254,6 +261,7 @@ class PolicyReminderService {
             const ScheduleFailure(
               type: ScheduleFailureType.unknown,
               message: 'Unknown scheduling failure',
+              code: ScheduleFailureCode.internalException,
             );
         failures.add(
           ReminderMutationFailure(
@@ -404,6 +412,7 @@ class PolicyReminderService {
           ScheduleFailure(
             type: ScheduleFailureType.permissionDenied,
             message: 'Notification environment not ready',
+            code: ScheduleFailureCode.permissionDenied,
           ),
         ],
       );
@@ -425,6 +434,7 @@ class PolicyReminderService {
           ScheduleFailure(
             type: ScheduleFailureType.unknown,
             message: '알림 동기화에 실패했습니다.',
+            code: ScheduleFailureCode.internalException,
           ),
         ],
       );
@@ -450,6 +460,7 @@ class PolicyReminderService {
                 const ScheduleFailure(
                   type: ScheduleFailureType.unknown,
                   message: 'Unknown cancellation failure during sync',
+                  code: ScheduleFailureCode.internalException,
                 ),
           );
         } else {
@@ -484,6 +495,7 @@ class PolicyReminderService {
           const ScheduleFailure(
             type: ScheduleFailureType.unknown,
             message: '알림 동기화 중 오류가 발생했습니다.',
+            code: ScheduleFailureCode.internalException,
           ),
         );
         logger.warn('Reschedule threw for ${reminder.reminderId}: $e\n$st');
@@ -494,6 +506,7 @@ class PolicyReminderService {
               const ScheduleFailure(
                 type: ScheduleFailureType.unknown,
                 message: 'Unknown scheduling failure during sync',
+                code: ScheduleFailureCode.internalException,
               ),
         );
         logger.warn(

--- a/lib/features/policy_new/domain/values/schedule_result.dart
+++ b/lib/features/policy_new/domain/values/schedule_result.dart
@@ -28,12 +28,25 @@ enum ScheduleFailureType {
   unknown,
 }
 
+enum ScheduleFailureCode {
+  permissionDenied('E_PERMISSION_DENIED'),
+  pastTime('E_PAST_TIME'),
+  invalidPolicy('E_INVALID_POLICY'),
+  internalException('E_INTERNAL_EXCEPTION');
+
+  const ScheduleFailureCode(this.label);
+
+  final String label;
+}
+
 class ScheduleFailure {
   const ScheduleFailure({
     required this.type,
     required this.message,
+    this.code,
   });
 
   final ScheduleFailureType type;
   final String message;
+  final ScheduleFailureCode? code;
 }


### PR DESCRIPTION
## Summary
- 알림 스케줄 실패 원인에 E_* 코드 메타데이터를 부여하고 사용자 메시지에 노출
- 취소된 알림을 삭제하지 않고 상태를 보존하도록 알림 센터 흐름을 수정
- 게이트웨이와 리마인더 동기화 로직에 공통 실패 코드 적용

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934826f86548324a9b24bc6ebcf0cd1)