### PR TITLE
정책 알림 UX 단순화 및 날짜 포맷 통일

### DIFF
--- a/lib/features/policy_new/presentation/detail/policy_detail_bottom_sheet.dart
+++ b/lib/features/policy_new/presentation/detail/policy_detail_bottom_sheet.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:intl/intl.dart';
-
 import '../../application/controllers/policy_detail_controller.dart';
 import '../../application/controllers/policy_query_override.dart';
 import '../../application/providers.dart';
@@ -15,6 +13,7 @@ import '../widgets/policy_list_loading.dart';
 import '../reminder/policy_reminder_button.dart';
 import 'widgets/policy_action_bar.dart';
 import '../explore/policy_explore_screen.dart';
+import '../utils/policy_date_formatter.dart';
 import '../../../../ui/layout/app_screen_container.dart';
 import '../../../../ui/components/app_section_title.dart';
 import '../../../../ui/components/app_divider.dart';
@@ -152,22 +151,22 @@ class _Content extends StatelessWidget {
                   ),
                   _InfoSection(
                     title: '신청 기간',
-                    content: _buildPeriodText(policy),
+                    content: _buildPeriodText(policy, dDay: dDay),
                     badge: dDay != null
-                        ? _DDayBadge(label: dDay, color: theme.colorScheme)
+                        ? _DDayBadge(label: '신청 마감 $dDay', color: theme.colorScheme)
                         : null,
                   ),
                   _InfoSection(
                     title: '신청 방법',
                     content: policy.applyUrl.isNotEmpty
-                        ? 'Online: ${policy.applyUrl}'
-                        : 'Application method not available.',
+                        ? '온라인 신청 · ${policy.applyUrl}'
+                        : '신청 방법 정보를 찾을 수 없습니다.',
                   ),
                   _InfoSection(
                     title: '문의처',
                     content: (policy.contact ?? '').isNotEmpty
                         ? policy.contact!
-                        : 'Contact info not available.',
+                        : '문의처 정보가 없습니다.',
                   ),
                   const SizedBox(height: AppSpacing.lg),
                   _ReExploreSection(
@@ -246,25 +245,29 @@ class _Content extends StatelessWidget {
       targets.add('고용: ${policy.employmentCondition}');
     }
 
-    if (targets.isEmpty) return 'Eligibility info not available.';
+    if (targets.isEmpty) return '대상 정보를 찾을 수 없습니다.';
     return targets.join('\n');
   }
 
-  static String _buildPeriodText(Policy policy) {
+  static String _buildPeriodText(Policy policy, {String? dDay}) {
     final start = policy.applicationStartDate;
     final end = policy.applicationEndDate;
-    final format = DateFormat('yyyy.MM.dd (E)', 'ko');
 
-    if (start == null && end == null) {
-      return '일정 미확정';
+    final baseRange =
+        PolicyDateFormatter.formatRange(start: start, end: end);
+
+    if (end == null) return baseRange;
+
+    final deadline = PolicyDateFormatter.buildDeadlineText(
+      end: end,
+      dDayLabel: dDay,
+    );
+
+    if (start == null) {
+      return deadline;
     }
-    if (start != null && end == null) {
-      return '신청 시작일 ${format.format(start.toLocal())}';
-    }
-    if (start == null && end != null) {
-      return '신청 마감일 ${format.format(end.toLocal())}';
-    }
-    return '${format.format(start!.toLocal())} ~ ${format.format(end!.toLocal())}';
+
+    return '$baseRange\n$deadline';
   }
 
   static String? _buildDDayLabel(Policy policy) {
@@ -430,7 +433,7 @@ class _ErrorView extends StatelessWidget {
   Widget build(BuildContext context) {
     final String message = error is PolicyFailure
         ? (error as PolicyFailure).message
-        : 'An unknown error occurred while loading the policy.';
+        : '정책 정보를 불러오는 중 알 수 없는 오류가 발생했어요.';
 
     return Center(
       child: Padding(
@@ -438,7 +441,7 @@ class _ErrorView extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Text('Failed to load policy details'),
+            const Text('정책 정보를 불러오지 못했어요'),
             const SizedBox(height: 8),
             Text(
               message,
@@ -448,7 +451,7 @@ class _ErrorView extends StatelessWidget {
             const SizedBox(height: 12),
             ElevatedButton(
               onPressed: onRetry,
-              child: const Text('Retry'),
+              child: const Text('다시 시도'),
             ),
           ],
         ),

--- a/lib/features/policy_new/presentation/detail/widgets/policy_action_bar.dart
+++ b/lib/features/policy_new/presentation/detail/widgets/policy_action_bar.dart
@@ -4,10 +4,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../domain/entities/policy.dart';
 import '../../../domain/entities/policy_reminder.dart';
 import '../../../domain/values/policy_reminder_status.dart';
-import '../../../domain/values/reminder_time_kind.dart';
 import '../../../application/controllers/policy_action_controller.dart';
 import '../../../application/controllers/policy_reminder_controller.dart';
 import '../../../application/providers.dart';
+import '../../utils/policy_date_formatter.dart';
 
 class PolicyActionBar extends ConsumerWidget {
   const PolicyActionBar({super.key, required this.policy});
@@ -184,42 +184,63 @@ class _ReminderButton extends StatelessWidget {
           ..sort((a, b) => a.scheduledAt.compareTo(b.scheduledAt));
 
         final label = _label(activeReminders);
-        final activeOptions =
-            activeReminders.map((reminder) => reminder.timeKind).toSet();
+        final subtitle = _subtitle(activeReminders);
 
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           mainAxisSize: MainAxisSize.min,
           children: [
-            OutlinedButton.icon(
-              onPressed: isProcessing || viewState.isMutating
-                  ? null
-                  : () async {
-                      final selected =
-                          await _selectOptions(context, activeOptions);
-                      if (selected != null) {
-                        await controller.setReminderOptions(
-                          policy,
-                          selected.toList(),
-                        );
-                      }
-                    },
-              icon: Icon(
-                activeReminders.isEmpty
-                    ? Icons.notifications
-                    : Icons.notifications_active,
+            DecoratedBox(
+              decoration: BoxDecoration(
+                color: Theme.of(context)
+                    .colorScheme
+                    .surfaceVariant
+                    .withOpacity(0.8),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: Theme.of(context).colorScheme.outlineVariant,
+                ),
               ),
-              label: Text(label),
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Row(
+                  children: [
+                    Icon(
+                      activeReminders.isEmpty
+                          ? Icons.notifications_none
+                          : Icons.notifications_active,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            label,
+                            style: Theme.of(context).textTheme.bodyLarge,
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            subtitle ?? '알림은 하단 버튼에서 설정할 수 있어요.',
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodySmall
+                                ?.copyWith(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurfaceVariant,
+                                ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             ),
-            if (activeReminders.isNotEmpty)
-              TextButton(
-                onPressed: isProcessing || viewState.isMutating
-                    ? null
-                    : controller.cancelReminder,
-                child: const Text('알림 취소'),
-              ),
             if (viewState.messages.isNotEmpty) ...[
-              const SizedBox(height: 4),
+              const SizedBox(height: 6),
               ...viewState.messages.map(
                 (message) => Text(
                   message,
@@ -244,22 +265,12 @@ class _ReminderButton extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           OutlinedButton.icon(
-            onPressed: isProcessing
-                ? null
-                : () async {
-                    final option = await _selectOptions(context, const {});
-                    if (option != null) {
-                      await controller.setReminderOptions(
-                        policy,
-                        option.toList(),
-                      );
-                    }
-                  },
+            onPressed: null,
             icon: const Icon(Icons.notifications_active_outlined),
-            label: const Text('알림 다시 설정'),
+            label: const Text('알림 상태를 불러오지 못했어요'),
           ),
           Text(
-            '알림 상태를 불러오지 못했습니다.',
+            '잠시 후 다시 시도하거나 하단 버튼에서 알림을 확인해보세요.',
             style: Theme.of(context).textTheme.bodySmall,
           ),
         ],
@@ -269,7 +280,7 @@ class _ReminderButton extends StatelessWidget {
 
   String _label(List<PolicyReminder> reminders) {
     if (reminders.isEmpty) {
-      return '신청 알림 설정';
+      return '신청 알림이 꺼져 있어요';
     }
     final first = reminders.first;
     if (first.status == PolicyReminderStatus.expired) {
@@ -281,68 +292,17 @@ class _ReminderButton extends StatelessWidget {
     return '알림 설정됨 · ${first.timeKind.label} 외 ${reminders.length - 1}';
   }
 
-  Future<Set<ReminderTimeKind>?> _selectOptions(
-    BuildContext context,
-    Set<ReminderTimeKind> current,
-  ) {
-    return showModalBottomSheet<Set<ReminderTimeKind>>(
-      context: context,
-      builder: (context) {
-        final selected = {...current};
-        return SafeArea(
-          child: StatefulBuilder(
-            builder: (context, setState) {
-              return Padding(
-                padding: const EdgeInsets.only(bottom: 12),
-                child: SingleChildScrollView(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      for (final option in ReminderTimeKind.values)
-                        CheckboxListTile(
-                          value: selected.contains(option),
-                          onChanged: (value) {
-                            setState(() {
-                              if (value ?? false) {
-                                selected.add(option);
-                              } else {
-                                selected.remove(option);
-                              }
-                            });
-                          },
-                          title: Text(option.label),
-                          subtitle: const Text('신청 마감 기준으로 알림을 설정합니다'),
-                        ),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16),
-                        child: Row(
-                          children: [
-                            Expanded(
-                              child: OutlinedButton(
-                                onPressed: () => Navigator.of(context).pop(),
-                                child: const Text('취소'),
-                              ),
-                            ),
-                            const SizedBox(width: 12),
-                            Expanded(
-                              child: ElevatedButton(
-                                onPressed: () =>
-                                    Navigator.of(context).pop(selected),
-                                child: const Text('저장'),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              );
-            },
-          ),
-        );
-      },
-    );
+  String? _subtitle(List<PolicyReminder> reminders) {
+    if (reminders.isEmpty) {
+      return null;
+    }
+    final next = reminders.first;
+    final dateText =
+        PolicyDateFormatter.formatDateTime(next.scheduledAt.toLocal());
+    if (reminders.length == 1) {
+      return '${next.timeKind.label} · $dateText';
+    }
+    return '${next.timeKind.label} 외 ${reminders.length - 1} · $dateText';
   }
 }
 

--- a/lib/features/policy_new/presentation/reminder/policy_reminder_button.dart
+++ b/lib/features/policy_new/presentation/reminder/policy_reminder_button.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
-
 import '../../application/providers.dart';
 import '../../application/controllers/policy_reminder_controller.dart';
 import '../../domain/entities/policy.dart';
 import '../../domain/entities/policy_reminder.dart';
 import '../../domain/values/policy_reminder_status.dart';
 import '../../domain/values/reminder_time_kind.dart';
+import '../utils/policy_date_formatter.dart';
 
 class PolicyReminderButton extends ConsumerWidget {
   const PolicyReminderButton({super.key, required this.policy});
@@ -33,6 +32,7 @@ class PolicyReminderButton extends ConsumerWidget {
           ..sort((a, b) => a.scheduledAt.compareTo(b.scheduledAt));
         final activeOptions =
             activeReminders.map((reminder) => reminder.timeKind).toSet();
+        final hasActiveReminders = activeReminders.isNotEmpty;
 
         if (viewState.messages.isNotEmpty) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -51,6 +51,7 @@ class PolicyReminderButton extends ConsumerWidget {
           viewState: viewState,
           activeOptions: activeOptions,
           activeReminders: activeReminders,
+          hasActiveReminders: hasActiveReminders,
           onToggleOption: (option, enabled) async {
             final next = {...activeOptions};
             if (enabled) {
@@ -154,6 +155,7 @@ class _ReminderSheetButton extends StatelessWidget {
     required this.viewState,
     required this.activeOptions,
     required this.activeReminders,
+    required this.hasActiveReminders,
     required this.onToggleOption,
     required this.onRemove,
     required this.onOpenOptions,
@@ -164,6 +166,7 @@ class _ReminderSheetButton extends StatelessWidget {
   final PolicyReminderViewState viewState;
   final Set<ReminderTimeKind> activeOptions;
   final List<PolicyReminder> activeReminders;
+  final bool hasActiveReminders;
   final Future<void> Function(ReminderTimeKind option, bool enabled)
       onToggleOption;
   final Future<void> Function(String reminderId) onRemove;
@@ -172,9 +175,11 @@ class _ReminderSheetButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final buttonLabel = hasActiveReminders ? '신청 알림 관리' : '신청 알림 설정';
+
     return ElevatedButton.icon(
       icon: const Icon(Icons.notifications_outlined),
-      label: const Text('신청 알림 설정'),
+      label: Text(buttonLabel),
       onPressed: () {
         showModalBottomSheet(
           context: context,
@@ -225,6 +230,9 @@ class _ReminderSheet extends StatelessWidget {
     final textTheme = Theme.of(context).textTheme;
     final colorScheme = Theme.of(context).colorScheme;
     final scrollController = ScrollController();
+    final reminderSummary = activeReminders.isEmpty
+        ? '알림이 설정되지 않았어요. 원하는 시점을 선택해보세요.'
+        : '알림 ${activeReminders.length}건이 예약되어 있어요.';
 
     return SizedBox(
       height: MediaQuery.of(context).size.height * 0.72,
@@ -255,6 +263,12 @@ class _ReminderSheet extends StatelessWidget {
                         _deadlineText(policy),
                         style: textTheme.bodySmall,
                       ),
+                      const SizedBox(height: 6),
+                      Text(
+                        reminderSummary,
+                        style: textTheme.bodySmall
+                            ?.copyWith(color: colorScheme.onSurfaceVariant),
+                      ),
                     ],
                   ),
                 ),
@@ -270,7 +284,7 @@ class _ReminderSheet extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text('알림 옵션', style: textTheme.labelLarge),
+                  Text('알림 옵션 선택', style: textTheme.labelLarge),
                   const SizedBox(height: 8),
                   Wrap(
                     spacing: 8,
@@ -321,8 +335,8 @@ class _ReminderSheet extends StatelessWidget {
                           ),
                           title: Text(reminder.timeKind.label),
                           subtitle: Text(
-                            DateFormat('yyyy.MM.dd (E) a h:mm', 'ko')
-                                .format(reminder.scheduledAt.toLocal()),
+                            PolicyDateFormatter
+                                .formatDateTime(reminder.scheduledAt),
                           ),
                           trailing: IconButton(
                             onPressed: viewState.isMutating
@@ -343,8 +357,9 @@ class _ReminderSheet extends StatelessWidget {
               children: [
                 Expanded(
                   child: OutlinedButton(
-                    onPressed:
-                        viewState.isMutating ? null : () => onCancelAll(),
+                    onPressed: viewState.isMutating || activeReminders.isEmpty
+                        ? null
+                        : () => onCancelAll(),
                     child: const Text('모든 알림 취소'),
                   ),
                 ),
@@ -359,9 +374,7 @@ class _ReminderSheet extends StatelessWidget {
   String _deadlineText(Policy policy) {
     final end = policy.applicationEndDate;
     if (end == null) return '신청 마감 정보가 없습니다.';
-    final formatter = DateFormat('yyyy.MM.dd (E)');
-    final local = end.toLocal();
-    return '신청 마감 · ${formatter.format(local)}';
+    return PolicyDateFormatter.buildDeadlineText(end: end);
   }
 
   IconData _iconForStatus(PolicyReminderStatus status) {

--- a/lib/features/policy_new/presentation/utils/policy_date_formatter.dart
+++ b/lib/features/policy_new/presentation/utils/policy_date_formatter.dart
@@ -1,0 +1,41 @@
+import 'package:intl/intl.dart';
+
+class PolicyDateFormatter {
+  PolicyDateFormatter._();
+
+  static final DateFormat _dateWithWeekday =
+      DateFormat('yyyy.MM.dd (E)', 'ko');
+  static final DateFormat _dateTimeWithWeekday =
+      DateFormat('yyyy.MM.dd (E) a h:mm', 'ko');
+
+  static String formatDate(DateTime date) {
+    return _dateWithWeekday.format(date.toLocal());
+  }
+
+  static String formatDateTime(DateTime date) {
+    return _dateTimeWithWeekday.format(date.toLocal());
+  }
+
+  static String formatRange({DateTime? start, DateTime? end}) {
+    if (start == null && end == null) {
+      return '일정 미확정';
+    }
+    if (start != null && end == null) {
+      return '신청 시작 · ${formatDate(start)}';
+    }
+    if (start == null && end != null) {
+      return '신청 마감 · ${formatDate(end)}';
+    }
+    return '${formatDate(start!)} ~ ${formatDate(end!)}';
+  }
+
+  static String buildDeadlineText({
+    required DateTime? end,
+    String prefix = '신청 마감',
+    String? dDayLabel,
+  }) {
+    if (end == null) return '$prefix 정보가 없습니다.';
+    final dDayPart = dDayLabel != null ? '$dDayLabel · ' : '';
+    return '$prefix $dDayPart${formatDate(end)}';
+  }
+}


### PR DESCRIPTION
## Summary
- 정책 상세 상단의 알림 영역을 상태 표시 위주로 단순화하고 하단 버튼을 알림 설정/관리에 단일 진입점으로 변경했습니다.
- 알림 옵션 바텀시트를 타이틀/옵션/예약 리스트 구조로 정리하고 취소 동작을 명확히 했습니다.
- 공통 날짜 포맷터를 도입해 신청 기간, 마감 안내, 예약 알림 표시를 `yyyy.MM.dd (E)` 형태로 통일했습니다.

## Testing
- Not run (flutter/dart tools unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693605baed948324982bfc1ad0a8917d)