### PR TITLE
feat: 정책 피드 개인화 점수 적용

### DIFF
--- a/lib/features/policy_new/application/controllers/base_feed_controller.dart
+++ b/lib/features/policy_new/application/controllers/base_feed_controller.dart
@@ -43,20 +43,20 @@ abstract class BasePolicyFeedController extends StateNotifier<PolicyPagingState>
     _isLoadingPage = false;
 
     final query = buildBaseQuery();
+    ref.read(policyScoreProvider.notifier).reset();
     state = const PolicyPagingState.loading();
 
     final result = await queryEngine.fetch(query, page: _page);
-    result.fold(
-      onSuccess: (list) {
-        state = PolicyPagingState.data(
-          items: list,
-          hasMore: list.length == queryEngine.pageSize,
-        );
-      },
-      onFailure: (err) {
-        state = PolicyPagingState.error(err);
-      },
-    );
+    if (result.isSuccess && result.data != null) {
+      final scored =
+          ref.read(policyScoreProvider.notifier).applyScore(result.data!, query: query);
+      state = PolicyPagingState.data(
+        items: scored,
+        hasMore: result.data!.length == queryEngine.pageSize,
+      );
+    } else {
+      state = PolicyPagingState.error(result.failure!);
+    }
   }
 
   Future<void> loadNextPage() async {
@@ -68,19 +68,18 @@ abstract class BasePolicyFeedController extends StateNotifier<PolicyPagingState>
     final query = buildBaseQuery();
 
     final result = await queryEngine.fetch(query, page: nextPage);
-    result.fold(
-      onSuccess: (list) {
-        final merged = [...state.items, ...list];
-        state = PolicyPagingState.data(
-          items: merged,
-          hasMore: list.length == queryEngine.pageSize,
-        );
-        _page = nextPage;
-      },
-      onFailure: (err) {
-        state = PolicyPagingState.error(err);
-      },
-    );
+    if (result.isSuccess && result.data != null) {
+      final merged = [...state.items, ...result.data!];
+      final scored =
+          ref.read(policyScoreProvider.notifier).applyScore(merged, query: query);
+      state = PolicyPagingState.data(
+        items: scored,
+        hasMore: result.data!.length == queryEngine.pageSize,
+      );
+      _page = nextPage;
+    } else {
+      state = PolicyPagingState.error(result.failure!);
+    }
 
     _isLoadingPage = false;
   }

--- a/lib/features/policy_new/application/controllers/policy_behavior_controller.dart
+++ b/lib/features/policy_new/application/controllers/policy_behavior_controller.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/policy.dart';
+import '../../domain/values/policy_category.dart';
+import '../../domain/values/policy_region.dart';
+
+class PolicyBehaviorRecord {
+  final String policyId;
+  final PolicyRegion region;
+  final PolicyCategory category;
+  final List<String> tags;
+  final DateTime timestamp;
+
+  const PolicyBehaviorRecord({
+    required this.policyId,
+    required this.region,
+    required this.category,
+    required this.tags,
+    required this.timestamp,
+  });
+}
+
+class PolicyBehaviorState {
+  final List<PolicyBehaviorRecord> recentViewedPolicies;
+  final List<PolicyBehaviorRecord> recentFavorites;
+
+  const PolicyBehaviorState({
+    this.recentViewedPolicies = const [],
+    this.recentFavorites = const [],
+  });
+
+  PolicyBehaviorState copyWith({
+    List<PolicyBehaviorRecord>? recentViewedPolicies,
+    List<PolicyBehaviorRecord>? recentFavorites,
+  }) {
+    return PolicyBehaviorState(
+      recentViewedPolicies: recentViewedPolicies ?? this.recentViewedPolicies,
+      recentFavorites: recentFavorites ?? this.recentFavorites,
+    );
+  }
+}
+
+class PolicyBehaviorController extends StateNotifier<PolicyBehaviorState> {
+  PolicyBehaviorController() : super(const PolicyBehaviorState());
+
+  static const _maxKeep = 30;
+
+  void recordView(Policy policy) {
+    _record(
+      policy: policy,
+      asFavorite: false,
+    );
+  }
+
+  void recordFavorite(Policy policy) {
+    _record(
+      policy: policy,
+      asFavorite: true,
+    );
+  }
+
+  void syncFavorites(List<Policy> policies, List<String> favoriteIds) {
+    for (final policy in policies) {
+      if (favoriteIds.contains(policy.id)) {
+        _record(policy: policy, asFavorite: true);
+      }
+    }
+  }
+
+  void _record({required Policy policy, required bool asFavorite}) {
+    final record = PolicyBehaviorRecord(
+      policyId: policy.id,
+      region: policy.region,
+      category: policy.category,
+      tags: policy.tags,
+      timestamp: DateTime.now(),
+    );
+
+    if (asFavorite) {
+      _updateList(isFavorite: true, record: record);
+    } else {
+      _updateList(isFavorite: false, record: record);
+    }
+  }
+
+  void _updateList({required bool isFavorite, required PolicyBehaviorRecord record}) {
+    final current = isFavorite
+        ? List<PolicyBehaviorRecord>.from(state.recentFavorites)
+        : List<PolicyBehaviorRecord>.from(state.recentViewedPolicies);
+
+    current.removeWhere((element) => element.policyId == record.policyId);
+    current.insert(0, record);
+
+    if (current.length > _maxKeep) {
+      current.removeRange(_maxKeep, current.length);
+    }
+
+    if (isFavorite) {
+      state = state.copyWith(recentFavorites: current);
+    } else {
+      state = state.copyWith(recentViewedPolicies: current);
+    }
+  }
+}

--- a/lib/features/policy_new/application/controllers/policy_scoring_controller.dart
+++ b/lib/features/policy_new/application/controllers/policy_scoring_controller.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/policy.dart';
+import '../../domain/values/policy_query.dart';
+import '../../domain/values/policy_region.dart';
+import '../providers.dart';
+import 'policy_behavior_controller.dart';
+
+class PolicyScoreController extends StateNotifier<Map<String, double>> {
+  PolicyScoreController(this.ref) : super(const {});
+
+  final Ref ref;
+
+  void reset() {
+    state = const {};
+  }
+
+  List<Policy> applyScore(
+    List<Policy> policies, {
+    required PolicyQuery query,
+  }) {
+    if (policies.isEmpty) {
+      reset();
+      return policies;
+    }
+
+    final behaviorNotifier = ref.read(policyBehaviorProvider.notifier);
+    final favoriteIds = ref.read(favoriteRepositoryProvider).allIds;
+    behaviorNotifier.syncFavorites(policies, favoriteIds);
+    final behavior = ref.read(policyBehaviorProvider);
+
+    final viewedTags = behavior.recentViewedPolicies
+        .expand((record) => record.tags)
+        .toSet();
+    final favoriteTags = behavior.recentFavorites
+        .expand((record) => record.tags)
+        .toSet();
+    final latestViewed = behavior.recentViewedPolicies.isNotEmpty
+        ? behavior.recentViewedPolicies.first
+        : null;
+
+    final preferredRegion = _preferredRegion(query);
+
+    final rawScores = <String, double>{};
+    for (final policy in policies) {
+      double score = 0;
+
+      final viewedIntersection =
+          policy.tags.where((tag) => viewedTags.contains(tag)).length;
+      final favoriteIntersection =
+          policy.tags.where((tag) => favoriteTags.contains(tag)).length;
+
+      score += viewedIntersection * 6;
+      score += favoriteIntersection * 10;
+
+      if (preferredRegion != null && policy.region == preferredRegion) {
+        score += 12;
+      }
+
+      if (latestViewed != null) {
+        if (policy.id == latestViewed.policyId) {
+          score += 18;
+        } else {
+          final matchesCategory = policy.category == latestViewed.category;
+          final matchesRegion = policy.region == latestViewed.region;
+          if (matchesCategory) score += 8;
+          if (matchesRegion) score += 6;
+        }
+      }
+
+      rawScores[policy.id] = score;
+    }
+
+    final normalized = _normalize(rawScores);
+    state = normalized;
+
+    final sorted = List<Policy>.from(policies);
+    sorted.sort((a, b) {
+      final scoreA = normalized[a.id] ?? 0;
+      final scoreB = normalized[b.id] ?? 0;
+      if (scoreA != scoreB) return scoreB.compareTo(scoreA);
+      return b.createdAt.compareTo(a.createdAt);
+    });
+
+    return sorted;
+  }
+
+  PolicyRegion? _preferredRegion(PolicyQuery query) {
+    if (query.filter.region != PolicyRegion.all) {
+      return query.filter.region;
+    }
+    return ref.read(userProfileProvider).region;
+  }
+
+  Map<String, double> _normalize(Map<String, double> rawScores) {
+    if (rawScores.isEmpty) return const {};
+    final maxScore = rawScores.values.fold<double>(0, (prev, element) {
+      return element > prev ? element : prev;
+    });
+
+    if (maxScore == 0) {
+      return rawScores.map((key, value) => MapEntry(key, 0));
+    }
+
+    return rawScores.map(
+      (key, value) => MapEntry(
+        key,
+        (value / maxScore) * 100,
+      ),
+    );
+  }
+}

--- a/lib/features/policy_new/application/providers.dart
+++ b/lib/features/policy_new/application/providers.dart
@@ -13,11 +13,13 @@ import '../domain/values/policy_settings.dart';
 import '../domain/values/policy_sort.dart';
 import 'controllers/base_feed_controller.dart';
 import 'controllers/policy_detail_controller.dart';
+import 'controllers/policy_behavior_controller.dart';
 import 'controllers/policy_event_bus.dart';
 import 'controllers/policy_feed_controllers.dart';
 import 'controllers/policy_paging_state.dart';
 import 'controllers/policy_query_controller.dart';
 import 'controllers/policy_query_engine.dart';
+import 'controllers/policy_scoring_controller.dart';
 import '../data/cache/policy_cache.dart';
 import '../data/repositories/policy_repository_impl.dart';
 import '../data/sources/policy_remote_source.dart';
@@ -83,6 +85,18 @@ final favoriteRepositoryProvider = Provider<FavoriteRepository>((ref) {
 final compareRepositoryProvider = Provider<CompareRepository>((ref) {
   return const CompareRepository();
 });
+
+final policyBehaviorProvider =
+    StateNotifierProvider<PolicyBehaviorController, PolicyBehaviorState>(
+  (ref) => PolicyBehaviorController(),
+);
+
+final policyScoreProvider =
+    StateNotifierProvider<PolicyScoreController, Map<String, double>>(
+  (ref) => PolicyScoreController(ref),
+);
+
+final policyDebugModeProvider = StateProvider<bool>((ref) => false);
 
 final isMockModeProvider = Provider<bool>((ref) => false);
 

--- a/lib/features/policy_new/presentation/detail/policy_detail_bottom_sheet.dart
+++ b/lib/features/policy_new/presentation/detail/policy_detail_bottom_sheet.dart
@@ -26,17 +26,20 @@ class PolicyDetailBottomSheet extends ConsumerWidget {
       initialChildSize: 0.85,
       minChildSize: 0.5,
       maxChildSize: 0.95,
-      builder: (context, scrollController) {
-        return Material(
-          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
-          clipBehavior: Clip.antiAlias,
-          child: asyncPolicy.when(
-            data: (policy) => _buildContent(context, scrollController, policy),
-            loading: () => const PolicyListLoading(),
-            error: (err, __) => _buildError(context, err, detailController),
-          ),
-        );
-      },
+          builder: (context, scrollController) {
+            return Material(
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+              clipBehavior: Clip.antiAlias,
+              child: asyncPolicy.when(
+                data: (policy) {
+                  ref.read(policyBehaviorProvider.notifier).recordView(policy);
+                  return _buildContent(context, scrollController, policy);
+                },
+                loading: () => const PolicyListLoading(),
+                error: (err, __) => _buildError(context, err, detailController),
+              ),
+            );
+          },
     );
   }
 

--- a/lib/features/policy_new/presentation/widgets/policy_card.dart
+++ b/lib/features/policy_new/presentation/widgets/policy_card.dart
@@ -7,10 +7,12 @@ class PolicyCard extends StatelessWidget {
     super.key,
     required this.policy,
     required this.onTap,
+    this.debugScore,
   });
 
   final Policy policy;
   final VoidCallback onTap;
+  final double? debugScore;
 
   @override
   Widget build(BuildContext context) {
@@ -25,9 +27,32 @@ class PolicyCard extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                policy.title,
-                style: Theme.of(context).textTheme.titleMedium,
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Text(
+                      policy.title,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  ),
+                  if (debugScore != null)
+                    Container(
+                      padding:
+                          const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: Colors.black.withOpacity(0.04),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        'score ${debugScore!.toStringAsFixed(1)}',
+                        style: Theme.of(context)
+                            .textTheme
+                            .labelSmall
+                            ?.copyWith(color: Colors.blueGrey.shade700),
+                      ),
+                    ),
+                ],
               ),
               const SizedBox(height: 6),
               Text(

--- a/lib/features/policy_new/presentation/widgets/policy_feed_list_view.dart
+++ b/lib/features/policy_new/presentation/widgets/policy_feed_list_view.dart
@@ -22,6 +22,8 @@ class PolicyFeedListView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final (state, notifier) = _useController(ref);
+    final debugMode = ref.watch(policyDebugModeProvider);
+    final scores = ref.watch(policyScoreProvider);
 
     notifier.ensureInitialized();
 
@@ -50,6 +52,7 @@ class PolicyFeedListView extends ConsumerWidget {
             final policy = state.items[index];
             return PolicyCard(
               policy: policy,
+              debugScore: debugMode ? scores[policy.id] : null,
               onTap: () => _openDetail(context, policy.id),
             );
           }


### PR DESCRIPTION
## Summary
- 최근 조회/즐겨찾기 기록을 보관하는 사용자 행동 컨트롤러와 점수 컨트롤러를 추가해 개인화 점수를 계산하도록 구성했습니다.
- 피드 컨트롤러가 조회한 정책 리스트에 점수를 적용해 정렬하고, 디버그 모드에서 카드에 점수를 표시할 수 있게 했습니다.
- 상세 화면 진입 시 조회 기록을 저장해 관련 정책이 상단에 노출되도록 기반을 마련했습니다.

## Testing
- dart format lib/features/policy_new/application/controllers/base_feed_controller.dart lib/features/policy_new/application/controllers/policy_scoring_controller.dart lib/features/policy_new/application/controllers/policy_behavior_controller.dart lib/features/policy_new/application/providers.dart lib/features/policy_new/presentation/widgets/policy_card.dart lib/features/policy_new/presentation/widgets/policy_feed_list_view.dart lib/features/policy_new/presentation/detail/policy_detail_bottom_sheet.dart *(fails: `dart` command not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934d5383360832483caeeec4860abf5)