### PR TITLE
Implement UI reaction feedback for policy feeds

### DIFF
--- a/lib/features/policy_new/application/controllers/base_feed_controller.dart
+++ b/lib/features/policy_new/application/controllers/base_feed_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../domain/entities/policy.dart';
 import '../../domain/values/policy_event.dart';
 import '../../domain/values/policy_feed_type.dart';
 import '../filters/policy_filter_ui_state.dart';
@@ -10,6 +11,7 @@ import 'policy_feed_memory_cache.dart';
 import 'policy_paging_state.dart';
 import 'policy_query_engine.dart';
 import 'policy_query_state.dart';
+import 'ui_reaction_controller.dart';
 
 abstract class BasePolicyFeedController
     extends StateNotifier<PolicyPagingState> {
@@ -79,6 +81,8 @@ abstract class BasePolicyFeedController
   final PolicyFeedType feedType;
   final PolicyQueryEngine queryEngine;
   final PolicyFeedMemoryCache _memoryCache;
+  UIReactionController get _reaction =>
+      ref.read(uiReactionControllerProvider(feedType).notifier);
 
   PolicyQueryState? _currentQuery;
 
@@ -162,6 +166,7 @@ abstract class BasePolicyFeedController
   Future<void> _onQueryChanged() async {
     final queryState = queryEngine.buildQueryState(feedType);
     if (_currentQuery?.hash == queryState.hash) {
+      _reaction.markRestored(queryState.hash);
       _restoreFromCache(queryState);
       return;
     }
@@ -173,6 +178,7 @@ abstract class BasePolicyFeedController
   Future<void> _reloadCurrentQuery({bool force = false}) async {
     final queryState = queryEngine.buildQueryState(feedType);
     if (!force && _currentQuery?.hash == queryState.hash) {
+      _reaction.markRestored(queryState.hash);
       _restoreFromCache(queryState);
       return;
     }
@@ -212,16 +218,23 @@ abstract class BasePolicyFeedController
   }) async {
     if (_isLoading) return;
 
+    final previousItems = List<Policy>.from(state.items);
+    final isInitialLoad = !append && previousItems.isEmpty;
+
     final shouldFetch = _shouldFetchForFeedType(queryState.query);
 
     if (!shouldFetch) {
       _isLoading = false;
       state = const PolicyPagingState.initial();
       _memoryCache.save(feedType, queryState, state, page: 1);
+      _reaction.markUnchanged(queryState.hash);
       return;
     }
 
     _isLoading = true;
+    if (!append) {
+      _reaction.markLoading(queryState.hash, isInitialLoad: isInitialLoad);
+    }
     if (!append) {
       state = const PolicyPagingState.loading();
     }
@@ -241,12 +254,28 @@ abstract class BasePolicyFeedController
         );
         _page = page;
         _memoryCache.save(feedType, queryState, state, page: _page);
+        _reaction.markResult(
+          queryHash: queryState.hash,
+          changed: !_areSameItems(previousItems, merged),
+        );
       },
       onFailure: (failure) {
         state = PolicyPagingState.error(failure);
+        _reaction.markFailure(
+          queryHash: queryState.hash,
+          message: failure.message,
+        );
       },
     );
 
     _isLoading = false;
+  }
+
+  bool _areSameItems(List<Policy> prev, List<Policy> next) {
+    if (prev.length != next.length) return false;
+    for (var i = 0; i < prev.length; i++) {
+      if (prev[i].id != next[i].id) return false;
+    }
+    return true;
   }
 }

--- a/lib/features/policy_new/application/controllers/ui_reaction_controller.dart
+++ b/lib/features/policy_new/application/controllers/ui_reaction_controller.dart
@@ -1,0 +1,229 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/values/policy_feed_type.dart';
+
+enum UIReactionPhase {
+  idle,
+  skeleton,
+  success,
+  unchanged,
+  failure,
+  confirmed,
+}
+
+@immutable
+class UIReactionState {
+  final UIReactionPhase phase;
+  final String message;
+  final String? queryHash;
+  final DateTime updatedAt;
+  final DateTime? lockUntil;
+
+  const UIReactionState({
+    this.phase = UIReactionPhase.idle,
+    this.message = '',
+    this.queryHash,
+    DateTime? updatedAt,
+    this.lockUntil,
+  }) : updatedAt = updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+
+  bool get isActive => phase != UIReactionPhase.idle;
+
+  bool get shouldHoldSkeleton {
+    if (lockUntil == null) return false;
+    return DateTime.now().isBefore(lockUntil!);
+  }
+
+  UIReactionState copyWith({
+    UIReactionPhase? phase,
+    String? message,
+    String? queryHash,
+    DateTime? updatedAt,
+    DateTime? lockUntil,
+  }) {
+    return UIReactionState(
+      phase: phase ?? this.phase,
+      message: message ?? this.message,
+      queryHash: queryHash ?? this.queryHash,
+      updatedAt: updatedAt ?? this.updatedAt,
+      lockUntil: lockUntil ?? this.lockUntil,
+    );
+  }
+}
+
+class UIReactionController extends StateNotifier<UIReactionState> {
+  UIReactionController({
+    required this.feedType,
+  }) : super(const UIReactionState());
+
+  final PolicyFeedType feedType;
+
+  static const _debounce = Duration(milliseconds: 320);
+  static const _holdSkeleton = Duration(milliseconds: 640);
+  static const _toastDuration = Duration(milliseconds: 1500);
+
+  Timer? _clearTimer;
+  Timer? _pendingTimer;
+  UIReactionPhase? _lastPhase;
+  String? _lastMessage;
+  DateTime? _lastEventAt;
+
+  void markLoading(String queryHash, {required bool isInitialLoad}) {
+    _cancelPending();
+    final now = DateTime.now();
+    if (_shouldDebounce(UIReactionPhase.skeleton, queryHash)) return;
+
+    state = UIReactionState(
+      phase: UIReactionPhase.skeleton,
+      message: '결과를 준비하고 있어요...',
+      queryHash: queryHash,
+      updatedAt: now,
+      lockUntil: isInitialLoad ? now.add(_holdSkeleton) : null,
+    );
+  }
+
+  void markRestored(String queryHash) {
+    _showTransient(
+      phase: UIReactionPhase.unchanged,
+      message: '동일한 조건이에요. 최근 결과를 보여드려요.',
+      queryHash: queryHash,
+    );
+  }
+
+  void markResult({
+    required String queryHash,
+    required bool changed,
+  }) {
+    _cancelPending();
+    final delay = _remainingSkeletonHold();
+    if (delay > Duration.zero) {
+      _pendingTimer = Timer(delay, () {
+        _pendingTimer = null;
+        _setResult(queryHash: queryHash, changed: changed);
+      });
+    } else {
+      _setResult(queryHash: queryHash, changed: changed);
+    }
+  }
+
+  void markFailure({
+    required String queryHash,
+    required String message,
+  }) {
+    _showTransient(
+      phase: UIReactionPhase.failure,
+      message: message,
+      queryHash: queryHash,
+    );
+  }
+
+  void markFilterConfirmed(String summary) {
+    _showTransient(
+      phase: UIReactionPhase.confirmed,
+      message: summary,
+      queryHash: state.queryHash,
+    );
+  }
+
+  void markSearchConfirmed(String keyword) {
+    final summary = keyword.trim().isEmpty
+        ? '검색어가 지워졌어요. 전체 결과를 보여드려요.'
+        : '"$keyword" 검색을 시작해요.';
+    _showTransient(
+      phase: UIReactionPhase.confirmed,
+      message: summary,
+      queryHash: state.queryHash,
+    );
+  }
+
+  void markUnchanged(String queryHash) {
+    _showTransient(
+      phase: UIReactionPhase.unchanged,
+      message: '변경된 조건이 없어요.',
+      queryHash: queryHash,
+    );
+  }
+
+  @override
+  void dispose() {
+    _clearTimer?.cancel();
+    _pendingTimer?.cancel();
+    super.dispose();
+  }
+
+  bool _shouldDebounce(UIReactionPhase phase, String messageKey) {
+    if (_lastPhase != phase || _lastMessage != messageKey) {
+      _lastPhase = phase;
+      _lastMessage = messageKey;
+      _lastEventAt = DateTime.now();
+      return false;
+    }
+
+    final now = DateTime.now();
+    final last = _lastEventAt;
+    if (last != null && now.difference(last) < _debounce) {
+      return true;
+    }
+
+    _lastEventAt = now;
+    return false;
+  }
+
+  void _setResult({
+    required String queryHash,
+    required bool changed,
+  }) {
+    _showTransient(
+      phase: changed ? UIReactionPhase.success : UIReactionPhase.unchanged,
+      message: changed ? '최신 결과로 업데이트됐어요.' : '결과가 이미 최신입니다.',
+      queryHash: queryHash,
+    );
+  }
+
+  void _showTransient({
+    required UIReactionPhase phase,
+    required String message,
+    required String? queryHash,
+  }) {
+    if (queryHash != null && _shouldDebounce(phase, queryHash)) return;
+
+    _cancelPending();
+    _clearTimer?.cancel();
+
+    state = state.copyWith(
+      phase: phase,
+      message: message,
+      queryHash: queryHash,
+      updatedAt: DateTime.now(),
+      lockUntil: null,
+    );
+
+    _clearTimer = Timer(_toastDuration, () {
+      state = state.copyWith(phase: UIReactionPhase.idle, message: '');
+    });
+  }
+
+  void _cancelPending() {
+    _pendingTimer?.cancel();
+    _pendingTimer = null;
+  }
+
+  Duration _remainingSkeletonHold() {
+    final lock = state.lockUntil;
+    if (lock == null) return Duration.zero;
+    final now = DateTime.now();
+    if (now.isAfter(lock)) return Duration.zero;
+    return lock.difference(now);
+  }
+}
+
+final uiReactionControllerProvider =
+    StateNotifierProvider.family<UIReactionController, UIReactionState,
+        PolicyFeedType>(
+  (ref, feedType) {
+    return UIReactionController(feedType: feedType);
+  },
+);

--- a/lib/features/policy_new/application/providers.dart
+++ b/lib/features/policy_new/application/providers.dart
@@ -41,6 +41,7 @@ import 'controllers/policy_paging_controller.dart';
 import 'controllers/policy_paging_state.dart';
 import 'controllers/policy_query_engine.dart';
 import 'controllers/policy_selection_controller.dart';
+import 'controllers/ui_reaction_controller.dart';
 import 'gateways/notification_gateway.dart';
 import 'gateways/notification_gateway_impl.dart';
 import 'services/policy_favorite_service.dart';

--- a/lib/features/policy_new/presentation/explore/policy_explore_screen.dart
+++ b/lib/features/policy_new/presentation/explore/policy_explore_screen.dart
@@ -116,7 +116,7 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
             ),
 
             // 🔹 탐색 상단 공통 필터 바
-            const PolicyFilterBar(),
+            PolicyFilterBar(feedType: feedType),
 
             // 🔹 본문: 정책 리스트 (단일 스크롤)
             Expanded(

--- a/lib/features/policy_new/presentation/filters/policy_filter_bar.dart
+++ b/lib/features/policy_new/presentation/filters/policy_filter_bar.dart
@@ -1,14 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../application/controllers/ui_reaction_controller.dart';
 import '../../application/filters/policy_filter_ui_state.dart';
+import '../../domain/values/policy_feed_type.dart';
 import '../../domain/values/policy_sort.dart';
 import 'policy_filter_bottom_sheet.dart';
 import 'policy_keyword_sheet.dart';
 import 'policy_sort_bottom_sheet.dart';
 
 class PolicyFilterBar extends ConsumerWidget {
-  const PolicyFilterBar({super.key});
+  const PolicyFilterBar({
+    super.key,
+    this.feedType = PolicyFeedType.recommend,
+  });
+
+  final PolicyFeedType feedType;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -21,7 +28,7 @@ class PolicyFilterBar extends ConsumerWidget {
         children: [
           Expanded(
             child: GestureDetector(
-              onTap: () => _openKeywordSheet(context),
+              onTap: () => _openKeywordSheet(context, ref),
               child: Container(
                 padding:
                     const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
@@ -54,14 +61,14 @@ class PolicyFilterBar extends ConsumerWidget {
             context,
             label: _sortLabel(ui.sort),
             icon: Icons.swap_vert,
-            onTap: () => _openSortSheet(context),
+            onTap: () => _openSortSheet(context, ref),
           ),
           const SizedBox(width: 6),
           _chipButton(
             context,
             label: '필터',
             icon: Icons.filter_alt_outlined,
-            onTap: () => _openFilterSheet(context),
+            onTap: () => _openFilterSheet(context, ref),
           ),
         ],
       ),
@@ -106,25 +113,34 @@ class PolicyFilterBar extends ConsumerWidget {
     }
   }
 
-  void _openKeywordSheet(BuildContext context) {
+  void _openKeywordSheet(BuildContext context, WidgetRef ref) {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
-      builder: (_) => const PolicyKeywordSheet(),
+      builder: (_) => PolicyKeywordSheet(feedType: feedType),
     );
+    ref
+        .read(uiReactionControllerProvider(feedType).notifier)
+        .markSearchConfirmed(ref.read(policyFilterUiStateProvider).keyword);
   }
 
-  void _openSortSheet(BuildContext context) {
+  void _openSortSheet(BuildContext context, WidgetRef ref) {
     showModalBottomSheet(
       context: context,
-      builder: (_) => const PolicySortBottomSheet(),
+      builder: (_) => PolicySortBottomSheet(feedType: feedType),
     );
+    ref
+        .read(uiReactionControllerProvider(feedType).notifier)
+        .markFilterConfirmed('정렬 옵션을 선택해보세요.');
   }
 
-  void _openFilterSheet(BuildContext context) {
+  void _openFilterSheet(BuildContext context, WidgetRef ref) {
     showModalBottomSheet(
       context: context,
-      builder: (_) => const PolicyFilterBottomSheet(),
+      builder: (_) => PolicyFilterBottomSheet(feedType: feedType),
     );
+    ref
+        .read(uiReactionControllerProvider(feedType).notifier)
+        .markFilterConfirmed('필터 조건을 업데이트했어요.');
   }
 }

--- a/lib/features/policy_new/presentation/filters/policy_filter_bottom_sheet.dart
+++ b/lib/features/policy_new/presentation/filters/policy_filter_bottom_sheet.dart
@@ -3,15 +3,22 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../application/filters/policy_filter_ui_state.dart';
 import '../../application/providers.dart';
+import '../../application/controllers/ui_reaction_controller.dart';
 import '../../domain/entities/department.dart';
 import '../../domain/entities/institution.dart';
 import '../../domain/values/policy_category.dart';
+import '../../domain/values/policy_feed_type.dart';
 import '../../domain/values/policy_region.dart';
 import '../../../../application/notifiers/region_notifier.dart';
 import 'widgets/region_selector_section.dart';
 
 class PolicyFilterBottomSheet extends ConsumerStatefulWidget {
-  const PolicyFilterBottomSheet({super.key});
+  const PolicyFilterBottomSheet({
+    super.key,
+    required this.feedType,
+  });
+
+  final PolicyFeedType feedType;
 
   @override
   ConsumerState<PolicyFilterBottomSheet> createState() =>
@@ -385,41 +392,52 @@ class _PolicyFilterBottomSheetState
       _departmentId = null;
       _departmentName = null;
     });
+    _notifyReaction('필터가 초기화됐어요.');
   }
 
   void _applyFilters() {
     final notifier = ref.read(policyFilterUiStateProvider.notifier);
     final current = ref.read(policyFilterUiStateProvider);
+    var hasChanged = false;
 
     if (current.region != _region) {
       notifier.setRegion(_region);
+      hasChanged = true;
     }
 
     if (current.category != _category) {
       notifier.setCategory(_category);
+      hasChanged = true;
     }
 
     if (current.showOnlyOnline != _showOnlyOnline) {
       notifier.toggleOnlineOnly();
+      hasChanged = true;
     }
 
     if (current.showOnlyOngoing != _showOnlyOngoing) {
       notifier.toggleOngoingOnly();
+      hasChanged = true;
     }
 
     if (current.institutionId != _institutionId ||
         current.institutionName != _institutionName) {
       notifier.setInstitution(id: _institutionId, name: _institutionName);
+      hasChanged = true;
     }
 
     if (current.departmentId != _departmentId ||
         current.departmentName != _departmentName) {
       notifier.setDepartment(id: _departmentId, name: _departmentName);
+      hasChanged = true;
     }
 
     ref.read(regionProvider.notifier).applyToFilter();
 
     Navigator.of(context).pop();
+    _notifyReaction(hasChanged
+        ? '필터가 적용됐어요. 결과를 새로 불러옵니다.'
+        : '변경된 조건이 없어요.');
   }
 
   String _regionLabel(PolicyRegion region) {
@@ -466,6 +484,12 @@ class _PolicyFilterBottomSheetState
       case PolicyCategory.other:
         return '기타';
     }
+  }
+
+  void _notifyReaction(String summary) {
+    ref
+        .read(uiReactionControllerProvider(widget.feedType).notifier)
+        .markFilterConfirmed(summary);
   }
 }
 

--- a/lib/features/policy_new/presentation/filters/policy_keyword_sheet.dart
+++ b/lib/features/policy_new/presentation/filters/policy_keyword_sheet.dart
@@ -3,10 +3,18 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../application/controllers/ui_reaction_controller.dart';
 import '../../application/filters/policy_filter_ui_state.dart';
+import '../../application/providers.dart';
+import '../../domain/values/policy_feed_type.dart';
 
 class PolicyKeywordSheet extends ConsumerStatefulWidget {
-  const PolicyKeywordSheet({super.key});
+  const PolicyKeywordSheet({
+    super.key,
+    this.feedType = PolicyFeedType.search,
+  });
+
+  final PolicyFeedType feedType;
 
   @override
   ConsumerState<PolicyKeywordSheet> createState() => _PolicyKeywordSheetState();
@@ -87,6 +95,16 @@ class _PolicyKeywordSheetState extends ConsumerState<PolicyKeywordSheet> {
   }
 
   void _applyKeyword(String value) {
-    ref.read(policyFilterUiStateProvider.notifier).setKeyword(value.trim());
+    final keyword = value.trim();
+    final prev = ref.read(policyFilterUiStateProvider).keyword;
+    ref.read(policyFilterUiStateProvider.notifier).setKeyword(keyword);
+
+    final reaction =
+        ref.read(uiReactionControllerProvider(widget.feedType).notifier);
+    if (prev == keyword) {
+      reaction.markUnchanged(ref.read(policyQueryProvider(widget.feedType)).hash);
+    } else {
+      reaction.markSearchConfirmed(keyword);
+    }
   }
 }

--- a/lib/features/policy_new/presentation/filters/policy_sort_bottom_sheet.dart
+++ b/lib/features/policy_new/presentation/filters/policy_sort_bottom_sheet.dart
@@ -1,11 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../application/controllers/ui_reaction_controller.dart';
 import '../../application/filters/policy_filter_ui_state.dart';
+import '../../domain/values/policy_feed_type.dart';
 import '../../domain/values/policy_sort.dart';
 
 class PolicySortBottomSheet extends ConsumerWidget {
-  const PolicySortBottomSheet({super.key});
+  const PolicySortBottomSheet({
+    super.key,
+    required this.feedType,
+  });
+
+  final PolicyFeedType feedType;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -30,6 +37,9 @@ class PolicySortBottomSheet extends ConsumerWidget {
                 onChanged: (value) {
                   if (value == null) return;
                   ref.read(policyFilterUiStateProvider.notifier).setSort(value);
+                  ref
+                      .read(uiReactionControllerProvider(feedType).notifier)
+                      .markFilterConfirmed('${_label(value)} 정렬을 적용했어요.');
                   Navigator.of(context).pop();
                 },
               ),

--- a/lib/features/policy_new/presentation/screens/policy_feed_home_screen.dart
+++ b/lib/features/policy_new/presentation/screens/policy_feed_home_screen.dart
@@ -99,7 +99,7 @@ class _PolicyFeedHomeScreenState extends ConsumerState<PolicyFeedHomeScreen>
         children: [
           // 🔵 추천 탭에서만 상단 필터 바 노출
           if (currentFeedType == PolicyFeedType.recommend)
-            const PolicyFilterBar(),
+            const PolicyFilterBar(feedType: PolicyFeedType.recommend),
 
           // 🔵 추천 탭에서만 추천 태그 바 노출
           if (_shouldShowTagsBar(currentFeedType))

--- a/lib/features/policy_new/presentation/widgets/policy_feed_list_view.dart
+++ b/lib/features/policy_new/presentation/widgets/policy_feed_list_view.dart
@@ -4,15 +4,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../application/behavior/policy_behavior_tracker.dart';
 import '../../application/controllers/base_feed_controller.dart';
+import '../../application/controllers/ui_reaction_controller.dart';
 import '../../application/controllers/policy_paging_state.dart';
 import '../../application/providers.dart';
-import '../../application/filters/policy_filter_ui_state.dart';
 import '../../domain/values/policy_feed_type.dart';
 import '../detail/policy_detail_bottom_sheet.dart';
+import 'policy_feed_reaction_banner.dart';
 import 'policy_card.dart';
 import 'policy_list_empty.dart';
 import 'policy_list_error.dart';
 import 'policy_list_loading.dart';
+import 'policy_list_skeleton.dart';
 import 'policy_search_empty_view.dart';
 
 class PolicyFeedListView extends ConsumerStatefulWidget {
@@ -68,10 +70,10 @@ class _PolicyFeedListViewState extends ConsumerState<PolicyFeedListView>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    final ui = ref.watch(policyFilterUiStateProvider);
     final queryState = ref.watch(policyQueryProvider(widget.feedType));
     final query = queryState.query;
     final (state, notifier) = _useController();
+    final reaction = ref.watch(uiReactionControllerProvider(widget.feedType));
     _latestState = state;
     _latestController = notifier;
 
@@ -93,18 +95,20 @@ class _PolicyFeedListViewState extends ConsumerState<PolicyFeedListView>
 
     Widget content;
 
-    if (state.failure != null) {
+    if (reaction.shouldHoldSkeleton ||
+        (state.isLoading && state.items.isEmpty)) {
+      content = const PolicyListSkeleton();
+    } else if (state.failure != null) {
       content = PolicyListError(
         key: const ValueKey('policy-list-error'),
         message: state.failure!.message,
         onRetry: notifier.loadFirstPage,
       );
-    } else if (state.isLoading && state.items.isEmpty) {
-      content = const PolicyListLoading(key: ValueKey('policy-list-loading'));
     } else if (shouldShowSearchGuide) {
       content = PolicySearchEmptyView(
         key: const ValueKey('policy-search-guide'),
         isKeywordTooShort: isKeywordTooShort,
+        feedType: widget.feedType,
       );
     } else if (!state.isLoading && state.items.isEmpty) {
       final emptyMessage = widget.feedType == PolicyFeedType.favorite
@@ -157,11 +161,21 @@ class _PolicyFeedListViewState extends ConsumerState<PolicyFeedListView>
       );
     }
 
-    return AnimatedSwitcher(
-      duration: const Duration(milliseconds: 180),
-      switchInCurve: Curves.easeOut,
-      switchOutCurve: Curves.easeOut,
-      child: content,
+    return Column(
+      children: [
+        PolicyFeedReactionBanner(
+          state: reaction,
+          onRetry: notifier.loadFirstPage,
+        ),
+        Expanded(
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 220),
+            switchInCurve: Curves.easeOut,
+            switchOutCurve: Curves.easeOut,
+            child: content,
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/features/policy_new/presentation/widgets/policy_feed_reaction_banner.dart
+++ b/lib/features/policy_new/presentation/widgets/policy_feed_reaction_banner.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+import '../../application/controllers/ui_reaction_controller.dart';
+
+class PolicyFeedReactionBanner extends StatelessWidget {
+  const PolicyFeedReactionBanner({
+    super.key,
+    required this.state,
+    required this.onRetry,
+  });
+
+  final UIReactionState state;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final isVisible = state.isActive;
+    final colorScheme = Theme.of(context).colorScheme;
+    final background = switch (state.phase) {
+      UIReactionPhase.failure => colorScheme.errorContainer,
+      UIReactionPhase.confirmed => colorScheme.primaryContainer,
+      UIReactionPhase.success => colorScheme.primaryContainer,
+      UIReactionPhase.unchanged => colorScheme.surfaceVariant,
+      _ => colorScheme.surfaceVariant,
+    };
+
+    final textColor = switch (state.phase) {
+      UIReactionPhase.failure => colorScheme.onErrorContainer,
+      UIReactionPhase.confirmed => colorScheme.onPrimaryContainer,
+      UIReactionPhase.success => colorScheme.onPrimaryContainer,
+      UIReactionPhase.unchanged => colorScheme.onSurfaceVariant,
+      _ => colorScheme.onSurfaceVariant,
+    };
+
+    final icon = switch (state.phase) {
+      UIReactionPhase.failure => Icons.warning_amber_rounded,
+      UIReactionPhase.success => Icons.check_circle,
+      UIReactionPhase.confirmed => Icons.play_arrow_rounded,
+      UIReactionPhase.unchanged => Icons.info_outline,
+      _ => Icons.autorenew,
+    };
+
+    return AnimatedCrossFade(
+      duration: const Duration(milliseconds: 200),
+      crossFadeState:
+          isVisible ? CrossFadeState.showFirst : CrossFadeState.showSecond,
+      firstChild: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+        child: Material(
+          elevation: 1,
+          borderRadius: BorderRadius.circular(12),
+          color: background,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            child: Row(
+              children: [
+                Icon(icon, size: 18, color: textColor),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    state.message,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: textColor,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                if (state.phase == UIReactionPhase.failure)
+                  TextButton(
+                    onPressed: onRetry,
+                    child: const Text('재시도'),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+      secondChild: const SizedBox(height: 12),
+    );
+  }
+}

--- a/lib/features/policy_new/presentation/widgets/policy_list_skeleton.dart
+++ b/lib/features/policy_new/presentation/widgets/policy_list_skeleton.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+import '../../../../ui/components/policy_skeleton_card.dart';
+
+class PolicyListSkeleton extends StatelessWidget {
+  const PolicyListSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+      itemBuilder: (_, __) => const PolicySkeletonCard(),
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemCount: 5,
+    );
+  }
+}

--- a/lib/features/policy_new/presentation/widgets/policy_search_empty_view.dart
+++ b/lib/features/policy_new/presentation/widgets/policy_search_empty_view.dart
@@ -1,15 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../domain/values/policy_feed_type.dart';
 import '../filters/policy_keyword_sheet.dart';
 
 class PolicySearchEmptyView extends ConsumerWidget {
   const PolicySearchEmptyView({
     super.key,
     required this.isKeywordTooShort,
+    this.feedType = PolicyFeedType.search,
   });
 
   final bool isKeywordTooShort;
+  final PolicyFeedType feedType;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -62,7 +65,7 @@ class PolicySearchEmptyView extends ConsumerWidget {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
-      builder: (_) => const PolicyKeywordSheet(),
+      builder: (_) => PolicyKeywordSheet(feedType: feedType),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add a UIReactionController and provider to drive feed lifecycle feedback across policy feeds
- show skeleton loaders, reaction banner, and retry affordances for feed updates and errors
- surface immediate confirmations for search, sort, and filter interactions with debounce and unchanged-state handling

## Testing
- Not run (dart CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69348756f0588324888024f3fb795772)