### PR TITLE
TASK52: unify policy filters across tabs

### DIFF
--- a/lib/features/policy_new/application/controllers/base_feed_controller.dart
+++ b/lib/features/policy_new/application/controllers/base_feed_controller.dart
@@ -5,6 +5,7 @@ import '../../domain/entities/policy.dart';
 import '../../domain/values/policy_event.dart';
 import '../../domain/values/policy_feed_type.dart';
 import '../filters/policy_filter_ui_state.dart';
+import '../filters/policy_search_keyword_provider.dart';
 import '../../../../application/notifiers/region_notifier.dart';
 import 'policy_event_bus.dart';
 import 'policy_feed_memory_cache.dart';
@@ -23,7 +24,12 @@ abstract class BasePolicyFeedController
   })  : _memoryCache = memoryCache,
         super(const PolicyPagingState.initial()) {
     ref.listen<PolicyFilterUiState>(
-      policyFilterUiStateProvider,
+      globalFilterProvider,
+      (_, __) => _onQueryChanged(),
+    );
+
+    ref.listen<String>(
+      policySearchKeywordProvider(feedType),
       (_, __) => _onQueryChanged(),
     );
 

--- a/lib/features/policy_new/application/controllers/global_filter_controller.dart
+++ b/lib/features/policy_new/application/controllers/global_filter_controller.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../filters/policy_filter_ui_state.dart';
+import '../filters/policy_search_keyword_provider.dart';
+import '../../domain/values/policy_feed_type.dart';
+
+class GlobalFilterController {
+  GlobalFilterController(this.ref);
+
+  final Ref ref;
+
+  PolicyFilterUiState get state => ref.read(globalFilterProvider);
+
+  void resetAll() {
+    ref.read(globalFilterProvider.notifier).resetAll();
+    for (final type in PolicyFeedType.values) {
+      ref.read(policySearchKeywordProvider(type).notifier).clear();
+    }
+  }
+
+  void setKeyword(PolicyFeedType feedType, String keyword) {
+    ref.read(policySearchKeywordProvider(feedType).notifier).set(keyword);
+  }
+
+  String keywordOf(PolicyFeedType feedType) {
+    return ref.read(policySearchKeywordProvider(feedType));
+  }
+}
+
+final globalFilterControllerProvider = Provider<GlobalFilterController>((ref) {
+  return GlobalFilterController(ref);
+});

--- a/lib/features/policy_new/application/controllers/policy_query_engine.dart
+++ b/lib/features/policy_new/application/controllers/policy_query_engine.dart
@@ -4,7 +4,6 @@ import '../../domain/entities/policy.dart';
 import '../../domain/values/policy_feed_type.dart';
 import '../../domain/values/policy_result.dart';
 import '../providers.dart';
-import 'policy_query_orchestrator.dart';
 import 'policy_query_state.dart';
 
 class PolicyQueryEngine {
@@ -18,16 +17,13 @@ class PolicyQueryEngine {
     return ref.read(policyQueryProvider(feedType));
   }
 
-  PolicyQueryOrchestrator get _orchestrator =>
-      ref.read(policyQueryOrchestratorProvider);
-
   Future<PolicyResult<List<Policy>>> fetch(
     PolicyFeedType feedType, {
     required int page,
     PolicyQueryState? queryState,
   }) async {
-    final query =
-        queryState?.query ?? _orchestrator.buildQuery(feedType).normalize();
+    final state = queryState ?? buildQueryState(feedType);
+    final query = state.query.normalize();
     final repo = ref.read(policyRepositoryProvider);
 
     return repo.fetchPoliciesByQuery(

--- a/lib/features/policy_new/application/controllers/policy_query_orchestrator.dart
+++ b/lib/features/policy_new/application/controllers/policy_query_orchestrator.dart
@@ -15,7 +15,7 @@ class PolicyQueryOrchestrator {
 
   final Ref ref;
 
-  PolicyFilterUiState get _ui => ref.read(policyFilterUiStateProvider);
+  PolicyFilterUiState get _ui => ref.read(globalFilterProvider);
   UserProfile get _profile => ref.read(userProfileProvider);
   PolicyBehaviorState get _behavior =>
       ref.read(policyBehaviorTrackerProvider);
@@ -24,16 +24,19 @@ class PolicyQueryOrchestrator {
 
   List<String> get _compareIds => ref.read(compareRepositoryProvider).ids;
 
-  PolicyQuery buildQuery(PolicyFeedType feedType) {
+  PolicyQuery buildQuery(
+    PolicyFeedType feedType, {
+    String keyword = '',
+  }) {
     switch (feedType) {
       case PolicyFeedType.recommend:
         return _buildRecommendQuery();
       case PolicyFeedType.all:
-        return _buildAllQuery();
+        return _buildAllQuery(keyword);
       case PolicyFeedType.region:
         return _buildRegionQuery();
       case PolicyFeedType.search:
-        return _buildSearchQuery();
+        return _buildSearchQuery(keyword);
       case PolicyFeedType.favorite:
         return _buildFavoriteQuery();
       case PolicyFeedType.compare:
@@ -74,7 +77,7 @@ class PolicyQueryOrchestrator {
     ).normalize();
   }
 
-  PolicyQuery _buildAllQuery() {
+  PolicyQuery _buildAllQuery(String keyword) {
     final filter = PolicyFilter(
       region: _ui.region,
       province: _ui.province,
@@ -90,7 +93,7 @@ class PolicyQueryOrchestrator {
 
     return PolicyQuery(
       feedType: PolicyFeedType.all,
-      keyword: _ui.keyword.isEmpty ? null : _ui.keyword,
+      keyword: keyword.isEmpty ? null : keyword,
       filter: filter,
       sort: _ui.sort,
     ).normalize();
@@ -119,7 +122,7 @@ class PolicyQueryOrchestrator {
     ).normalize();
   }
 
-  PolicyQuery _buildSearchQuery() {
+  PolicyQuery _buildSearchQuery(String keyword) {
     final filter = PolicyFilter(
       region: _ui.region,
       province: _ui.province,
@@ -134,7 +137,7 @@ class PolicyQueryOrchestrator {
 
     return PolicyQuery(
       feedType: PolicyFeedType.search,
-      keyword: _ui.keyword.isEmpty ? null : _ui.keyword,
+      keyword: keyword.isEmpty ? null : keyword,
       filter: filter,
       tags: _ui.tags,
       sort: _ui.sort,

--- a/lib/features/policy_new/application/controllers/policy_query_override.dart
+++ b/lib/features/policy_new/application/controllers/policy_query_override.dart
@@ -21,7 +21,7 @@ class PolicyQueryOverrideNotifier
   String? _hash;
 
   PolicyFilterUiState applyFromDetail(Policy policy, PolicyReExploreMode mode) {
-    final filter = ref.read(policyFilterUiStateProvider.notifier).applyFromDetail(
+    final filter = ref.read(globalFilterProvider.notifier).applyFromDetail(
           policy,
           mode,
           PolicyReExploreBuilder.buildFilter,

--- a/lib/features/policy_new/application/explore/explore_providers.dart
+++ b/lib/features/policy_new/application/explore/explore_providers.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../application/notifiers/region_notifier.dart';
 import '../filters/policy_filter_ui_state.dart';
+import '../controllers/global_filter_controller.dart';
 import 'explore_state.dart';
 import '../../domain/values/policy_category.dart';
 import '../../domain/values/policy_sort.dart';
+import '../../domain/values/policy_feed_type.dart';
 import '../reexplore/policy_reexplore.dart';
 
 final exploreStateProvider =
@@ -23,9 +24,6 @@ class ExploreController extends StateNotifier<ExploreState> {
     if (mode != ExploreSubMode.search && state.keyword.isNotEmpty) {
       _syncKeyword('');
       state = state.copyWith(keyword: '');
-    }
-    if (mode == ExploreSubMode.region && state.selectedRegionCode == null) {
-      setMyRegion();
     }
     state = state.copyWith(mode: mode);
   }
@@ -52,47 +50,16 @@ class ExploreController extends StateNotifier<ExploreState> {
 
   void clearKeyword() => setKeyword('');
 
-  Future<void> setMyRegion() async {
-    debugPrint('[Explore] setMyRegion');
-    final notifier = ref.read(regionProvider.notifier);
-    final city = notifier.selectedCity;
-    final summary = notifier.summary;
-    if (city != null && city.isNotEmpty) {
-      state = state.copyWith(
-        selectedRegionName: summary,
-        selectedRegionCode: city,
-        useMyRegionAsDefault: true,
-        mode: ExploreSubMode.region,
-      );
-    } else {
-      state = state.copyWith(
-        selectedRegionName: '경북 전체',
-        selectedRegionCode: null,
-        useMyRegionAsDefault: true,
-        mode: ExploreSubMode.region,
-      );
-    }
-  }
-
-  void setCustomRegion({required String name, required String code}) {
-    debugPrint('[Explore] setCustomRegion: $name ($code)');
-    state = state.copyWith(
-      selectedRegionName: name,
-      selectedRegionCode: code,
-      useMyRegionAsDefault: false,
-      mode: ExploreSubMode.region,
-    );
-  }
-
   void _syncKeyword(String keyword) {
-    ref.read(policyFilterUiStateProvider.notifier).setKeyword(keyword);
+    ref
+        .read(globalFilterControllerProvider)
+        .setKeyword(PolicyFeedType.search, keyword);
   }
 
   void setStatusFilter(PolicyStatusFilter filter) {
     debugPrint('[Explore] setStatus: $filter');
-    state = state.copyWith(statusFilter: filter);
-    final filterNotifier = ref.read(policyFilterUiStateProvider.notifier);
-    final current = ref.read(policyFilterUiStateProvider).showOnlyOngoing;
+    final filterNotifier = ref.read(globalFilterProvider.notifier);
+    final current = ref.read(globalFilterProvider).showOnlyOngoing;
     final shouldBeOngoingOnly = filter == PolicyStatusFilter.inProgressOnly;
     if (shouldBeOngoingOnly != current) {
       filterNotifier.toggleOngoingOnly();
@@ -101,8 +68,7 @@ class ExploreController extends StateNotifier<ExploreState> {
 
   void setSortKind(PolicySortKind sortKind) {
     debugPrint('[Explore] setSort: $sortKind');
-    state = state.copyWith(sortKind: sortKind);
-    final notifier = ref.read(policyFilterUiStateProvider.notifier);
+    final notifier = ref.read(globalFilterProvider.notifier);
     PolicySortOption option;
     switch (sortKind) {
       case PolicySortKind.recommended:
@@ -123,47 +89,26 @@ class ExploreController extends StateNotifier<ExploreState> {
 
   void toggleCategory(String categoryId) {
     debugPrint('[Explore] toggleCategory: $categoryId');
-    final current = [...state.selectedCategories];
-    if (current.contains(categoryId)) {
-      current.remove(categoryId);
-    } else {
-      current.add(categoryId);
-    }
-    state = state.copyWith(selectedCategories: current);
-
     final catEnum = _mapCategory(categoryId);
-    ref.read(policyFilterUiStateProvider.notifier).setCategory(catEnum);
+    final current = ref.read(globalFilterProvider).category;
+    ref
+        .read(globalFilterProvider.notifier)
+        .setCategory(current == catEnum ? null : catEnum);
   }
 
   void clearFilters() {
     debugPrint('[Explore] clearFilters');
-    state = state.copyWith(
-      statusFilter: PolicyStatusFilter.inProgressOnly,
-      sortKind: PolicySortKind.recommended,
-      selectedCategories: const [],
-      selectedSupportTypes: const [],
-    );
-    final notifier = ref.read(policyFilterUiStateProvider.notifier);
-    notifier.resetAll();
+    ref.read(globalFilterControllerProvider).resetAll();
+    state = state.copyWith(mode: ExploreSubMode.all, keyword: '');
   }
 
   void applyFromDetail({
     required PolicyFilterUiState filter,
     required PolicyReExploreMode _mode,
   }) {
-    final categoryId = _categoryId(filter.category);
-    final status = filter.showOnlyOngoing
-        ? PolicyStatusFilter.inProgressOnly
-        : PolicyStatusFilter.includeClosed;
-    final sortKind = _mapSortKind(filter.sort);
-
     state = state.copyWith(
       mode: ExploreSubMode.all,
       keyword: '',
-      statusFilter: status,
-      sortKind: sortKind,
-      selectedCategories:
-          categoryId != null ? List.unmodifiable([categoryId]) : const [],
     );
   }
 
@@ -184,39 +129,4 @@ class ExploreController extends StateNotifier<ExploreState> {
     }
   }
 
-  String? _categoryId(PolicyCategory? category) {
-    switch (category) {
-      case PolicyCategory.employment:
-        return 'employment';
-      case PolicyCategory.startup:
-        return 'startup';
-      case PolicyCategory.housing:
-        return 'housing';
-      case PolicyCategory.education:
-        return 'education';
-      case PolicyCategory.life:
-        return 'life';
-      case PolicyCategory.welfare:
-        return 'welfare';
-      case PolicyCategory.culture:
-        return 'culture';
-      case PolicyCategory.other:
-        return 'other';
-      case null:
-        return null;
-    }
-  }
-
-  PolicySortKind _mapSortKind(PolicySortOption option) {
-    switch (option) {
-      case PolicySortOption.recommendation:
-        return PolicySortKind.recommended;
-      case PolicySortOption.latest:
-        return PolicySortKind.newest;
-      case PolicySortOption.deadline:
-        return PolicySortKind.deadline;
-      case PolicySortOption.popularity:
-        return PolicySortKind.amount;
-    }
-  }
 }

--- a/lib/features/policy_new/application/explore/explore_state.dart
+++ b/lib/features/policy_new/application/explore/explore_state.dart
@@ -17,49 +17,18 @@ class ExploreState {
   const ExploreState({
     this.mode = ExploreSubMode.all,
     this.keyword = '',
-    this.selectedRegionName,
-    this.selectedRegionCode,
-    this.useMyRegionAsDefault = false,
-    this.statusFilter = PolicyStatusFilter.inProgressOnly,
-    this.sortKind = PolicySortKind.recommended,
-    this.selectedCategories = const [],
-    this.selectedSupportTypes = const [],
   });
 
   final ExploreSubMode mode;
   final String keyword;
-  final String? selectedRegionName;
-  final String? selectedRegionCode;
-  final bool useMyRegionAsDefault;
-  final PolicyStatusFilter statusFilter;
-  final PolicySortKind sortKind;
-  final List<String> selectedCategories;
-  final List<String> selectedSupportTypes;
-
-  bool get hasKeyword => keyword.isNotEmpty;
-  bool get hasRegion => selectedRegionName != null && selectedRegionName!.isNotEmpty;
 
   ExploreState copyWith({
     ExploreSubMode? mode,
     String? keyword,
-    String? selectedRegionName,
-    String? selectedRegionCode,
-    bool? useMyRegionAsDefault,
-    PolicyStatusFilter? statusFilter,
-    PolicySortKind? sortKind,
-    List<String>? selectedCategories,
-    List<String>? selectedSupportTypes,
   }) {
     return ExploreState(
       mode: mode ?? this.mode,
       keyword: keyword ?? this.keyword,
-      selectedRegionName: selectedRegionName ?? this.selectedRegionName,
-      selectedRegionCode: selectedRegionCode ?? this.selectedRegionCode,
-      useMyRegionAsDefault: useMyRegionAsDefault ?? this.useMyRegionAsDefault,
-      statusFilter: statusFilter ?? this.statusFilter,
-      sortKind: sortKind ?? this.sortKind,
-      selectedCategories: selectedCategories ?? this.selectedCategories,
-      selectedSupportTypes: selectedSupportTypes ?? this.selectedSupportTypes,
     );
   }
 }

--- a/lib/features/policy_new/application/filters/policy_filter_summary.dart
+++ b/lib/features/policy_new/application/filters/policy_filter_summary.dart
@@ -2,12 +2,15 @@ import '../../domain/values/policy_category.dart';
 import '../../domain/values/policy_sort.dart';
 import 'policy_filter_ui_state.dart';
 
-String buildPolicyFilterSummary(PolicyFilterUiState filter) {
+String buildPolicyFilterSummary(
+  PolicyFilterUiState filter, {
+  String keyword = '',
+}) {
   final buffer = StringBuffer(filter.regionSummary);
 
-  final keyword = filter.keyword.trim();
-  if (keyword.isNotEmpty) {
-    buffer.write(' · 검색어 "$keyword"');
+  final trimmedKeyword = keyword.trim();
+  if (trimmedKeyword.isNotEmpty) {
+    buffer.write(' · 검색어 "$trimmedKeyword"');
   }
 
   if (filter.tags.isNotEmpty) {
@@ -37,14 +40,17 @@ String buildPolicyFilterSummary(PolicyFilterUiState filter) {
   return buffer.toString();
 }
 
-String buildPolicyFilterConditionSummary(PolicyFilterUiState filter) {
+String buildPolicyFilterConditionSummary(
+  PolicyFilterUiState filter, {
+  String keyword = '',
+}) {
   final parts = <String>[
     filter.regionSummary,
   ];
 
-  final keyword = filter.keyword.trim();
-  if (keyword.isNotEmpty) {
-    parts.add('검색어 "$keyword"');
+  final trimmedKeyword = keyword.trim();
+  if (trimmedKeyword.isNotEmpty) {
+    parts.add('검색어 "$trimmedKeyword"');
   }
 
   if (filter.tags.isNotEmpty) {

--- a/lib/features/policy_new/application/filters/policy_filter_ui_state.dart
+++ b/lib/features/policy_new/application/filters/policy_filter_ui_state.dart
@@ -15,7 +15,6 @@ class PolicyFilterUiState {
   final String? district;
   final PolicyCategory? category;
   final PolicySortOption sort;
-  final String keyword;
   final List<String> tags;
   final bool showOnlyOnline;
   final bool showOnlyOngoing;
@@ -31,7 +30,6 @@ class PolicyFilterUiState {
     this.district,
     this.category,
     this.sort = PolicySortOption.latest,
-    this.keyword = '',
     this.tags = const [],
     this.showOnlyOnline = false,
     this.showOnlyOngoing = false,
@@ -48,7 +46,6 @@ class PolicyFilterUiState {
     String? district,
     PolicyCategory? category,
     PolicySortOption? sort,
-    String? keyword,
     List<String>? tags,
     bool? showOnlyOnline,
     bool? showOnlyOngoing,
@@ -68,7 +65,6 @@ class PolicyFilterUiState {
       district: district ?? this.district,
       category: category ?? this.category,
       sort: sort ?? this.sort,
-      keyword: keyword ?? this.keyword,
       tags: nextTags,
       showOnlyOnline: showOnlyOnline ?? this.showOnlyOnline,
       showOnlyOngoing: showOnlyOngoing ?? this.showOnlyOngoing,
@@ -112,9 +108,6 @@ class PolicyFilterUiStateNotifier extends StateNotifier<PolicyFilterUiState> {
 
   void setSort(PolicySortOption sort) => state = state.copyWith(sort: sort);
 
-  void setKeyword(String keyword) =>
-      state = state.copyWith(keyword: keyword);
-
   void setTags(List<String> tags) => state = state.copyWith(tags: tags);
 
   void toggleOnlineOnly() =>
@@ -149,7 +142,10 @@ class PolicyFilterUiStateNotifier extends StateNotifier<PolicyFilterUiState> {
   }
 }
 
-final policyFilterUiStateProvider =
+final globalFilterProvider =
     StateNotifierProvider<PolicyFilterUiStateNotifier, PolicyFilterUiState>(
   (ref) => PolicyFilterUiStateNotifier(),
 );
+
+@Deprecated('Use globalFilterProvider instead')
+final policyFilterUiStateProvider = globalFilterProvider;

--- a/lib/features/policy_new/application/filters/policy_search_keyword_provider.dart
+++ b/lib/features/policy_new/application/filters/policy_search_keyword_provider.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/values/policy_feed_type.dart';
+
+class PolicySearchKeywordNotifier extends StateNotifier<String> {
+  PolicySearchKeywordNotifier() : super('');
+
+  void set(String value) => state = value.trim();
+
+  void clear() => state = '';
+}
+
+final policySearchKeywordProvider = StateNotifierProvider.family<
+    PolicySearchKeywordNotifier, String, PolicyFeedType>((ref, _) {
+  return PolicySearchKeywordNotifier();
+});

--- a/lib/features/policy_new/application/providers.dart
+++ b/lib/features/policy_new/application/providers.dart
@@ -39,6 +39,7 @@ import 'controllers/notification_center_controller.dart';
 import 'controllers/policy_action_controller.dart';
 import 'controllers/policy_paging_controller.dart';
 import 'controllers/policy_paging_state.dart';
+import 'controllers/global_filter_controller.dart';
 import 'controllers/policy_query_engine.dart';
 import 'controllers/policy_selection_controller.dart';
 import 'controllers/policy_query_override.dart';
@@ -49,6 +50,7 @@ import 'services/policy_favorite_service.dart';
 import 'services/policy_reminder_scheduler.dart';
 import 'services/policy_reminder_service.dart';
 import 'filters/policy_filter_ui_state.dart';
+import 'filters/policy_search_keyword_provider.dart';
 import 'filters/policy_filter_summary.dart';
 import 'models/user_collections.dart';
 import 'controllers/policy_feed_memory_cache.dart';
@@ -417,7 +419,8 @@ final notificationCenterControllerProvider = StateNotifierProvider<
 
 final policyQueryProvider = Provider.family<PolicyQueryState, PolicyFeedType>(
   (ref, feedType) {
-    final filter = ref.watch(policyFilterUiStateProvider);
+    final filter = ref.watch(globalFilterProvider);
+    final keyword = ref.watch(policySearchKeywordProvider(feedType));
 
     // dependencies to rebuild query on changes
     ref.watch(userProfileProvider);
@@ -425,26 +428,27 @@ final policyQueryProvider = Provider.family<PolicyQueryState, PolicyFeedType>(
     ref.watch(favoriteIdsProvider);
     ref.watch(compareRepositoryProvider);
 
-  final orchestrator = ref.read(policyQueryOrchestratorProvider);
-  final query = orchestrator.buildQuery(feedType);
+    final orchestrator = ref.read(policyQueryOrchestratorProvider);
+    final query = orchestrator.buildQuery(feedType, keyword: keyword);
 
-  final baseState = PolicyQueryState(
-    query: query,
-    hash: query.cacheScopeKey,
-    summary: buildPolicyFilterSummary(filter),
-    conditionSummary: buildPolicyFilterConditionSummary(filter),
-  );
+    final baseState = PolicyQueryState(
+      query: query,
+      hash: query.cacheScopeKey,
+      summary: buildPolicyFilterSummary(filter, keyword: keyword),
+      conditionSummary:
+          buildPolicyFilterConditionSummary(filter, keyword: keyword),
+    );
 
-  final overrideNotifier =
-      ref.read(policyQueryOverrideProvider(feedType).notifier);
-  overrideNotifier.ensureActiveForHash(baseState.hash);
+    final overrideNotifier =
+        ref.read(policyQueryOverrideProvider(feedType).notifier);
+    overrideNotifier.ensureActiveForHash(baseState.hash);
 
-  final overrideState = ref.watch(policyQueryOverrideProvider(feedType));
-  if (overrideState != null &&
-      overrideState.queryState.hash == baseState.hash) {
-    return overrideState.queryState;
-  }
+    final overrideState = ref.watch(policyQueryOverrideProvider(feedType));
+    if (overrideState != null &&
+        overrideState.queryState.hash == baseState.hash) {
+      return overrideState.queryState;
+    }
 
-  return baseState;
+    return baseState;
   },
 );

--- a/lib/features/policy_new/presentation/explore/policy_explore_screen.dart
+++ b/lib/features/policy_new/presentation/explore/policy_explore_screen.dart
@@ -6,13 +6,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../application/explore/explore_providers.dart';
 import '../../application/explore/explore_state.dart';
 import '../../application/filters/policy_filter_ui_state.dart';
+import '../../application/filters/policy_search_keyword_provider.dart';
 import '../../application/providers.dart';
 import '../../domain/values/policy_feed_type.dart';
+import '../../domain/values/policy_category.dart';
 import '../../domain/values/policy_sort.dart';
 import '../filters/policy_filter_bar.dart';
 import '../widgets/policy_feed_list_view.dart';
-import '../../../../application/notifiers/region_notifier.dart';
-import '../../../../ui/screens/region/region_select_screen.dart';
+import '../widgets/policy_query_summary.dart';
 
 class PolicyExploreScreen extends ConsumerStatefulWidget {
   const PolicyExploreScreen({super.key});
@@ -50,21 +51,24 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
   Widget build(BuildContext context) {
     final state = ref.watch(exploreStateProvider);
     final controller = ref.read(exploreStateProvider.notifier);
-    final filterUi = ref.watch(policyFilterUiStateProvider);
-    final regionNotifier = ref.read(regionProvider.notifier);
-    final regionName = state.selectedRegionName ?? regionNotifier.summary;
+    final filterUi = ref.watch(globalFilterProvider);
+
+    final keyword = ref.watch(policySearchKeywordProvider(PolicyFeedType.search));
 
     // 검색어 동기화
-    if (_searchController.text != state.keyword) {
-      _searchController.text = state.keyword;
+    if (_searchController.text != keyword) {
+      _searchController.text = keyword;
       _searchController.selection = TextSelection.fromPosition(
         TextPosition(offset: _searchController.text.length),
       );
     }
 
-    final feedType = _feedTypeFor(state);
+    final feedType = _feedTypeFor(state, keyword: keyword);
     final queryState = ref.watch(policyQueryProvider(feedType));
     final summary = queryState.summary;
+    final statusFilter =
+        filterUi.showOnlyOngoing ? PolicyStatusFilter.inProgressOnly : PolicyStatusFilter.includeClosed;
+    final sortKind = _mapSortKind(filterUi.sort);
 
     return Scaffold(
       appBar: AppBar(
@@ -81,8 +85,8 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   _SearchBarRow(
-                    keyword: state.keyword,
-                    sortKind: state.sortKind,
+                    keyword: keyword,
+                    sortKind: sortKind,
                     onKeywordChanged: controller.setKeyword,
                     onSubmit: controller.setKeyword,
                     onSortChanged: controller.setSortKind,
@@ -92,8 +96,10 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
                   ),
                   const SizedBox(height: 8),
                   _QuickFilterChips(
-                    state: state,
-                    regionName: regionName,
+                    isOngoingOnly:
+                        statusFilter == PolicyStatusFilter.inProgressOnly,
+                    regionName: filterUi.regionSummary,
+                    isRegionMode: state.mode == ExploreSubMode.region,
                     onToggleStatus: (value) =>
                         controller.setStatusFilter(value),
                     onToggleRegion: () {
@@ -106,7 +112,7 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
                     },
                   ),
                   const SizedBox(height: 8),
-                  _SummaryRow(
+                  PolicyQuerySummary(
                     summary: summary,
                     conditionSummary: queryState.conditionSummary,
                     onReset: controller.clearFilters,
@@ -162,14 +168,73 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
     return PolicyFeedListView(feedType: feedType);
   }
 
-  PolicyFeedType _feedTypeFor(ExploreState state) {
-    if (state.mode == ExploreSubMode.search && state.keyword.isNotEmpty) {
+  PolicyFeedType _feedTypeFor(ExploreState state, {String keyword = ''}) {
+    if (state.mode == ExploreSubMode.search && keyword.isNotEmpty) {
       return PolicyFeedType.search;
     }
     if (state.mode == ExploreSubMode.region) {
       return PolicyFeedType.region;
     }
     return PolicyFeedType.all;
+  }
+
+  String? _categoryId(PolicyCategory? category) {
+    switch (category) {
+      case PolicyCategory.employment:
+        return 'employment';
+      case PolicyCategory.startup:
+        return 'startup';
+      case PolicyCategory.housing:
+        return 'housing';
+      case PolicyCategory.education:
+        return 'education';
+      case PolicyCategory.life:
+        return 'life';
+      case PolicyCategory.welfare:
+        return 'welfare';
+      case PolicyCategory.culture:
+        return 'culture';
+      case PolicyCategory.other:
+        return 'other';
+      case null:
+        return null;
+    }
+  }
+
+  PolicySortKind _mapSortKind(PolicySortOption option) {
+    switch (option) {
+      case PolicySortOption.recommendation:
+        return PolicySortKind.recommended;
+      case PolicySortOption.latest:
+        return PolicySortKind.newest;
+      case PolicySortOption.deadline:
+        return PolicySortKind.deadline;
+      case PolicySortOption.popularity:
+        return PolicySortKind.amount;
+    }
+  }
+
+  PolicyCategory? _mapCategory(String id) {
+    switch (id) {
+      case 'employment':
+        return PolicyCategory.employment;
+      case 'startup':
+        return PolicyCategory.startup;
+      case 'housing':
+        return PolicyCategory.housing;
+      case 'education':
+        return PolicyCategory.education;
+      case 'life':
+        return PolicyCategory.life;
+      case 'welfare':
+        return PolicyCategory.welfare;
+      case 'culture':
+        return PolicyCategory.culture;
+      case 'other':
+        return PolicyCategory.other;
+      default:
+        return null;
+    }
   }
 
   void _openFilterBottomSheet(
@@ -181,8 +246,14 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
       context: context,
       isScrollControlled: true,
       builder: (ctx) {
-        final tempCategories = {...state.selectedCategories};
-        var tempStatus = state.statusFilter;
+        final filter = ref.read(globalFilterProvider);
+        final initialCategory = _categoryId(filter.category);
+        final tempCategories = {
+          if (initialCategory != null) initialCategory,
+        };
+        var tempStatus = filter.showOnlyOngoing
+            ? PolicyStatusFilter.inProgressOnly
+            : PolicyStatusFilter.includeClosed;
         return StatefulBuilder(
           builder: (context, setState) {
             return SafeArea(
@@ -291,11 +362,14 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
                         Expanded(
                           child: ElevatedButton(
                             onPressed: () {
-                              controller.clearFilters();
                               controller.setStatusFilter(tempStatus);
-                              for (final id in tempCategories) {
-                                controller.toggleCategory(id);
-                              }
+                              final selectedCategory =
+                                  tempCategories.isNotEmpty ? tempCategories.first : null;
+                              final categoryEnum =
+                                  selectedCategory != null ? _mapCategory(selectedCategory) : null;
+                              ref
+                                  .read(globalFilterProvider.notifier)
+                                  .setCategory(selectedCategory == null ? null : categoryEnum);
                               Navigator.of(context).pop();
                             },
                             child: const Text('적용'),
@@ -439,14 +513,16 @@ class _SearchBarRow extends StatelessWidget {
 
 class _QuickFilterChips extends StatelessWidget {
   const _QuickFilterChips({
-    required this.state,
+    required this.isOngoingOnly,
     required this.regionName,
+    required this.isRegionMode,
     required this.onToggleStatus,
     required this.onToggleRegion,
   });
 
-  final ExploreState state;
+  final bool isOngoingOnly;
   final String regionName;
+  final bool isRegionMode;
   final void Function(PolicyStatusFilter) onToggleStatus;
   final VoidCallback onToggleRegion;
 
@@ -455,12 +531,12 @@ class _QuickFilterChips extends StatelessWidget {
     final chips = <Widget>[
       ChoiceChip(
         label: const Text('진행중만'),
-        selected: state.statusFilter == PolicyStatusFilter.inProgressOnly,
+        selected: isOngoingOnly,
         onSelected: (_) => onToggleStatus(PolicyStatusFilter.inProgressOnly),
       ),
       ChoiceChip(
         label: Text('내 지역 ($regionName)'),
-        selected: state.mode == ExploreSubMode.region,
+        selected: isRegionMode,
         onSelected: (_) => onToggleRegion(),
       ),
     ];
@@ -483,57 +559,3 @@ class _QuickFilterChips extends StatelessWidget {
   }
 }
 
-class _SummaryRow extends StatelessWidget {
-  const _SummaryRow({
-    required this.summary,
-    required this.conditionSummary,
-    required this.onReset,
-    required this.onTap,
-  });
-
-  final String summary;
-  final String conditionSummary;
-  final VoidCallback onReset;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onTap,
-      child: Row(
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  summary,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodyMedium
-                      ?.copyWith(fontWeight: FontWeight.w600),
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  conditionSummary,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodySmall
-                      ?.copyWith(color: Colors.black54),
-                ),
-              ],
-            ),
-          ),
-          TextButton(
-            onPressed: onReset,
-            child: const Text('초기화'),
-          ),
-        ],
-      ),
-    );
-  }
-}

--- a/lib/features/policy_new/presentation/filters/policy_filter_bar.dart
+++ b/lib/features/policy_new/presentation/filters/policy_filter_bar.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../application/controllers/ui_reaction_controller.dart';
 import '../../application/filters/policy_filter_ui_state.dart';
+import '../../application/filters/policy_search_keyword_provider.dart';
 import '../../domain/values/policy_feed_type.dart';
 import '../../domain/values/policy_sort.dart';
 import 'policy_filter_bottom_sheet.dart';
@@ -19,7 +20,8 @@ class PolicyFilterBar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ui = ref.watch(policyFilterUiStateProvider);
+    final ui = ref.watch(globalFilterProvider);
+    final keyword = ref.watch(policySearchKeywordProvider(feedType));
 
     return Container(
       color: Theme.of(context).scaffoldBackgroundColor,
@@ -42,12 +44,12 @@ class PolicyFilterBar extends ConsumerWidget {
                     const SizedBox(width: 6),
                     Expanded(
                       child: Text(
-                        ui.keyword.isEmpty ? '검색어를 입력하세요' : ui.keyword,
+                        keyword.isEmpty ? '검색어를 입력하세요' : keyword,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: TextStyle(
                           color:
-                              ui.keyword.isEmpty ? Colors.grey : Colors.black,
+                              keyword.isEmpty ? Colors.grey : Colors.black,
                         ),
                       ),
                     ),
@@ -121,7 +123,7 @@ class PolicyFilterBar extends ConsumerWidget {
     );
     ref
         .read(uiReactionControllerProvider(feedType).notifier)
-        .markSearchConfirmed(ref.read(policyFilterUiStateProvider).keyword);
+        .markSearchConfirmed(ref.read(policySearchKeywordProvider(feedType)));
   }
 
   void _openSortSheet(BuildContext context, WidgetRef ref) {

--- a/lib/features/policy_new/presentation/filters/policy_filter_bottom_sheet.dart
+++ b/lib/features/policy_new/presentation/filters/policy_filter_bottom_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../application/filters/policy_filter_ui_state.dart';
+import '../../application/controllers/global_filter_controller.dart';
 import '../../application/providers.dart';
 import '../../application/controllers/ui_reaction_controller.dart';
 import '../../domain/entities/department.dart';
@@ -40,7 +41,7 @@ class _PolicyFilterBottomSheetState
   @override
   void initState() {
     super.initState();
-    final ui = ref.read(policyFilterUiStateProvider);
+    final ui = ref.read(globalFilterProvider);
     _region = ui.region;
     _category = ui.category;
     _showOnlyOnline = ui.showOnlyOnline;
@@ -381,7 +382,7 @@ class _PolicyFilterBottomSheetState
   }
 
   void _resetFilters() {
-    ref.read(policyFilterUiStateProvider.notifier).resetAll();
+    ref.read(globalFilterControllerProvider).resetAll();
     setState(() {
       _region = PolicyRegion.all;
       _category = null;
@@ -396,8 +397,8 @@ class _PolicyFilterBottomSheetState
   }
 
   void _applyFilters() {
-    final notifier = ref.read(policyFilterUiStateProvider.notifier);
-    final current = ref.read(policyFilterUiStateProvider);
+    final notifier = ref.read(globalFilterProvider.notifier);
+    final current = ref.read(globalFilterProvider);
     var hasChanged = false;
 
     if (current.region != _region) {

--- a/lib/features/policy_new/presentation/filters/policy_keyword_sheet.dart
+++ b/lib/features/policy_new/presentation/filters/policy_keyword_sheet.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../application/controllers/ui_reaction_controller.dart';
-import '../../application/filters/policy_filter_ui_state.dart';
+import '../../application/filters/policy_search_keyword_provider.dart';
 import '../../application/providers.dart';
 import '../../domain/values/policy_feed_type.dart';
 
@@ -27,8 +27,8 @@ class _PolicyKeywordSheetState extends ConsumerState<PolicyKeywordSheet> {
   @override
   void initState() {
     super.initState();
-    final ui = ref.read(policyFilterUiStateProvider);
-    _controller = TextEditingController(text: ui.keyword);
+    final keyword = ref.read(policySearchKeywordProvider(widget.feedType));
+    _controller = TextEditingController(text: keyword);
   }
 
   @override
@@ -96,8 +96,9 @@ class _PolicyKeywordSheetState extends ConsumerState<PolicyKeywordSheet> {
 
   void _applyKeyword(String value) {
     final keyword = value.trim();
-    final prev = ref.read(policyFilterUiStateProvider).keyword;
-    ref.read(policyFilterUiStateProvider.notifier).setKeyword(keyword);
+    final notifier = ref.read(policySearchKeywordProvider(widget.feedType).notifier);
+    final prev = ref.read(policySearchKeywordProvider(widget.feedType));
+    notifier.set(keyword);
 
     final reaction =
         ref.read(uiReactionControllerProvider(widget.feedType).notifier);

--- a/lib/features/policy_new/presentation/filters/policy_recommend_tags_bar.dart
+++ b/lib/features/policy_new/presentation/filters/policy_recommend_tags_bar.dart
@@ -9,8 +9,8 @@ class PolicyRecommendTagsBar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ui = ref.watch(policyFilterUiStateProvider);
-    final notifier = ref.read(policyFilterUiStateProvider.notifier);
+    final ui = ref.watch(globalFilterProvider);
+    final notifier = ref.read(globalFilterProvider.notifier);
     final profileTags = ref.watch(userProfileProvider).recommendTags;
     final tags = ui.tags.isNotEmpty
         ? ui.tags

--- a/lib/features/policy_new/presentation/filters/policy_sort_bottom_sheet.dart
+++ b/lib/features/policy_new/presentation/filters/policy_sort_bottom_sheet.dart
@@ -16,7 +16,7 @@ class PolicySortBottomSheet extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ui = ref.watch(policyFilterUiStateProvider);
+    final ui = ref.watch(globalFilterProvider);
 
     return SafeArea(
       child: Padding(
@@ -36,7 +36,7 @@ class PolicySortBottomSheet extends ConsumerWidget {
                 groupValue: ui.sort,
                 onChanged: (value) {
                   if (value == null) return;
-                  ref.read(policyFilterUiStateProvider.notifier).setSort(value);
+                  ref.read(globalFilterProvider.notifier).setSort(value);
                   ref
                       .read(uiReactionControllerProvider(feedType).notifier)
                       .markFilterConfirmed('${_label(value)} 정렬을 적용했어요.');

--- a/lib/features/policy_new/presentation/tabs/policy_feed_tab.dart
+++ b/lib/features/policy_new/presentation/tabs/policy_feed_tab.dart
@@ -2,12 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../application/filters/policy_filter_ui_state.dart';
+import '../../application/filters/policy_search_keyword_provider.dart';
+import '../../application/controllers/global_filter_controller.dart';
 import '../../application/providers.dart';
 import '../../domain/values/policy_feed_type.dart';
 import '../../domain/values/policy_category.dart';
 import '../compare/widgets/compare_entry_bar.dart';
 import '../widgets/policy_feed_list_view.dart';
 import '../compare/policy_compare_screen.dart';
+import '../widgets/policy_query_summary.dart';
 import '../../../../ui/layout/app_screen_container.dart';
 import '../../../../ui/layout/app_floating_bar.dart';
 import '../../../../ui/components/app_card.dart';
@@ -36,7 +39,7 @@ class _PolicyFeedTabState extends ConsumerState<PolicyFeedTab> {
   @override
   void initState() {
     super.initState();
-    ref.listen<PolicyFilterUiState>(policyFilterUiStateProvider,
+    ref.listen<PolicyFilterUiState>(globalFilterProvider,
         (prev, next) async {
       if (!mounted) return;
       if (prev == null || prev == next) return;
@@ -50,7 +53,8 @@ class _PolicyFeedTabState extends ConsumerState<PolicyFeedTab> {
 
   @override
   Widget build(BuildContext context) {
-    final filter = ref.watch(policyFilterUiStateProvider);
+    final filter = ref.watch(globalFilterProvider);
+    final keyword = ref.watch(policySearchKeywordProvider(widget.feedType));
     final queryState = ref.watch(policyQueryProvider(widget.feedType));
     final compareCount = ref.watch(compareRepositoryProvider).ids.length;
     final showCompareBar =
@@ -67,22 +71,24 @@ class _PolicyFeedTabState extends ConsumerState<PolicyFeedTab> {
             const SizedBox(height: AppSpacing.lg),
             Text('정책 탐색', style: AppText.textTheme.headlineSmall),
             const SizedBox(height: AppSpacing.sm),
-            Text(
-              summaryText,
-              style: AppText.textTheme.bodyMedium,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
+            PolicyQuerySummary(
+              summary: summaryText,
+              conditionSummary: queryState.conditionSummary,
+              onReset: () =>
+                  ref.read(globalFilterControllerProvider).resetAll(),
             ),
             const SizedBox(height: AppSpacing.md),
             _SelectedFilterBadges(
               filter: filter,
-              onClearKeyword: () =>
-                  ref.read(policyFilterUiStateProvider.notifier).setKeyword(''),
+              keyword: keyword,
+              onClearKeyword: () => ref
+                  .read(globalFilterControllerProvider)
+                  .setKeyword(widget.feedType, ''),
               onClearCategory: () => ref
-                  .read(policyFilterUiStateProvider.notifier)
+                  .read(globalFilterProvider.notifier)
                   .setCategory(null),
               onToggleOngoing: () => ref
-                  .read(policyFilterUiStateProvider.notifier)
+                  .read(globalFilterProvider.notifier)
                   .toggleOngoingOnly(),
             ),
             const SizedBox(height: AppSpacing.md),
@@ -127,12 +133,14 @@ class _PolicyFeedTabState extends ConsumerState<PolicyFeedTab> {
 class _SelectedFilterBadges extends StatelessWidget {
   const _SelectedFilterBadges({
     required this.filter,
+    required this.keyword,
     required this.onClearKeyword,
     required this.onClearCategory,
     required this.onToggleOngoing,
   });
 
   final PolicyFilterUiState filter;
+  final String keyword;
   final VoidCallback onClearKeyword;
   final VoidCallback onClearCategory;
   final VoidCallback onToggleOngoing;
@@ -150,13 +158,13 @@ class _SelectedFilterBadges extends StatelessWidget {
       onRemove: null,
     ));
 
-    if (filter.keyword.isNotEmpty) {
+    if (keyword.isNotEmpty) {
       badges.add(_Badge(
-        label: '검색어 "${filter.keyword}"',
+        label: '검색어 "$keyword"',
         color: color,
         textStyle: textStyle,
         onRemove: onClearKeyword,
-    )); 
+      ));
     }
 
     if (filter.category != null) {

--- a/lib/features/policy_new/presentation/widgets/policy_query_summary.dart
+++ b/lib/features/policy_new/presentation/widgets/policy_query_summary.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+class PolicyQuerySummary extends StatelessWidget {
+  const PolicyQuerySummary({
+    super.key,
+    required this.summary,
+    required this.conditionSummary,
+    required this.onReset,
+    this.onTap,
+  });
+
+  final String summary;
+  final String conditionSummary;
+  final VoidCallback onReset;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  summary,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodyMedium
+                      ?.copyWith(fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  conditionSummary,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodySmall
+                      ?.copyWith(color: Colors.black54),
+                ),
+              ],
+            ),
+          ),
+          TextButton(
+            onPressed: onReset,
+            child: const Text('초기화'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a global filter controller and per-feed keyword provider to serve as the single source of truth for policy filters
- rebuild policy query providers off the centralized filter state so explore, search, and recommendation tabs stay in sync
- standardize the query summary UI and reset flow across policy screens while keeping search keywords independent

## Testing
- Not run (tooling unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934cf6d33b48324bd28cb8be3c3a7fd)