### PR TITLE
피드 스켈레톤 전환 UX 개선

### DIFF
--- a/lib/features/policy_new/application/controllers/base_feed_controller.dart
+++ b/lib/features/policy_new/application/controllers/base_feed_controller.dart
@@ -103,7 +103,7 @@ abstract class BasePolicyFeedController
   }
 
   Future<void> ensureInitialized() async {
-    if (state.items.isNotEmpty || state.isLoading) return;
+    if (state.visibleItems.isNotEmpty || state.isLoading) return;
     await _reloadCurrentQuery();
   }
 
@@ -131,7 +131,7 @@ abstract class BasePolicyFeedController
 
     result.fold(
       onSuccess: (list) {
-        final merged = [...state.items, ...list];
+        final merged = [...state.currentResults, ...list];
         state = PolicyPagingState.data(
           items: merged,
           hasMore: list.length == queryEngine.pageSize,
@@ -218,7 +218,8 @@ abstract class BasePolicyFeedController
   }) async {
     if (_isLoading) return;
 
-    final previousItems = List<Policy>.from(state.items);
+    final previousItems = List<Policy>.from(state.visibleItems);
+    final previousResults = previousItems.isEmpty ? null : previousItems;
     final isInitialLoad = !append && previousItems.isEmpty;
 
     final shouldFetch = _shouldFetchForFeedType(queryState.query);
@@ -236,7 +237,7 @@ abstract class BasePolicyFeedController
       _reaction.markLoading(queryState.hash, isInitialLoad: isInitialLoad);
     }
     if (!append) {
-      state = const PolicyPagingState.loading();
+      state = PolicyPagingState.loading(previousResults: previousResults);
     }
 
     final result = await queryEngine.fetch(
@@ -247,7 +248,7 @@ abstract class BasePolicyFeedController
 
     result.fold(
       onSuccess: (list) {
-        final merged = append ? [...state.items, ...list] : list;
+        final merged = append ? [...state.currentResults, ...list] : list;
         state = PolicyPagingState.data(
           items: merged,
           hasMore: list.length == queryEngine.pageSize,
@@ -260,7 +261,7 @@ abstract class BasePolicyFeedController
         );
       },
       onFailure: (failure) {
-        state = PolicyPagingState.error(failure);
+        state = PolicyPagingState.error(failure, previousResults: previousResults);
         _reaction.markFailure(
           queryHash: queryState.hash,
           message: failure.message,

--- a/lib/features/policy_new/application/controllers/policy_paging_state.dart
+++ b/lib/features/policy_new/application/controllers/policy_paging_state.dart
@@ -6,26 +6,30 @@ import '../../domain/values/policy_failure.dart';
 @immutable
 class PolicyPagingState {
   final bool isLoading;
-  final List<Policy> items;
+  final List<Policy> currentResults;
+  final List<Policy>? previousResults;
   final PolicyFailure? failure;
   final bool hasMore;
 
   const PolicyPagingState({
     required this.isLoading,
-    required this.items,
+    required this.currentResults,
+    required this.previousResults,
     required this.failure,
     required this.hasMore,
   });
 
   const PolicyPagingState.initial()
       : isLoading = false,
-        items = const [],
+        currentResults = const [],
+        previousResults = null,
         failure = null,
         hasMore = true;
 
-  const PolicyPagingState.loading()
+  const PolicyPagingState.loading({List<Policy>? previousResults})
       : isLoading = true,
-        items = const [],
+        currentResults = previousResults ?? const [],
+        previousResults = previousResults,
         failure = null,
         hasMore = true;
 
@@ -35,15 +39,24 @@ class PolicyPagingState {
   }) =>
       PolicyPagingState(
         isLoading: false,
-        items: items,
+        currentResults: items,
+        previousResults: null,
         failure: null,
         hasMore: hasMore,
       );
 
-  factory PolicyPagingState.error(PolicyFailure failure) => PolicyPagingState(
+  factory PolicyPagingState.error(
+    PolicyFailure failure, {
+    List<Policy>? previousResults,
+  }) =>
+      PolicyPagingState(
         isLoading: false,
-        items: const [],
+        currentResults: previousResults ?? const [],
+        previousResults: null,
         failure: failure,
         hasMore: false,
       );
+
+  List<Policy> get visibleItems =>
+      currentResults.isNotEmpty ? currentResults : (previousResults ?? const []);
 }

--- a/lib/features/policy_new/application/controllers/ui_reaction_controller.dart
+++ b/lib/features/policy_new/application/controllers/ui_reaction_controller.dart
@@ -62,7 +62,7 @@ class UIReactionController extends StateNotifier<UIReactionState> {
   final PolicyFeedType feedType;
 
   static const _debounce = Duration(milliseconds: 320);
-  static const _holdSkeleton = Duration(milliseconds: 640);
+  static const _holdSkeleton = Duration(milliseconds: 400);
   static const _toastDuration = Duration(milliseconds: 1500);
 
   Timer? _clearTimer;
@@ -81,7 +81,7 @@ class UIReactionController extends StateNotifier<UIReactionState> {
       message: '결과를 준비하고 있어요...',
       queryHash: queryHash,
       updatedAt: now,
-      lockUntil: isInitialLoad ? now.add(_holdSkeleton) : null,
+      lockUntil: now.add(_holdSkeleton),
     );
   }
 

--- a/lib/features/policy_new/presentation/widgets/policy_feed_list_view.dart
+++ b/lib/features/policy_new/presentation/widgets/policy_feed_list_view.dart
@@ -7,6 +7,7 @@ import '../../application/controllers/base_feed_controller.dart';
 import '../../application/controllers/ui_reaction_controller.dart';
 import '../../application/controllers/policy_paging_state.dart';
 import '../../application/providers.dart';
+import '../../domain/entities/policy.dart';
 import '../../domain/values/policy_feed_type.dart';
 import '../detail/policy_detail_bottom_sheet.dart';
 import 'policy_feed_reaction_banner.dart';
@@ -81,6 +82,15 @@ class _PolicyFeedListViewState extends ConsumerState<PolicyFeedListView>
       _isLoadingMore = false;
     }
 
+    final visibleItems = state.visibleItems;
+    final isInitialLoading = state.isLoading && visibleItems.isEmpty;
+    final isTransitionLoading = state.isLoading && state.previousResults != null;
+    var showSkeleton =
+        reaction.shouldHoldSkeleton || isInitialLoading || isTransitionLoading;
+    if (state.failure != null) {
+      showSkeleton = false;
+    }
+
     final keyword = query.keyword?.trim() ?? '';
     final hasKeyword = keyword.isNotEmpty;
     final isKeywordTooShort = hasKeyword && keyword.length < 2;
@@ -88,17 +98,14 @@ class _PolicyFeedListViewState extends ConsumerState<PolicyFeedListView>
 
     final shouldShowSearchGuide =
         widget.feedType == PolicyFeedType.search &&
-            state.items.isEmpty &&
-            !state.isLoading &&
+            visibleItems.isEmpty &&
+            !isInitialLoading &&
             !hasTags &&
             (!hasKeyword || isKeywordTooShort);
 
     Widget content;
 
-    if (reaction.shouldHoldSkeleton ||
-        (state.isLoading && state.items.isEmpty)) {
-      content = const PolicyListSkeleton();
-    } else if (state.failure != null) {
+    if (state.failure != null) {
       content = PolicyListError(
         key: const ValueKey('policy-list-error'),
         message: state.failure!.message,
@@ -110,7 +117,7 @@ class _PolicyFeedListViewState extends ConsumerState<PolicyFeedListView>
         isKeywordTooShort: isKeywordTooShort,
         feedType: widget.feedType,
       );
-    } else if (!state.isLoading && state.items.isEmpty) {
+    } else if (!state.isLoading && visibleItems.isEmpty) {
       final emptyMessage = widget.feedType == PolicyFeedType.favorite
           ? '즐겨찾기한 정책이 없습니다.\n마음에 드는 정책의 하트 버튼을 눌러 저장해보세요.'
           : '조건에 맞는 정책이 없습니다.\n${queryState.conditionSummary} 조건을 조정해보세요.';
@@ -133,11 +140,11 @@ class _PolicyFeedListViewState extends ConsumerState<PolicyFeedListView>
           addAutomaticKeepAlives: false,
           addSemanticIndexes: false,
           addRepaintBoundaries: false,
-          itemCount:
-              state.items.length + (_shouldShowFooterLoader(state) ? 1 : 0),
+          itemCount: visibleItems.length +
+              (_shouldShowFooterLoader(state, visibleItems) ? 1 : 0),
           itemBuilder: (context, index) {
-            if (index < state.items.length) {
-              final policy = state.items[index];
+            if (index < visibleItems.length) {
+              final policy = visibleItems[index];
               return RepaintBoundary(
                 child: PolicyCard(
                   key: ValueKey('policy-${policy.id}'),
@@ -159,6 +166,18 @@ class _PolicyFeedListViewState extends ConsumerState<PolicyFeedListView>
           },
         ),
       );
+
+      if (showSkeleton) {
+        content = Stack(
+          key: const ValueKey('policy-list-content'),
+          children: [
+            Positioned.fill(child: content),
+            const Positioned.fill(
+              child: IgnorePointer(child: PolicyListSkeleton()),
+            ),
+          ],
+        );
+      }
     }
 
     return Column(
@@ -179,8 +198,9 @@ class _PolicyFeedListViewState extends ConsumerState<PolicyFeedListView>
     );
   }
 
-  bool _shouldShowFooterLoader(PolicyPagingState state) {
-    if (state.items.isEmpty) return false;
+  bool _shouldShowFooterLoader(PolicyPagingState state, List<Policy> items) {
+    if (items.isEmpty) return false;
+    if (state.previousResults != null) return false;
     return _isLoadingMore || (state.isLoading && state.hasMore);
   }
 

--- a/test/features/policy_new/application/policy_feed_memory_cache_test.dart
+++ b/test/features/policy_new/application/policy_feed_memory_cache_test.dart
@@ -37,7 +37,7 @@ void main() {
 
       expect(restored, isNotNull);
       expect(restored!.page, 2);
-      expect(restored.state.items, isEmpty);
+      expect(restored.state.currentResults, isEmpty);
       expect(restored.query.hash, 'q1');
     });
 


### PR DESCRIPTION
## Summary
- Feed 상태에 이전/현재 결과를 포함해 조건 변경 시 데이터를 유지하도록 조정했습니다.
- 로딩/전환 동안 스켈레톤을 오버레이로 표시하고 최소 표시 시간(400ms)을 적용했습니다.
- 실패 시 스켈레톤을 제거하고 에러 UI를 노출하도록 처리했습니다.

## Testing
- flutter test test/features/policy_new/application/policy_feed_memory_cache_test.dart (실패: 환경에 flutter 명령어가 없습니다)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693489b6ce008324adc9fb0d80abc93a)