### PR TITLE
fix: 정책 알림 흐름 및 신청 기간 표시 개선

### DIFF
--- a/lib/features/policy_new/application/controllers/policy_reminder_controller.dart
+++ b/lib/features/policy_new/application/controllers/policy_reminder_controller.dart
@@ -90,12 +90,7 @@ class PolicyReminderController
     final previous = state.value ?? PolicyReminderViewState.initial();
     state = AsyncData(previous.copyWith(isRefreshing: true));
 
-    final reminders =
-        await ref.read(policyReminderRepositoryProvider).getRemindersForPolicy(
-              policyId,
-            );
-
-    reminders.sort((a, b) => a.scheduledAt.compareTo(b.scheduledAt));
+    final reminders = await _fetchReminders();
 
     state = AsyncData(
       previous.copyWith(
@@ -113,37 +108,28 @@ class PolicyReminderController
     final previous = state.value ?? PolicyReminderViewState.initial();
     state = AsyncData(previous.copyWith(isMutating: true, messages: const []));
     try {
-      final currentKinds = previous.reminders
-          .where(
-              (reminder) => reminder.status == PolicyReminderStatus.scheduled)
-          .map((reminder) => reminder.timeKind)
-          .toSet();
       final nextKinds = kinds.toSet();
 
-      final toRemove = currentKinds.difference(nextKinds);
+      await _service.cancelAllByPolicy(policyId, deleteFromRepository: true);
 
-      for (final reminder in previous.reminders) {
-        if (toRemove.contains(reminder.timeKind)) {
-          await _service.cancelReminder(reminder.reminderId);
-        }
-      }
+      final result = nextKinds.isEmpty
+          ? const ReminderMutationResult(reminders: [], failures: [])
+          : await _service.createRemindersForPolicy(
+              policy,
+              nextKinds.toList(),
+            );
 
-      final result = await _service.createRemindersForPolicy(
-        policy,
-        nextKinds.toList(),
-      );
-
-      final current = [
-        ...result.reminders,
-      ]..sort((a, b) => a.scheduledAt.compareTo(b.scheduledAt));
+      final refreshed = await _fetchReminders();
 
       state = AsyncData(
-        previous.copyWith(
-          reminders: current,
+        PolicyReminderViewState(
+          reminders: refreshed,
+          isRefreshing: false,
           isMutating: false,
           messages: _messagesForResult(result),
         ),
       );
+
       return result;
     } catch (e, st) {
       await load();
@@ -163,11 +149,8 @@ class PolicyReminderController
     final previous = state.value ?? PolicyReminderViewState.initial();
     state = AsyncData(previous.copyWith(isMutating: true));
     try {
-      await _service.cancelReminder(reminderId);
-      final current = [
-        for (final reminder in previous.reminders)
-          if (reminder.reminderId != reminderId) reminder,
-      ]..sort((a, b) => a.scheduledAt.compareTo(b.scheduledAt));
+      await _service.cancelReminder(reminderId, deleteFromRepository: true);
+      final current = await _fetchReminders();
       state = AsyncData(
         previous.copyWith(
           reminders: current,
@@ -190,7 +173,10 @@ class PolicyReminderController
     final previous = state.value ?? PolicyReminderViewState.initial();
     state = AsyncData(previous.copyWith(isMutating: true));
     try {
-      await _service.cancelAllByPolicy(policyId);
+      await _service.cancelAllByPolicy(
+        policyId,
+        deleteFromRepository: true,
+      );
       state = AsyncData(
         previous.copyWith(
           reminders: const [],
@@ -285,10 +271,15 @@ class PolicyReminderController
     final failureMessages = _messagesForFailures(result.failures);
     if (failureMessages.isNotEmpty) return failureMessages;
 
-    if (result.reminders.isEmpty) {
-      return const ['알림을 예약하지 못했어요. 잠시 후 다시 시도해주세요.'];
-    }
-
     return const [];
+  }
+
+  Future<List<PolicyReminder>> _fetchReminders() async {
+    final reminders =
+        await ref.read(policyReminderRepositoryProvider).getRemindersForPolicy(
+              policyId,
+            );
+    reminders.sort((a, b) => a.scheduledAt.compareTo(b.scheduledAt));
+    return reminders;
   }
 }

--- a/lib/features/policy_new/application/services/policy_reminder_service.dart
+++ b/lib/features/policy_new/application/services/policy_reminder_service.dart
@@ -296,7 +296,10 @@ class PolicyReminderService {
     return ReminderMutationResult(reminders: reminders, failures: failures);
   }
 
-  Future<void> cancelReminder(String reminderId) async {
+  Future<void> cancelReminder(
+    String reminderId, {
+    bool deleteFromRepository = false,
+  }) async {
     final reminder = await repository.getReminder(reminderId);
     if (reminder == null || reminder.status == PolicyReminderStatus.canceled) {
       return;
@@ -310,7 +313,11 @@ class PolicyReminderService {
       updatedAt: now,
     );
 
-    await repository.upsertReminder(canceledReminder);
+    if (deleteFromRepository) {
+      await repository.deleteReminderById(reminder.reminderId);
+    } else {
+      await repository.upsertReminder(canceledReminder);
+    }
     try {
       final result = await notificationGateway.cancelReminder(reminder.reminderId);
       if (!result.success) {
@@ -327,7 +334,10 @@ class PolicyReminderService {
     ));
   }
 
-  Future<void> cancelAllByPolicy(String policyId) async {
+  Future<void> cancelAllByPolicy(
+    String policyId, {
+    bool deleteFromRepository = false,
+  }) async {
     final reminders = await repository.getRemindersForPolicy(policyId);
     try {
       final bulkResult = await notificationGateway.cancelAllForPolicy(policyId);
@@ -353,13 +363,19 @@ class PolicyReminderService {
         logger.warn('Cancel reminder threw for ${reminder.reminderId}: $e\n$st');
       }
 
-      final canceledReminder = reminder.copyWith(
-        status: PolicyReminderStatus.canceled,
-        isActive: false,
-        canceledAt: now,
-        updatedAt: now,
-      );
-      await repository.upsertReminder(canceledReminder);
+      if (!deleteFromRepository) {
+        final canceledReminder = reminder.copyWith(
+          status: PolicyReminderStatus.canceled,
+          isActive: false,
+          canceledAt: now,
+          updatedAt: now,
+        );
+        await repository.upsertReminder(canceledReminder);
+      }
+    }
+
+    if (deleteFromRepository) {
+      await repository.deleteRemindersByPolicy(policyId);
     }
     if (reminders.isNotEmpty) {
       eventBus.emit(PolicyEvent(

--- a/lib/features/policy_new/presentation/detail/policy_detail_bottom_sheet.dart
+++ b/lib/features/policy_new/presentation/detail/policy_detail_bottom_sheet.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:intl/intl.dart';
+
 import '../../application/controllers/policy_detail_controller.dart';
 import '../../application/controllers/policy_query_override.dart';
 import '../../application/providers.dart';
@@ -251,18 +253,18 @@ class _Content extends StatelessWidget {
   static String _buildPeriodText(Policy policy) {
     final start = policy.applicationStartDate;
     final end = policy.applicationEndDate;
+    final format = DateFormat('yyyy.MM.dd (E)', 'ko');
 
     if (start == null && end == null) {
       return '일정 미확정';
     }
     if (start != null && end == null) {
-      return 'Start: ${start.toLocal().toString().split(" ").first}';
+      return '신청 시작일 ${format.format(start.toLocal())}';
     }
     if (start == null && end != null) {
-      return 'End: ${end.toLocal().toString().split(" ").first}';
+      return '신청 마감일 ${format.format(end.toLocal())}';
     }
-    return 'Period: ${start!.toLocal().toString().split(" ").first} ~ '
-        '${end!.toLocal().toString().split(" ").first}';
+    return '${format.format(start!.toLocal())} ~ ${format.format(end!.toLocal())}';
   }
 
   static String? _buildDDayLabel(Policy policy) {


### PR DESCRIPTION
## Summary
- 신청 기간을 한국어 날짜 포맷(yyyy.MM.dd (E))으로 표기하고 영어 라벨을 제거했습니다.
- 정책 알림 설정/해제 시 기존 알림을 먼저 정리하고 Isar 상태를 재조회해 버튼, 요약, 예약 목록이 동기화되도록 했습니다.
- 알림 취소 시 OS/DB 양쪽에서 정리하도록 서비스 로직을 보강했습니다.

## Testing
- Not run (CI 환경에서 실행되지 않음)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693600a40660832484d3293aeb393a9b)