### PR TITLE
정책 피드 쿼리 상태 통합 및 캐시 개선

### DIFF
--- a/lib/features/policy_new/application/controllers/base_feed_controller.dart
+++ b/lib/features/policy_new/application/controllers/base_feed_controller.dart
@@ -6,8 +6,10 @@ import '../../domain/values/policy_feed_type.dart';
 import '../filters/policy_filter_ui_state.dart';
 import '../../../../application/notifiers/region_notifier.dart';
 import 'policy_event_bus.dart';
+import 'policy_feed_memory_cache.dart';
 import 'policy_paging_state.dart';
 import 'policy_query_engine.dart';
+import 'policy_query_state.dart';
 
 abstract class BasePolicyFeedController
     extends StateNotifier<PolicyPagingState> {
@@ -15,17 +17,19 @@ abstract class BasePolicyFeedController
     required this.ref,
     required this.feedType,
     required this.queryEngine,
-  }) : super(const PolicyPagingState.initial()) {
+    required PolicyFeedMemoryCache memoryCache,
+  })  : _memoryCache = memoryCache,
+        super(const PolicyPagingState.initial()) {
     ref.listen<PolicyFilterUiState>(
       policyFilterUiStateProvider,
-      (_, next) => forceReload(next),
+      (_, __) => _onQueryChanged(),
     );
 
     ref.listen<String?>(
       regionProvider,
       (previous, next) {
         if (previous != next) {
-          onRegionChanged();
+          _reloadCurrentQuery(force: true);
         }
       },
     );
@@ -36,6 +40,7 @@ abstract class BasePolicyFeedController
         if (next == null) return;
         switch (next.type) {
           case PolicyEventType.cacheCleared:
+            _memoryCache.evictFeed(feedType);
             _resetPaging();
             break;
           case PolicyEventType.refreshRequested:
@@ -73,6 +78,9 @@ abstract class BasePolicyFeedController
   final Ref ref;
   final PolicyFeedType feedType;
   final PolicyQueryEngine queryEngine;
+  final PolicyFeedMemoryCache _memoryCache;
+
+  PolicyQueryState? _currentQuery;
 
   int _page = 1;
   bool _isLoading = false;
@@ -86,16 +94,16 @@ abstract class BasePolicyFeedController
   void _resetPaging() {
     _page = 1;
     _isLoading = false;
+    _currentQuery = null;
     state = const PolicyPagingState.initial();
   }
 
   Future<void> ensureInitialized() async {
     if (state.items.isNotEmpty || state.isLoading) return;
-    await loadFirstPage();
+    await _reloadCurrentQuery();
   }
 
-  Future<void> loadFirstPage() async =>
-      reload(ref.read(policyFilterUiStateProvider));
+  Future<void> loadFirstPage() async => _reloadCurrentQuery(force: true);
 
   Future<void> loadNextPage() async {
     if (_isLoading) return;
@@ -103,12 +111,19 @@ abstract class BasePolicyFeedController
       debugPrint('[PAGING-LAST-PAGE:NO-OP] feed=${feedType.name}, page=$_page');
       return;
     }
-    if (!_shouldFetchForFeedType(ref.read(policyFilterUiStateProvider))) return;
+
+    final queryState = _currentQuery ?? queryEngine.buildQueryState(feedType);
+
+    if (!_shouldFetchForFeedType(queryState.query)) return;
 
     _isLoading = true;
     final nextPage = _page + 1;
 
-    final result = await queryEngine.fetch(feedType, page: nextPage);
+    final result = await queryEngine.fetch(
+      feedType,
+      page: nextPage,
+      queryState: queryState,
+    );
 
     result.fold(
       onSuccess: (list) {
@@ -118,6 +133,7 @@ abstract class BasePolicyFeedController
           hasMore: list.length == queryEngine.pageSize,
         );
         _page = nextPage;
+        _memoryCache.save(feedType, queryState, state, page: _page);
       },
       onFailure: (failure) {
         state = PolicyPagingState.error(failure);
@@ -128,39 +144,103 @@ abstract class BasePolicyFeedController
   }
 
   Future<void> refresh() async {
-    await reload(ref.read(policyFilterUiStateProvider));
+    await _reloadCurrentQuery(force: true);
   }
 
-  /// 지역 등 주요 조건 변경 시 사용: 페이징 초기화 후 첫 페이지 재로딩
-  Future<void> onRegionChanged() async {
-    await reload(ref.read(policyFilterUiStateProvider));
+  bool _shouldFetchForFeedType(PolicyQuery query) {
+    if (feedType != PolicyFeedType.search) {
+      return true;
+    }
+
+    final keyword = query.keyword?.trim() ?? '';
+    final hasKeyword = keyword.length >= 2;
+    final hasTags = query.tags.isNotEmpty || query.filter.tags.isNotEmpty;
+
+    return hasKeyword || hasTags;
   }
 
-  Future<void> reload(PolicyFilterUiState filter) async {
-    await forceReload(filter);
+  Future<void> _onQueryChanged() async {
+    final queryState = queryEngine.buildQueryState(feedType);
+    if (_currentQuery?.hash == queryState.hash) {
+      _restoreFromCache(queryState);
+      return;
+    }
+
+    _currentQuery = queryState;
+    await _restoreOrFetch(queryState);
   }
 
-  Future<void> forceReload(PolicyFilterUiState filter) async {
+  Future<void> _reloadCurrentQuery({bool force = false}) async {
+    final queryState = queryEngine.buildQueryState(feedType);
+    if (!force && _currentQuery?.hash == queryState.hash) {
+      _restoreFromCache(queryState);
+      return;
+    }
+
+    _currentQuery = queryState;
+    await _fetchFirstPage(queryState);
+  }
+
+  Future<void> _restoreOrFetch(PolicyQueryState queryState) async {
+    if (_restoreFromCache(queryState)) {
+      return;
+    }
+
+    await _fetchFirstPage(queryState);
+  }
+
+  bool _restoreFromCache(PolicyQueryState queryState) {
+    final cached = _memoryCache.restore(feedType, queryState.hash);
+    if (cached == null) return false;
+
+    _page = cached.page;
+    _currentQuery = queryState;
+    _isLoading = false;
+    state = cached.state;
+    return true;
+  }
+
+  Future<void> _fetchFirstPage(PolicyQueryState queryState) async {
     _page = 1;
-    _isLoading = true;
-    state = const PolicyPagingState.loading();
+    await _fetchPage(queryState, page: _page, append: false);
+  }
 
-    final shouldFetch = _shouldFetchForFeedType(filter);
+  Future<void> _fetchPage(
+    PolicyQueryState queryState, {
+    required int page,
+    required bool append,
+  }) async {
+    if (_isLoading) return;
+
+    final shouldFetch = _shouldFetchForFeedType(queryState.query);
 
     if (!shouldFetch) {
       _isLoading = false;
       state = const PolicyPagingState.initial();
+      _memoryCache.save(feedType, queryState, state, page: 1);
       return;
     }
 
-    final result = await queryEngine.fetch(feedType, page: _page);
+    _isLoading = true;
+    if (!append) {
+      state = const PolicyPagingState.loading();
+    }
+
+    final result = await queryEngine.fetch(
+      feedType,
+      page: page,
+      queryState: queryState,
+    );
 
     result.fold(
       onSuccess: (list) {
+        final merged = append ? [...state.items, ...list] : list;
         state = PolicyPagingState.data(
-          items: list,
+          items: merged,
           hasMore: list.length == queryEngine.pageSize,
         );
+        _page = page;
+        _memoryCache.save(feedType, queryState, state, page: _page);
       },
       onFailure: (failure) {
         state = PolicyPagingState.error(failure);
@@ -168,17 +248,5 @@ abstract class BasePolicyFeedController
     );
 
     _isLoading = false;
-  }
-
-  bool _shouldFetchForFeedType(PolicyFilterUiState filter) {
-    if (feedType != PolicyFeedType.search) {
-      return true;
-    }
-
-    final keyword = filter.keyword.trim();
-    final hasKeyword = keyword.length >= 2;
-    final hasTags = filter.tags.isNotEmpty;
-
-    return hasKeyword || hasTags;
   }
 }

--- a/lib/features/policy_new/application/controllers/policy_feed_controllers.dart
+++ b/lib/features/policy_new/application/controllers/policy_feed_controllers.dart
@@ -5,6 +5,7 @@ class RecommendFeedController extends BasePolicyFeedController {
   RecommendFeedController({
     required super.ref,
     required super.queryEngine,
+    required super.memoryCache,
   }) : super(feedType: PolicyFeedType.recommend);
 }
 
@@ -12,6 +13,7 @@ class AllFeedController extends BasePolicyFeedController {
   AllFeedController({
     required super.ref,
     required super.queryEngine,
+    required super.memoryCache,
   }) : super(feedType: PolicyFeedType.all);
 }
 
@@ -19,6 +21,7 @@ class RegionFeedController extends BasePolicyFeedController {
   RegionFeedController({
     required super.ref,
     required super.queryEngine,
+    required super.memoryCache,
   }) : super(feedType: PolicyFeedType.region);
 }
 
@@ -26,6 +29,7 @@ class SearchFeedController extends BasePolicyFeedController {
   SearchFeedController({
     required super.ref,
     required super.queryEngine,
+    required super.memoryCache,
   }) : super(feedType: PolicyFeedType.search);
 }
 
@@ -33,5 +37,6 @@ class FavoriteFeedController extends BasePolicyFeedController {
   FavoriteFeedController({
     required super.ref,
     required super.queryEngine,
+    required super.memoryCache,
   }) : super(feedType: PolicyFeedType.favorite);
 }

--- a/lib/features/policy_new/application/controllers/policy_feed_memory_cache.dart
+++ b/lib/features/policy_new/application/controllers/policy_feed_memory_cache.dart
@@ -1,0 +1,43 @@
+import '../../domain/values/policy_feed_type.dart';
+import 'policy_paging_state.dart';
+import 'policy_query_state.dart';
+
+class PolicyFeedCacheEntry {
+  const PolicyFeedCacheEntry({
+    required this.query,
+    required this.state,
+    required this.page,
+  });
+
+  final PolicyQueryState query;
+  final PolicyPagingState state;
+  final int page;
+}
+
+class PolicyFeedMemoryCache {
+  final Map<PolicyFeedType, Map<String, PolicyFeedCacheEntry>> _store = {};
+
+  PolicyFeedCacheEntry? restore(PolicyFeedType feedType, String hash) {
+    final scope = _store[feedType];
+    if (scope == null) return null;
+    return scope[hash];
+  }
+
+  void save(PolicyFeedType feedType, PolicyQueryState query, PolicyPagingState state,
+      {required int page}) {
+    final scope = _store.putIfAbsent(feedType, () => {});
+    scope[query.hash] = PolicyFeedCacheEntry(
+      query: query,
+      state: state,
+      page: page,
+    );
+  }
+
+  void evictFeed(PolicyFeedType feedType) {
+    _store.remove(feedType);
+  }
+
+  void clear() {
+    _store.clear();
+  }
+}

--- a/lib/features/policy_new/application/controllers/policy_query_engine.dart
+++ b/lib/features/policy_new/application/controllers/policy_query_engine.dart
@@ -5,6 +5,7 @@ import '../../domain/values/policy_feed_type.dart';
 import '../../domain/values/policy_result.dart';
 import '../providers.dart';
 import 'policy_query_orchestrator.dart';
+import 'policy_query_state.dart';
 
 class PolicyQueryEngine {
   PolicyQueryEngine(this.ref);
@@ -13,14 +14,20 @@ class PolicyQueryEngine {
 
   int get pageSize => ref.read(policySettingsProvider).pageSize;
 
+  PolicyQueryState buildQueryState(PolicyFeedType feedType) {
+    return ref.read(policyQueryProvider(feedType));
+  }
+
   PolicyQueryOrchestrator get _orchestrator =>
       ref.read(policyQueryOrchestratorProvider);
 
   Future<PolicyResult<List<Policy>>> fetch(
     PolicyFeedType feedType, {
     required int page,
+    PolicyQueryState? queryState,
   }) async {
-    final query = _orchestrator.buildQuery(feedType);
+    final query =
+        queryState?.query ?? _orchestrator.buildQuery(feedType).normalize();
     final repo = ref.read(policyRepositoryProvider);
 
     return repo.fetchPoliciesByQuery(

--- a/lib/features/policy_new/application/controllers/policy_query_state.dart
+++ b/lib/features/policy_new/application/controllers/policy_query_state.dart
@@ -1,0 +1,15 @@
+import '../../domain/values/policy_query.dart';
+
+class PolicyQueryState {
+  const PolicyQueryState({
+    required this.query,
+    required this.hash,
+    required this.summary,
+    required this.conditionSummary,
+  });
+
+  final PolicyQuery query;
+  final String hash;
+  final String summary;
+  final String conditionSummary;
+}

--- a/lib/features/policy_new/application/filters/policy_filter_summary.dart
+++ b/lib/features/policy_new/application/filters/policy_filter_summary.dart
@@ -1,0 +1,97 @@
+import '../../domain/values/policy_category.dart';
+import '../../domain/values/policy_sort.dart';
+import 'policy_filter_ui_state.dart';
+
+String buildPolicyFilterSummary(PolicyFilterUiState filter) {
+  final buffer = StringBuffer(filter.regionSummary);
+
+  final keyword = filter.keyword.trim();
+  if (keyword.isNotEmpty) {
+    buffer.write(' · 검색어 "$keyword"');
+  }
+
+  if (filter.tags.isNotEmpty) {
+    buffer.write(' · 태그(${filter.tags.join(', ')})');
+  }
+
+  if (filter.category != null) {
+    buffer.write(' · ${_categoryLabel(filter.category!)}');
+  }
+
+  if (filter.showOnlyOngoing) {
+    buffer.write(' · 모집중만');
+  }
+
+  if (filter.showOnlyOnline) {
+    buffer.write(' · 온라인 참여');
+  }
+
+  buffer.write(' · ${_sortLabel(filter.sort)}');
+
+  return buffer.toString();
+}
+
+String buildPolicyFilterConditionSummary(PolicyFilterUiState filter) {
+  final parts = <String>[
+    filter.regionSummary,
+  ];
+
+  final keyword = filter.keyword.trim();
+  if (keyword.isNotEmpty) {
+    parts.add('검색어 "$keyword"');
+  }
+
+  if (filter.tags.isNotEmpty) {
+    parts.add('태그(${filter.tags.join(', ')})');
+  }
+
+  if (filter.category != null) {
+    parts.add(_categoryLabel(filter.category!));
+  }
+
+  if (filter.showOnlyOngoing) {
+    parts.add('모집중만');
+  }
+
+  if (filter.showOnlyOnline) {
+    parts.add('온라인 참여');
+  }
+
+  parts.add(_sortLabel(filter.sort));
+
+  return parts.join(' · ');
+}
+
+String _categoryLabel(PolicyCategory category) {
+  switch (category) {
+    case PolicyCategory.employment:
+      return '취업';
+    case PolicyCategory.startup:
+      return '창업';
+    case PolicyCategory.housing:
+      return '주거';
+    case PolicyCategory.education:
+      return '교육';
+    case PolicyCategory.life:
+      return '생활';
+    case PolicyCategory.welfare:
+      return '복지';
+    case PolicyCategory.culture:
+      return '문화';
+    case PolicyCategory.other:
+      return '기타';
+  }
+}
+
+String _sortLabel(PolicySortOption sort) {
+  switch (sort) {
+    case PolicySortOption.recommendation:
+      return '추천순';
+    case PolicySortOption.latest:
+      return '최신순';
+    case PolicySortOption.deadline:
+      return '마감임박';
+    case PolicySortOption.popularity:
+      return '인기순';
+  }
+}

--- a/lib/features/policy_new/application/providers.dart
+++ b/lib/features/policy_new/application/providers.dart
@@ -47,7 +47,9 @@ import 'services/policy_favorite_service.dart';
 import 'services/policy_reminder_scheduler.dart';
 import 'services/policy_reminder_service.dart';
 import 'filters/policy_filter_ui_state.dart';
+import 'filters/policy_filter_summary.dart';
 import 'models/user_collections.dart';
+import 'controllers/policy_feed_memory_cache.dart';
 import '../data/cache/policy_cache.dart';
 import '../data/repositories/department_repository_impl.dart';
 import '../data/repositories/institution_repository_impl.dart';
@@ -65,6 +67,7 @@ import '../data/sources/policy_remote_source_mock.dart';
 import '../data/sources/compare_local_data_source.dart';
 import '../../../application/di.dart' as app_di;
 import 'recommendation/user_profile_service.dart';
+import 'controllers/policy_query_state.dart';
 
 class ConsolePolicyLogger implements PolicyLogger {
   @override
@@ -234,6 +237,18 @@ final departmentListProvider = FutureProvider.family<List<Department>, String>(
 
 final policyCacheProvider = Provider((ref) => PolicyCache());
 
+final policyFeedMemoryCacheProvider = Provider<PolicyFeedMemoryCache>((ref) {
+  final cache = PolicyFeedMemoryCache();
+
+  ref.listen<PolicyEvent?>(policyEventBusProvider, (previous, next) {
+    if (next?.type == PolicyEventType.cacheCleared) {
+      cache.clear();
+    }
+  });
+
+  return cache;
+});
+
 final policyRepositoryProvider = Provider<PolicyRepository>((ref) {
   return PolicyRepositoryImpl(
     remote: ref.watch(activePolicyRemoteProvider),
@@ -302,6 +317,7 @@ final recommendFeedControllerProvider =
   (ref) => RecommendFeedController(
     ref: ref,
     queryEngine: ref.read(policyQueryEngineProvider),
+    memoryCache: ref.read(policyFeedMemoryCacheProvider),
   ),
 );
 
@@ -310,6 +326,7 @@ final allFeedControllerProvider =
   (ref) => AllFeedController(
     ref: ref,
     queryEngine: ref.read(policyQueryEngineProvider),
+    memoryCache: ref.read(policyFeedMemoryCacheProvider),
   ),
 );
 
@@ -318,6 +335,7 @@ final regionFeedControllerProvider =
   (ref) => RegionFeedController(
     ref: ref,
     queryEngine: ref.read(policyQueryEngineProvider),
+    memoryCache: ref.read(policyFeedMemoryCacheProvider),
   ),
 );
 
@@ -326,6 +344,7 @@ final searchFeedControllerProvider =
   (ref) => SearchFeedController(
     ref: ref,
     queryEngine: ref.read(policyQueryEngineProvider),
+    memoryCache: ref.read(policyFeedMemoryCacheProvider),
   ),
 );
 
@@ -334,6 +353,7 @@ final favoriteFeedControllerProvider =
   (ref) => FavoriteFeedController(
     ref: ref,
     queryEngine: ref.read(policyQueryEngineProvider),
+    memoryCache: ref.read(policyFeedMemoryCacheProvider),
   ),
 );
 
@@ -393,16 +413,24 @@ final notificationCenterControllerProvider = StateNotifierProvider<
   (ref) => NotificationCenterController(ref: ref),
 );
 
-final policyQueryProvider = Provider.family<PolicyQuery, PolicyFeedType>(
+final policyQueryProvider = Provider.family<PolicyQueryState, PolicyFeedType>(
   (ref, feedType) {
+    final filter = ref.watch(policyFilterUiStateProvider);
+
     // dependencies to rebuild query on changes
-    ref.watch(policyFilterUiStateProvider);
     ref.watch(userProfileProvider);
     ref.watch(policyBehaviorTrackerProvider);
     ref.watch(favoriteIdsProvider);
     ref.watch(compareRepositoryProvider);
 
     final orchestrator = ref.read(policyQueryOrchestratorProvider);
-    return orchestrator.buildQuery(feedType);
+    final query = orchestrator.buildQuery(feedType);
+
+    return PolicyQueryState(
+      query: query,
+      hash: query.cacheScopeKey,
+      summary: buildPolicyFilterSummary(filter),
+      conditionSummary: buildPolicyFilterConditionSummary(filter),
+    );
   },
 );

--- a/lib/features/policy_new/presentation/tabs/policy_feed_tab.dart
+++ b/lib/features/policy_new/presentation/tabs/policy_feed_tab.dart
@@ -5,7 +5,6 @@ import '../../application/filters/policy_filter_ui_state.dart';
 import '../../application/providers.dart';
 import '../../domain/values/policy_feed_type.dart';
 import '../../domain/values/policy_category.dart';
-import '../../domain/values/policy_sort.dart';
 import '../compare/widgets/compare_entry_bar.dart';
 import '../widgets/policy_feed_list_view.dart';
 import '../compare/policy_compare_screen.dart';
@@ -52,12 +51,13 @@ class _PolicyFeedTabState extends ConsumerState<PolicyFeedTab> {
   @override
   Widget build(BuildContext context) {
     final filter = ref.watch(policyFilterUiStateProvider);
+    final queryState = ref.watch(policyQueryProvider(widget.feedType));
     final compareCount = ref.watch(compareRepositoryProvider).ids.length;
     final showCompareBar =
         widget.feedType == PolicyFeedType.favorite && compareCount > 0;
 
-    final summaryText = _buildSummary(filter);
-    final filterKey = _filterKey(filter);
+    final summaryText = queryState.summary;
+    final filterKey = queryState.hash;
 
     return Scaffold(
       body: AppScreenContainer(
@@ -122,66 +122,6 @@ class _PolicyFeedTabState extends ConsumerState<PolicyFeedTab> {
     );
   }
 
-  String _buildSummary(PolicyFilterUiState filter) {
-    final buffer = StringBuffer();
-    buffer.write(filter.regionSummary);
-    if (filter.keyword.isNotEmpty) {
-      buffer.write(' · "${filter.keyword}"');
-    }
-    if (filter.category != null) {
-      buffer.write(' · ${_categoryLabel(filter.category!)}');
-    }
-    if (filter.showOnlyOngoing) {
-      buffer.write(' · 진행중만');
-    }
-    switch (filter.sort) {
-      case PolicySortOption.recommendation:
-        buffer.write(' · 추천순');
-        break;
-      case PolicySortOption.latest:
-        buffer.write(' · 최신순');
-        break;
-      case PolicySortOption.deadline:
-        buffer.write(' · 마감임박');
-        break;
-      case PolicySortOption.popularity:
-        buffer.write(' · 인기순');
-        break;
-    }
-    return buffer.toString();
-  }
-
-  String _filterKey(PolicyFilterUiState filter) {
-    return [
-      filter.regionSummary,
-      filter.keyword,
-      filter.category?.name ?? '',
-      filter.showOnlyOngoing.toString(),
-      filter.sort.name,
-      filter.tags.join(','),
-    ].join('|');
-  }
-
-  String _categoryLabel(PolicyCategory category) {
-    switch (category) {
-      case PolicyCategory.employment:
-        return '취업';
-      case PolicyCategory.startup:
-        return '창업';
-      case PolicyCategory.housing:
-        return '주거';
-      case PolicyCategory.education:
-        return '교육';
-      case PolicyCategory.life:
-        return '생활';
-      case PolicyCategory.welfare:
-        return '복지';
-      case PolicyCategory.culture:
-        return '문화';
-      case PolicyCategory.other:
-        return '기타';
-    }
-  }
 }
 
 class _SelectedFilterBadges extends StatelessWidget {

--- a/lib/features/policy_new/presentation/widgets/policy_feed_list_view.dart
+++ b/lib/features/policy_new/presentation/widgets/policy_feed_list_view.dart
@@ -69,6 +69,8 @@ class _PolicyFeedListViewState extends ConsumerState<PolicyFeedListView>
   Widget build(BuildContext context) {
     super.build(context);
     final ui = ref.watch(policyFilterUiStateProvider);
+    final queryState = ref.watch(policyQueryProvider(widget.feedType));
+    final query = queryState.query;
     final (state, notifier) = _useController();
     _latestState = state;
     _latestController = notifier;
@@ -77,10 +79,10 @@ class _PolicyFeedListViewState extends ConsumerState<PolicyFeedListView>
       _isLoadingMore = false;
     }
 
-    final keyword = ui.keyword.trim();
+    final keyword = query.keyword?.trim() ?? '';
     final hasKeyword = keyword.isNotEmpty;
     final isKeywordTooShort = hasKeyword && keyword.length < 2;
-    final hasTags = ui.tags.isNotEmpty;
+    final hasTags = query.tags.isNotEmpty || query.filter.tags.isNotEmpty;
 
     final shouldShowSearchGuide =
         widget.feedType == PolicyFeedType.search &&
@@ -107,11 +109,14 @@ class _PolicyFeedListViewState extends ConsumerState<PolicyFeedListView>
     } else if (!state.isLoading && state.items.isEmpty) {
       final emptyMessage = widget.feedType == PolicyFeedType.favorite
           ? '즐겨찾기한 정책이 없습니다.\n마음에 드는 정책의 하트 버튼을 눌러 저장해보세요.'
-          : '표시할 정책이 없습니다.\n필터나 검색 조건을 바꿔보세요.';
+          : '조건에 맞는 정책이 없습니다.\n${queryState.conditionSummary} 조건을 조정해보세요.';
 
       content = PolicyListEmpty(
         key: const ValueKey('policy-list-empty'),
         message: emptyMessage,
+        summary: widget.feedType == PolicyFeedType.favorite
+            ? null
+            : queryState.summary,
       );
     } else {
       content = RefreshIndicator(

--- a/lib/features/policy_new/presentation/widgets/policy_list_empty.dart
+++ b/lib/features/policy_new/presentation/widgets/policy_list_empty.dart
@@ -4,18 +4,33 @@ class PolicyListEmpty extends StatelessWidget {
   const PolicyListEmpty({
     super.key,
     this.message = '표시할 정책이 없습니다.\n필터나 검색 조건을 바꿔보세요.',
+    this.summary,
   });
 
   final String message;
+  final String? summary;
 
   @override
   Widget build(BuildContext context) {
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(32),
-        child: Text(
-          message,
-          textAlign: TextAlign.center,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              message,
+              textAlign: TextAlign.center,
+            ),
+            if (summary != null && summary!.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              Text(
+                '현재 조건: $summary',
+                style: Theme.of(context).textTheme.bodySmall,
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ],
         ),
       ),
     );

--- a/test/features/policy_new/application/policy_feed_memory_cache_test.dart
+++ b/test/features/policy_new/application/policy_feed_memory_cache_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:youth_road_app/features/policy_new/application/controllers/policy_feed_memory_cache.dart';
+import 'package:youth_road_app/features/policy_new/application/controllers/policy_paging_state.dart';
+import 'package:youth_road_app/features/policy_new/application/controllers/policy_query_state.dart';
+import 'package:youth_road_app/features/policy_new/domain/entities/policy.dart';
+import 'package:youth_road_app/features/policy_new/domain/values/policy_feed_type.dart';
+import 'package:youth_road_app/features/policy_new/domain/values/policy_filter.dart';
+import 'package:youth_road_app/features/policy_new/domain/values/policy_query.dart';
+import 'package:youth_road_app/features/policy_new/domain/values/policy_sort.dart';
+
+PolicyQueryState _buildQueryState(String hash, {PolicyFeedType feedType = PolicyFeedType.all}) {
+  return PolicyQueryState(
+    query: PolicyQuery(
+      filter: const PolicyFilter(),
+      feedType: feedType,
+      sort: PolicySortOption.latest,
+    ),
+    hash: hash,
+    summary: '요약',
+    conditionSummary: '조건',
+  );
+}
+
+void main() {
+  group('PolicyFeedMemoryCache', () {
+    test('동일한 해시로 저장된 상태를 복원한다', () {
+      final cache = PolicyFeedMemoryCache();
+      final state = PolicyPagingState.data(
+        items: const <Policy>[],
+        hasMore: true,
+      );
+      final queryState = _buildQueryState('q1');
+
+      cache.save(PolicyFeedType.all, queryState, state, page: 2);
+
+      final restored = cache.restore(PolicyFeedType.all, 'q1');
+
+      expect(restored, isNotNull);
+      expect(restored!.page, 2);
+      expect(restored.state.items, isEmpty);
+      expect(restored.query.hash, 'q1');
+    });
+
+    test('피드 단위로 캐시를 개별 삭제할 수 있다', () {
+      final cache = PolicyFeedMemoryCache();
+      final state = PolicyPagingState.data(
+        items: const <Policy>[],
+        hasMore: false,
+      );
+
+      cache.save(
+        PolicyFeedType.all,
+        _buildQueryState('first'),
+        state,
+        page: 1,
+      );
+      cache.save(
+        PolicyFeedType.search,
+        _buildQueryState('second', feedType: PolicyFeedType.search),
+        state,
+        page: 1,
+      );
+
+      cache.evictFeed(PolicyFeedType.all);
+
+      expect(cache.restore(PolicyFeedType.all, 'first'), isNull);
+      expect(cache.restore(PolicyFeedType.search, 'second'), isNotNull);
+    });
+  });
+}

--- a/test/features/policy_new/application/policy_filter_summary_test.dart
+++ b/test/features/policy_new/application/policy_filter_summary_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:youth_road_app/features/policy_new/application/filters/policy_filter_summary.dart';
+import 'package:youth_road_app/features/policy_new/application/filters/policy_filter_ui_state.dart';
+import 'package:youth_road_app/features/policy_new/domain/values/policy_category.dart';
+import 'package:youth_road_app/features/policy_new/domain/values/policy_sort.dart';
+
+void main() {
+  group('PolicyFilterSummary', () {
+    test('요약 문자열에 선택된 조건이 포함된다', () {
+      const filter = PolicyFilterUiState(
+        keyword: '청년',
+        category: PolicyCategory.employment,
+        tags: ['태그1', '태그2'],
+        showOnlyOngoing: true,
+        showOnlyOnline: true,
+        sort: PolicySortOption.deadline,
+      );
+
+      final summary = buildPolicyFilterSummary(filter);
+
+      expect(summary, contains('검색어 "청년"'));
+      expect(summary, contains('태그(태그1, 태그2)'));
+      expect(summary, contains('취업'));
+      expect(summary, contains('모집중만'));
+      expect(summary, contains('온라인 참여'));
+      expect(summary, contains('마감임박'));
+    });
+
+    test('조건 요약은 지역과 검색어를 명시한다', () {
+      const filter = PolicyFilterUiState(
+        province: '경상북도',
+        city: '포항시',
+        keyword: '주거',
+        sort: PolicySortOption.popularity,
+      );
+
+      final conditionSummary = buildPolicyFilterConditionSummary(filter);
+
+      expect(conditionSummary, contains('경북 포항시'));
+      expect(conditionSummary, contains('검색어 "주거"'));
+      expect(conditionSummary, contains('인기순'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- 쿼리 파생 모델에 요약/해시 정보를 담아 피드 컨트롤러에서 캐시 기반으로 복원하고 동일 조건 요청을 건너뜁니다.
- 검색·필터 조건에 맞춘 빈 상태 메시지와 요약 문구를 노출하도록 UI를 보강했습니다.
- 쿼리 요약/메모리 캐시 유틸과 관련 단위 테스트를 추가했습니다.

## Testing
- flutter test test/features/policy_new/application/policy_filter_summary_test.dart *(환경에 flutter 명령이 없어 실행 불가)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69348440effc832481aa0999534252f3)