### PR TITLE
TASK51 – 정책 상세 재탐색 엔트리 추가

### DIFF
--- a/lib/features/policy_new/application/controllers/policy_query_override.dart
+++ b/lib/features/policy_new/application/controllers/policy_query_override.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../filters/policy_filter_ui_state.dart';
+import '../reexplore/policy_reexplore.dart';
+import '../../domain/entities/policy.dart';
+import '../../domain/values/policy_feed_type.dart';
+import 'policy_query_state.dart';
+
+class PolicyQueryOverride {
+  const PolicyQueryOverride({required this.queryState});
+
+  final PolicyQueryState queryState;
+}
+
+class PolicyQueryOverrideNotifier
+    extends StateNotifier<PolicyQueryOverride?> {
+  PolicyQueryOverrideNotifier(this.ref, PolicyFeedType _) : super(null);
+
+  final Ref ref;
+
+  String? _hash;
+
+  PolicyFilterUiState applyFromDetail(Policy policy, PolicyReExploreMode mode) {
+    final filter = ref.read(policyFilterUiStateProvider.notifier).applyFromDetail(
+          policy,
+          mode,
+          PolicyReExploreBuilder.buildFilter,
+        );
+    final queryState =
+        PolicyReExploreBuilder.buildQueryState(policy, mode, filter);
+    _hash = queryState.hash;
+    state = PolicyQueryOverride(queryState: queryState);
+    return filter;
+  }
+
+  void ensureActiveForHash(String hash) {
+    if (_hash != null && _hash != hash) {
+      _hash = null;
+      state = null;
+    }
+  }
+
+  void clear() {
+    _hash = null;
+    state = null;
+  }
+}
+
+final policyQueryOverrideProvider = StateNotifierProvider.family<
+    PolicyQueryOverrideNotifier, PolicyQueryOverride?, PolicyFeedType>(
+  (ref, feedType) => PolicyQueryOverrideNotifier(ref, feedType),
+);

--- a/lib/features/policy_new/application/explore/explore_providers.dart
+++ b/lib/features/policy_new/application/explore/explore_providers.dart
@@ -6,6 +6,7 @@ import '../filters/policy_filter_ui_state.dart';
 import 'explore_state.dart';
 import '../../domain/values/policy_category.dart';
 import '../../domain/values/policy_sort.dart';
+import '../reexplore/policy_reexplore.dart';
 
 final exploreStateProvider =
     StateNotifierProvider<ExploreController, ExploreState>(
@@ -146,6 +147,26 @@ class ExploreController extends StateNotifier<ExploreState> {
     notifier.resetAll();
   }
 
+  void applyFromDetail({
+    required PolicyFilterUiState filter,
+    required PolicyReExploreMode _mode,
+  }) {
+    final categoryId = _categoryId(filter.category);
+    final status = filter.showOnlyOngoing
+        ? PolicyStatusFilter.inProgressOnly
+        : PolicyStatusFilter.includeClosed;
+    final sortKind = _mapSortKind(filter.sort);
+
+    state = state.copyWith(
+      mode: ExploreSubMode.all,
+      keyword: '',
+      statusFilter: status,
+      sortKind: sortKind,
+      selectedCategories:
+          categoryId != null ? List.unmodifiable([categoryId]) : const [],
+    );
+  }
+
   PolicyCategory? _mapCategory(String id) {
     switch (id) {
       case 'employment':
@@ -160,6 +181,42 @@ class ExploreController extends StateNotifier<ExploreState> {
         return PolicyCategory.life;
       default:
         return null;
+    }
+  }
+
+  String? _categoryId(PolicyCategory? category) {
+    switch (category) {
+      case PolicyCategory.employment:
+        return 'employment';
+      case PolicyCategory.startup:
+        return 'startup';
+      case PolicyCategory.housing:
+        return 'housing';
+      case PolicyCategory.education:
+        return 'education';
+      case PolicyCategory.life:
+        return 'life';
+      case PolicyCategory.welfare:
+        return 'welfare';
+      case PolicyCategory.culture:
+        return 'culture';
+      case PolicyCategory.other:
+        return 'other';
+      case null:
+        return null;
+    }
+  }
+
+  PolicySortKind _mapSortKind(PolicySortOption option) {
+    switch (option) {
+      case PolicySortOption.recommendation:
+        return PolicySortKind.recommended;
+      case PolicySortOption.latest:
+        return PolicySortKind.newest;
+      case PolicySortOption.deadline:
+        return PolicySortKind.deadline;
+      case PolicySortOption.popularity:
+        return PolicySortKind.amount;
     }
   }
 }

--- a/lib/features/policy_new/application/filters/policy_filter_summary.dart
+++ b/lib/features/policy_new/application/filters/policy_filter_summary.dart
@@ -18,6 +18,12 @@ String buildPolicyFilterSummary(PolicyFilterUiState filter) {
     buffer.write(' · ${_categoryLabel(filter.category!)}');
   }
 
+  if ((filter.institutionName ?? '').isNotEmpty) {
+    buffer.write(' · ${filter.institutionName}');
+  } else if ((filter.institutionId ?? '').isNotEmpty) {
+    buffer.write(' · 기관 필터 적용');
+  }
+
   if (filter.showOnlyOngoing) {
     buffer.write(' · 모집중만');
   }
@@ -47,6 +53,12 @@ String buildPolicyFilterConditionSummary(PolicyFilterUiState filter) {
 
   if (filter.category != null) {
     parts.add(_categoryLabel(filter.category!));
+  }
+
+  if ((filter.institutionName ?? '').isNotEmpty) {
+    parts.add(filter.institutionName!);
+  } else if ((filter.institutionId ?? '').isNotEmpty) {
+    parts.add('기관 필터 적용');
   }
 
   if (filter.showOnlyOngoing) {

--- a/lib/features/policy_new/application/filters/policy_filter_ui_state.dart
+++ b/lib/features/policy_new/application/filters/policy_filter_ui_state.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../domain/entities/policy.dart';
 import '../../domain/values/policy_category.dart';
 import '../../domain/values/policy_region.dart';
 import '../../domain/values/policy_sort.dart';
+import '../reexplore/policy_reexplore.dart';
 
 @immutable
 class PolicyFilterUiState {
@@ -134,6 +136,17 @@ class PolicyFilterUiStateNotifier extends StateNotifier<PolicyFilterUiState> {
       );
 
   void resetAll() => state = const PolicyFilterUiState();
+
+  PolicyFilterUiState applyFromDetail(
+    Policy policy,
+    PolicyReExploreMode mode,
+    PolicyFilterUiState Function(PolicyFilterUiState, Policy, PolicyReExploreMode)
+        builder,
+  ) {
+    final next = builder(state, policy, mode);
+    state = next;
+    return next;
+  }
 }
 
 final policyFilterUiStateProvider =

--- a/lib/features/policy_new/application/providers.dart
+++ b/lib/features/policy_new/application/providers.dart
@@ -41,6 +41,7 @@ import 'controllers/policy_paging_controller.dart';
 import 'controllers/policy_paging_state.dart';
 import 'controllers/policy_query_engine.dart';
 import 'controllers/policy_selection_controller.dart';
+import 'controllers/policy_query_override.dart';
 import 'controllers/ui_reaction_controller.dart';
 import 'gateways/notification_gateway.dart';
 import 'gateways/notification_gateway_impl.dart';
@@ -424,14 +425,26 @@ final policyQueryProvider = Provider.family<PolicyQueryState, PolicyFeedType>(
     ref.watch(favoriteIdsProvider);
     ref.watch(compareRepositoryProvider);
 
-    final orchestrator = ref.read(policyQueryOrchestratorProvider);
-    final query = orchestrator.buildQuery(feedType);
+  final orchestrator = ref.read(policyQueryOrchestratorProvider);
+  final query = orchestrator.buildQuery(feedType);
 
-    return PolicyQueryState(
-      query: query,
-      hash: query.cacheScopeKey,
-      summary: buildPolicyFilterSummary(filter),
-      conditionSummary: buildPolicyFilterConditionSummary(filter),
-    );
+  final baseState = PolicyQueryState(
+    query: query,
+    hash: query.cacheScopeKey,
+    summary: buildPolicyFilterSummary(filter),
+    conditionSummary: buildPolicyFilterConditionSummary(filter),
+  );
+
+  final overrideNotifier =
+      ref.read(policyQueryOverrideProvider(feedType).notifier);
+  overrideNotifier.ensureActiveForHash(baseState.hash);
+
+  final overrideState = ref.watch(policyQueryOverrideProvider(feedType));
+  if (overrideState != null &&
+      overrideState.queryState.hash == baseState.hash) {
+    return overrideState.queryState;
+  }
+
+  return baseState;
   },
 );

--- a/lib/features/policy_new/application/reexplore/policy_reexplore.dart
+++ b/lib/features/policy_new/application/reexplore/policy_reexplore.dart
@@ -1,0 +1,101 @@
+import '../../domain/entities/policy.dart';
+import '../../domain/values/policy_feed_type.dart';
+import '../../domain/values/policy_filter.dart';
+import '../../domain/values/policy_query.dart';
+import '../../domain/values/policy_sort.dart';
+import '../filters/policy_filter_summary.dart';
+import '../filters/policy_filter_ui_state.dart';
+import '../controllers/policy_query_state.dart';
+
+enum PolicyReExploreMode {
+  similar,
+  institution,
+  category,
+}
+
+class PolicyReExploreBuilder {
+  static PolicyFilterUiState buildFilter(
+    PolicyFilterUiState _,
+    Policy policy,
+    PolicyReExploreMode mode,
+  ) {
+    final tags = _primaryTags(policy);
+
+    switch (mode) {
+      case PolicyReExploreMode.similar:
+        return PolicyFilterUiState(
+          region: policy.region,
+          category: policy.category,
+          tags: tags,
+          sort: PolicySortOption.recommendation,
+        );
+      case PolicyReExploreMode.institution:
+        return PolicyFilterUiState(
+          region: policy.region,
+          sort: PolicySortOption.latest,
+          institutionId: policy.institutionId,
+          institutionName: policy.institution,
+          departmentId: policy.departmentId,
+          departmentName: policy.department,
+        );
+      case PolicyReExploreMode.category:
+        return PolicyFilterUiState(
+          region: policy.region,
+          category: policy.category,
+          sort: PolicySortOption.latest,
+        );
+    }
+  }
+
+  static PolicyQueryState buildQueryState(
+    Policy policy,
+    PolicyReExploreMode mode,
+    PolicyFilterUiState filter,
+  ) {
+    final tags = mode == PolicyReExploreMode.similar ? _primaryTags(policy) : const <String>[];
+
+    final query = PolicyQuery(
+      feedType: PolicyFeedType.all,
+      filter: PolicyFilter(
+        region: filter.region,
+        province: filter.province,
+        city: filter.city,
+        district: filter.district,
+        category: filter.category,
+        isOnline: filter.showOnlyOnline ? true : null,
+        isOngoing: filter.showOnlyOngoing ? true : null,
+        institutionId: filter.institutionId,
+        departmentId: filter.departmentId,
+        tags: tags.isNotEmpty ? tags : filter.tags,
+      ),
+      tags: tags.isNotEmpty ? tags : filter.tags,
+      sort: _sortFor(mode, filter),
+    ).normalize();
+
+    return PolicyQueryState(
+      query: query,
+      hash: query.cacheScopeKey,
+      summary: buildPolicyFilterSummary(filter),
+      conditionSummary: buildPolicyFilterConditionSummary(filter),
+    );
+  }
+
+  static PolicySortOption _sortFor(
+    PolicyReExploreMode mode,
+    PolicyFilterUiState filter,
+  ) {
+    switch (mode) {
+      case PolicyReExploreMode.similar:
+        return PolicySortOption.recommendation;
+      case PolicyReExploreMode.institution:
+      case PolicyReExploreMode.category:
+        return filter.sort;
+    }
+  }
+
+  static List<String> _primaryTags(Policy policy) {
+    if (policy.tags.isNotEmpty) return policy.tags;
+    if (policy.keywords.isNotEmpty) return policy.keywords;
+    return const [];
+  }
+}

--- a/lib/features/policy_new/presentation/detail/policy_detail_bottom_sheet.dart
+++ b/lib/features/policy_new/presentation/detail/policy_detail_bottom_sheet.dart
@@ -2,12 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../application/controllers/policy_detail_controller.dart';
+import '../../application/controllers/policy_query_override.dart';
 import '../../application/providers.dart';
+import '../../application/explore/explore_providers.dart';
+import '../../application/reexplore/policy_reexplore.dart';
 import '../../domain/entities/policy.dart';
 import '../../domain/values/policy_failure.dart';
+import '../../domain/values/policy_feed_type.dart';
 import '../widgets/policy_list_loading.dart';
 import '../reminder/policy_reminder_button.dart';
 import 'widgets/policy_action_bar.dart';
+import '../explore/policy_explore_screen.dart';
 import '../../../../ui/layout/app_screen_container.dart';
 import '../../../../ui/components/app_section_title.dart';
 import '../../../../ui/components/app_divider.dart';
@@ -38,6 +43,27 @@ class _PolicyDetailBottomSheetState
         .onInit();
   }
 
+  void _onReExplore(
+    BuildContext context,
+    Policy policy,
+    PolicyReExploreMode mode,
+  ) {
+    final overrideNotifier =
+        ref.read(policyQueryOverrideProvider(PolicyFeedType.all).notifier);
+    final filter = overrideNotifier.applyFromDetail(policy, mode);
+
+    ref
+        .read(exploreStateProvider.notifier)
+        .applyFromDetail(filter: filter, mode: mode);
+
+    Navigator.of(context).pop();
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => const PolicyExploreScreen(),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final asyncPolicy = ref.watch(policyDetailProvider(widget.policyId));
@@ -55,8 +81,11 @@ class _PolicyDetailBottomSheetState
           borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
           clipBehavior: Clip.antiAlias,
           child: asyncPolicy.when(
-            data: (policy) =>
-                _Content(policy: policy, controller: scrollController),
+            data: (policy) => _Content(
+              policy: policy,
+              controller: scrollController,
+              onReExplore: (mode) => _onReExplore(context, policy, mode),
+            ),
             loading: () => const PolicyListLoading(),
             error: (err, __) => _ErrorView(
               error: err,
@@ -73,10 +102,12 @@ class _Content extends StatelessWidget {
   const _Content({
     required this.policy,
     required this.controller,
+    required this.onReExplore,
   });
 
   final Policy policy;
   final ScrollController controller;
+  final ValueChanged<PolicyReExploreMode> onReExplore;
 
   @override
   Widget build(BuildContext context) {
@@ -135,6 +166,11 @@ class _Content extends StatelessWidget {
                     content: (policy.contact ?? '').isNotEmpty
                         ? policy.contact!
                         : 'Contact info not available.',
+                  ),
+                  const SizedBox(height: AppSpacing.lg),
+                  _ReExploreSection(
+                    policy: policy,
+                    onSelect: onReExplore,
                   ),
                   const SizedBox(height: AppSpacing.xl),
                 ],
@@ -278,6 +314,77 @@ class _InfoSection extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _ReExploreSection extends StatelessWidget {
+  const _ReExploreSection({
+    required this.policy,
+    required this.onSelect,
+  });
+
+  final Policy policy;
+  final ValueChanged<PolicyReExploreMode> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasInstitution = (policy.institutionId ?? '').isNotEmpty;
+
+    return AppCard(
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const AppSectionTitle(title: '이 정책과 함께 보기'),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            '비슷한 정책이나 같은 기관·카테고리의 최신 정책을 이어서 탐색해보세요.',
+            style: AppText.textTheme.bodyMedium?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          FilledButton.icon(
+            onPressed: () => onSelect(PolicyReExploreMode.similar),
+            icon: const Icon(Icons.auto_awesome),
+            style: FilledButton.styleFrom(
+              minimumSize: const Size.fromHeight(48),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(14),
+              ),
+            ),
+            label: const Text('비슷한 정책 더 보기'),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          FilledButton.tonalIcon(
+            onPressed: () => onSelect(PolicyReExploreMode.category),
+            icon: const Icon(Icons.category_outlined),
+            style: FilledButton.styleFrom(
+              minimumSize: const Size.fromHeight(48),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(14),
+              ),
+            ),
+            label: const Text('같은 카테고리 최신 정책 보기'),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          FilledButton.tonalIcon(
+            onPressed:
+                hasInstitution ? () => onSelect(PolicyReExploreMode.institution) : null,
+            icon: const Icon(Icons.apartment_outlined),
+            style: FilledButton.styleFrom(
+              minimumSize: const Size.fromHeight(48),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(14),
+              ),
+            ),
+            label: Text(
+              hasInstitution ? '같은 기관 정책 보기' : '기관 정보가 없습니다',
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/policy_new/presentation/explore/policy_explore_screen.dart
+++ b/lib/features/policy_new/presentation/explore/policy_explore_screen.dart
@@ -63,7 +63,8 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
     }
 
     final feedType = _feedTypeFor(state);
-    final summary = _summaryFor(state, filterUi.regionSummary);
+    final queryState = ref.watch(policyQueryProvider(feedType));
+    final summary = queryState.summary;
 
     return Scaffold(
       appBar: AppBar(
@@ -107,6 +108,7 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
                   const SizedBox(height: 8),
                   _SummaryRow(
                     summary: summary,
+                    conditionSummary: queryState.conditionSummary,
                     onReset: controller.clearFilters,
                     onTap: () =>
                         _openFilterBottomSheet(context, controller, state),
@@ -168,31 +170,6 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
       return PolicyFeedType.region;
     }
     return PolicyFeedType.all;
-  }
-
-  String _summaryFor(ExploreState state, String regionSummary) {
-    if (state.mode == ExploreSubMode.search && state.keyword.isNotEmpty) {
-      return '"${state.keyword}" 검색 결과';
-    }
-    if (state.mode == ExploreSubMode.region) {
-      final name = state.selectedRegionName?.isNotEmpty == true
-          ? state.selectedRegionName!
-          : regionSummary;
-      return '$name 지역 정책';
-    }
-    final statusLabel = _statusLabel(state.statusFilter);
-    return '경북 전체 · $statusLabel';
-  }
-
-  String _statusLabel(PolicyStatusFilter filter) {
-    switch (filter) {
-      case PolicyStatusFilter.inProgressOnly:
-        return '진행중만';
-      case PolicyStatusFilter.includeClosed:
-        return '마감 포함';
-      case PolicyStatusFilter.closedOnly:
-        return '마감만';
-    }
   }
 
   void _openFilterBottomSheet(
@@ -509,11 +486,13 @@ class _QuickFilterChips extends StatelessWidget {
 class _SummaryRow extends StatelessWidget {
   const _SummaryRow({
     required this.summary,
+    required this.conditionSummary,
     required this.onReset,
     required this.onTap,
   });
 
   final String summary;
+  final String conditionSummary;
   final VoidCallback onReset;
   final VoidCallback onTap;
 
@@ -524,14 +503,29 @@ class _SummaryRow extends StatelessWidget {
       child: Row(
         children: [
           Expanded(
-            child: Text(
-              summary,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: Theme.of(context)
-                  .textTheme
-                  .bodyMedium
-                  ?.copyWith(fontWeight: FontWeight.w600),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  summary,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodyMedium
+                      ?.copyWith(fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  conditionSummary,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodySmall
+                      ?.copyWith(color: Colors.black54),
+                ),
+              ],
             ),
           ),
           TextButton(


### PR DESCRIPTION
## Summary
- 정책 상세 바텀시트에 비슷한 정책/기관/카테고리 재탐색 액션을 추가했습니다.
- 정책 정보 기반으로 필터와 쿼리를 구성하는 재탐색 빌더와 쿼리 오버라이드 노티파이어를 도입했습니다.
- 탐색 화면 상단 요약 영역을 실제 쿼리 조건으로 갱신해 재탐색 후에도 필터 상태를 명확히 보여줍니다.

## Testing
- Not run (environment lacks `dart`/`flutter` tooling).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934c73df84c8324b7433213baea463c)