### PR TITLE
정책 탐색 화면 검색/필터 UI 간소화

### DIFF
--- a/lib/features/policy_new/presentation/explore/policy_explore_screen.dart
+++ b/lib/features/policy_new/presentation/explore/policy_explore_screen.dart
@@ -11,7 +11,6 @@ import '../../application/providers.dart';
 import '../../domain/values/policy_feed_type.dart';
 import '../../domain/values/policy_category.dart';
 import '../../domain/values/policy_sort.dart';
-import '../filters/policy_filter_bar.dart';
 import '../widgets/policy_feed_list_view.dart';
 import '../widgets/policy_query_summary.dart';
 
@@ -80,7 +79,7 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
           children: [
             // 🔹 상단 컨트롤 영역 (검색 / 퀵 필터 / 요약)
             Padding(
-              padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -94,7 +93,7 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
                         _openFilterBottomSheet(context, controller, state),
                     textController: _searchController,
                   ),
-                  const SizedBox(height: 8),
+                  const SizedBox(height: 12),
                   _QuickFilterChips(
                     isOngoingOnly:
                         statusFilter == PolicyStatusFilter.inProgressOnly,
@@ -111,20 +110,18 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
                       }
                     },
                   ),
-                  const SizedBox(height: 8),
+                  const SizedBox(height: 10),
                   PolicyQuerySummary(
                     summary: summary,
                     conditionSummary: queryState.conditionSummary,
                     onReset: controller.clearFilters,
                     onTap: () =>
                         _openFilterBottomSheet(context, controller, state),
+                    showConditionSummary: false,
                   ),
                 ],
               ),
             ),
-
-            // 🔹 탐색 상단 공통 필터 바
-            PolicyFilterBar(feedType: feedType),
 
             // 🔹 본문: 정책 리스트 (단일 스크롤)
             Expanded(
@@ -436,7 +433,10 @@ class _SearchBarRow extends StatelessWidget {
           child: TextField(
             controller: textController,
             decoration: const InputDecoration(
+              labelText: '정책 제목/키워드 검색',
               hintText: '검색어를 입력하세요',
+              prefixIcon: Icon(Icons.search),
+              isDense: true,
             ),
             textInputAction: TextInputAction.search,
             onChanged: onKeywordChanged,

--- a/lib/features/policy_new/presentation/widgets/policy_query_summary.dart
+++ b/lib/features/policy_new/presentation/widgets/policy_query_summary.dart
@@ -7,12 +7,14 @@ class PolicyQuerySummary extends StatelessWidget {
     required this.conditionSummary,
     required this.onReset,
     this.onTap,
+    this.showConditionSummary = true,
   });
 
   final String summary;
   final String conditionSummary;
   final VoidCallback onReset;
   final VoidCallback? onTap;
+  final bool showConditionSummary;
 
   @override
   Widget build(BuildContext context) {
@@ -33,16 +35,18 @@ class PolicyQuerySummary extends StatelessWidget {
                       .bodyMedium
                       ?.copyWith(fontWeight: FontWeight.w600),
                 ),
-                const SizedBox(height: 4),
-                Text(
-                  conditionSummary,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodySmall
-                      ?.copyWith(color: Colors.black54),
-                ),
+                if (showConditionSummary && conditionSummary.isNotEmpty) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    conditionSummary,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodySmall
+                        ?.copyWith(color: Colors.black54),
+                  ),
+                ],
               ],
             ),
           ),


### PR DESCRIPTION
## Summary
- 정책 탐색 상단에서 검색창을 하나로 정리하고 검색 라벨을 명확히 표시했습니다.
- 퀵 필터와 필터 요약을 한 영역으로 묶어 간격을 조정하고 중복 노출을 제거했습니다.

## Testing
- Not run (환경에 flutter/dart 미설치)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936024b5f508324bdee8d160dfc73b2)