### PR TITLE
Maintain region mode after re-exploring from detail

### DIFF
--- a/lib/features/policy_new/application/explore/explore_providers.dart
+++ b/lib/features/policy_new/application/explore/explore_providers.dart
@@ -9,6 +9,7 @@ import '../../domain/values/policy_sort.dart';
 import '../../domain/values/policy_feed_type.dart';
 import '../../domain/values/policy_status_filter.dart';
 import '../reexplore/policy_reexplore.dart';
+import '../../../../application/notifiers/region_notifier.dart';
 
 final exploreStateProvider =
     StateNotifierProvider<ExploreController, ExploreState>(
@@ -32,12 +33,13 @@ class ExploreController extends StateNotifier<ExploreState> {
   void setKeyword(String value) {
     final trimmed = value.trim();
     debugPrint('[Explore] setKeyword: "$trimmed"');
+    final hasRegionSelection = ref.read(regionProvider)?.isNotEmpty ?? false;
     if (trimmed.isEmpty) {
       _syncKeyword('');
       state = state.copyWith(
         keyword: '',
         mode: state.mode == ExploreSubMode.search
-            ? ExploreSubMode.all
+            ? (hasRegionSelection ? ExploreSubMode.region : ExploreSubMode.all)
             : state.mode,
       );
       return;
@@ -95,16 +97,38 @@ class ExploreController extends StateNotifier<ExploreState> {
 
   void clearFilters() {
     debugPrint('[Explore] clearFilters');
+    final hasRegionSelection = ref.read(regionProvider)?.isNotEmpty ?? false;
     ref.read(globalFilterControllerProvider).resetAll();
-    state = state.copyWith(mode: ExploreSubMode.all, keyword: '');
+    state = state.copyWith(
+      mode: hasRegionSelection ? ExploreSubMode.region : ExploreSubMode.all,
+      keyword: '',
+    );
+  }
+
+  void ensureRegionMode({required bool hasSelection}) {
+    if (state.mode == ExploreSubMode.search && state.keyword.isNotEmpty) {
+      return;
+    }
+
+    final nextMode = hasSelection ? ExploreSubMode.region : ExploreSubMode.all;
+    if (state.mode != nextMode) {
+      state = state.copyWith(mode: nextMode);
+    }
   }
 
   void applyFromDetail({
     required PolicyFilterUiState filter,
     required PolicyReExploreMode mode,
   }) {
+    final hasRegionSelection =
+        (filter.city?.isNotEmpty ?? false) || (filter.district?.isNotEmpty ?? false);
+    final nextMode = hasRegionSelection ? ExploreSubMode.region : ExploreSubMode.all;
+
+    if (state.keyword.isNotEmpty) {
+      _syncKeyword('');
+    }
     state = state.copyWith(
-      mode: ExploreSubMode.all,
+      mode: nextMode,
       keyword: '',
     );
   }

--- a/lib/features/policy_new/presentation/detail/policy_detail_bottom_sheet.dart
+++ b/lib/features/policy_new/presentation/detail/policy_detail_bottom_sheet.dart
@@ -313,7 +313,10 @@ class _InfoSection extends StatelessWidget {
             const SizedBox(height: AppSpacing.sm),
             Text(
               content,
-              style: AppText.textTheme.bodyMedium,
+              style: AppText.textTheme.bodyLarge?.copyWith(
+                height: 1.4,
+                fontWeight: FontWeight.w500,
+              ),
               softWrap: true,
               overflow: TextOverflow.visible,
             ),

--- a/lib/features/policy_new/presentation/detail/widgets/policy_action_bar.dart
+++ b/lib/features/policy_new/presentation/detail/widgets/policy_action_bar.dart
@@ -9,6 +9,7 @@ import '../../../application/controllers/policy_action_controller.dart';
 import '../../../application/controllers/policy_reminder_controller.dart';
 import '../../../application/providers.dart';
 import '../../utils/policy_date_formatter.dart';
+import '../../../../ui/theme/app_text.dart';
 
 class PolicyActionBar extends ConsumerWidget {
   const PolicyActionBar({super.key, required this.policy});
@@ -48,33 +49,38 @@ class PolicyActionBar extends ConsumerWidget {
                   ),
                 ),
 
-              // 🔥 문제였던 부분 해결: width: double.infinity 제거
               Row(
                 children: [
-                  _IconActionButton(
-                    icon: state.isFavorite
-                        ? Icons.favorite
-                        : Icons.favorite_border,
-                    active: state.isFavorite,
-                    label: '좋아요',
-                    onTap: state.isProcessing
-                        ? null
-                        : () async => controller.toggleFavorite(policy),
+                  Expanded(
+                    child: PolicyActionButton(
+                      icon: state.isFavorite
+                          ? Icons.favorite
+                          : Icons.favorite_border,
+                      label: '찜하기',
+                      active: state.isFavorite,
+                      onPressed: state.isProcessing
+                          ? null
+                          : () async => controller.toggleFavorite(policy),
+                    ),
                   ),
                   const SizedBox(width: 8),
-                  _IconActionButton(
-                    icon: state.isCompared
-                        ? Icons.compare_arrows
-                        : Icons.compare_arrows_outlined,
-                    active: state.isCompared,
-                    label: '비교함',
-                    onTap: state.isProcessing
-                        ? null
-                        : () async => controller.toggleCompare(policy),
+                  Expanded(
+                    child: PolicyActionButton(
+                      icon: state.isCompared
+                          ? Icons.compare_arrows
+                          : Icons.compare_arrows_outlined,
+                      label: '비교함',
+                      active: state.isCompared,
+                      onPressed: state.isProcessing
+                          ? null
+                          : () async => controller.toggleCompare(policy),
+                    ),
                   ),
-                  const SizedBox(width: 8),
-
-                  // 🔥 Expanded로 폭 충돌 해결
+                ],
+              ),
+              const SizedBox(height: 8),
+              Row(
+                children: [
                   Expanded(
                     child: _ReminderButton(
                       policy: policy,
@@ -83,11 +89,13 @@ class PolicyActionBar extends ConsumerWidget {
                       isProcessing: state.isProcessing,
                     ),
                   ),
-
                   const SizedBox(width: 8),
-
                   Expanded(
-                    child: ElevatedButton.icon(
+                    child: PolicyActionButton(
+                      icon: Icons.open_in_new,
+                      label: '신청 페이지 열기',
+                      description: '정책 안내 페이지로 이동',
+                      variant: PolicyActionButtonVariant.primary,
                       onPressed: state.isProcessing
                           ? null
                           : () async {
@@ -101,8 +109,6 @@ class PolicyActionBar extends ConsumerWidget {
                                 );
                               }
                             },
-                      icon: const Icon(Icons.open_in_new),
-                      label: const Text('신청 페이지 열기'),
                     ),
                   ),
                 ],
@@ -135,110 +141,98 @@ class _ReminderButton extends StatelessWidget {
     final isClosed = policy.isClosed;
 
     if (!hasScheduleWindow) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          OutlinedButton.icon(
-            onPressed: null,
-            icon: const Icon(Icons.notifications_off_outlined),
-            label: const Text('신청 일정 없음'),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            '신청 일정 정보가 없어 알림을 설정할 수 없습니다.',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.error,
-                ),
-          ),
-        ],
+      return PolicyActionButton(
+        icon: Icons.notifications_off_outlined,
+        label: '신청 일정 없음',
+        description: '알림을 설정할 일정 정보가 없어요',
+        onPressed: null,
       );
     }
 
     if (isClosed) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          OutlinedButton.icon(
-            onPressed: null,
-            icon: const Icon(Icons.notifications_off_outlined),
-            label: const Text('마감된 정책입니다'),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            '마감된 정책은 알림을 설정할 수 없어요.',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.error,
-                ),
-          ),
-        ],
+      return PolicyActionButton(
+        icon: Icons.notifications_off_outlined,
+        label: '마감된 정책입니다',
+        description: '마감된 정책은 알림을 설정할 수 없어요',
+        onPressed: null,
       );
     }
 
     return reminderState.when(
       data: (viewState) {
-        final activeReminders = viewState.reminders
-            .where(
-                (reminder) => reminder.status != PolicyReminderStatus.canceled)
-            .toList()
+        final reminders = [...viewState.reminders]
           ..sort((a, b) => a.scheduledAt.compareTo(b.scheduledAt));
 
-        final label = _label(activeReminders);
-        final subtitle = _subtitle(activeReminders);
+        final scheduledReminders = reminders
+            .where((reminder) =>
+                reminder.status == PolicyReminderStatus.scheduled)
+            .toList();
+
+        final firedReminders = reminders
+            .where((reminder) => reminder.status == PolicyReminderStatus.fired)
+            .toList();
+
+        final expiredReminders = reminders
+            .where((reminder) => reminder.status == PolicyReminderStatus.expired)
+            .toList();
+
+        final canceledReminders = reminders
+            .where((reminder) => reminder.status == PolicyReminderStatus.canceled)
+            .toList();
+
+        final visibleReminders = () {
+          if (scheduledReminders.isNotEmpty) return scheduledReminders;
+          if (canceledReminders.isNotEmpty) return canceledReminders;
+          if (firedReminders.isNotEmpty) return firedReminders;
+          return expiredReminders;
+        }();
+
+        final label = _label(visibleReminders);
+        final subtitle = _subtitle(visibleReminders);
+        final isReminderBusy = viewState.isMutating || viewState.isRefreshing;
+        final isActionBusy = isProcessing && !isReminderBusy;
+        final isDisabled = isActionBusy || isReminderBusy;
+
+        IconData resolveIcon() {
+          if (scheduledReminders.isNotEmpty) return Icons.notifications_active;
+          if (visibleReminders.isEmpty) return Icons.notifications_none;
+
+          final status = visibleReminders.first.status;
+          if (status == PolicyReminderStatus.canceled ||
+              status == PolicyReminderStatus.expired) {
+            return Icons.notifications_off_outlined;
+          }
+          if (status == PolicyReminderStatus.fired) {
+            return Icons.notifications_active_outlined;
+          }
+          return Icons.notifications_none;
+        }
 
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
-          mainAxisSize: MainAxisSize.min,
           children: [
-            DecoratedBox(
-              decoration: BoxDecoration(
-                color: Theme.of(context)
-                    .colorScheme
-                    .surfaceVariant
-                    .withOpacity(0.8),
-                borderRadius: BorderRadius.circular(12),
-                border: Border.all(
-                  color: Theme.of(context).colorScheme.outlineVariant,
-                ),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(12),
-                child: Row(
-                  children: [
-                    Icon(
-                      activeReminders.isEmpty
-                          ? Icons.notifications_none
-                          : Icons.notifications_active,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                    const SizedBox(width: 10),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            label,
-                            style: Theme.of(context).textTheme.bodyLarge,
-                          ),
-                          const SizedBox(height: 2),
-                          Text(
-                            subtitle ?? '알림은 하단 버튼에서 설정할 수 있어요.',
-                            style: Theme.of(context)
-                                .textTheme
-                                .bodySmall
-                                ?.copyWith(
-                                  color: Theme.of(context)
-                                      .colorScheme
-                                      .onSurfaceVariant,
-                                ),
-                          ),
-                        ],
+            PolicyActionButton(
+              icon: resolveIcon(),
+              label: label,
+              description: subtitle ??
+                  (isActionBusy
+                      ? '다른 작업을 처리하는 중이에요.'
+                      : '마감 전에 알림을 받아보세요.'),
+              onPressed: isDisabled
+                  ? null
+                  : () async => controller.toggleReminder(policy),
+              active: scheduledReminders.isNotEmpty,
+              variant: PolicyActionButtonVariant.tonal,
+              trailing: isReminderBusy
+                  ? SizedBox(
+                      height: 18,
+                      width: 18,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
-                    ),
-                  ],
-                ),
-              ),
+                    )
+                  : null,
             ),
             if (viewState.messages.isNotEmpty) ...[
               const SizedBox(height: 6),
@@ -254,38 +248,38 @@ class _ReminderButton extends StatelessWidget {
           ],
         );
       },
-      loading: () => const Center(
-        child: SizedBox(
-          height: 48,
-          width: 48,
-          child: CircularProgressIndicator(),
+      loading: () => const PolicyActionButton(
+        icon: Icons.notifications_active_outlined,
+        label: '알림 정보를 불러오는 중',
+        trailing: SizedBox(
+          height: 18,
+          width: 18,
+          child: CircularProgressIndicator(strokeWidth: 2),
         ),
+        onPressed: null,
       ),
-      error: (err, __) => Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          OutlinedButton.icon(
-            onPressed: null,
-            icon: const Icon(Icons.notifications_active_outlined),
-            label: const Text('알림 상태를 불러오지 못했어요'),
-          ),
-          Text(
-            '잠시 후 다시 시도하거나 하단 버튼에서 알림을 확인해보세요.',
-            style: Theme.of(context).textTheme.bodySmall,
-          ),
-        ],
+      error: (err, __) => PolicyActionButton(
+        icon: Icons.notifications_active_outlined,
+        label: '알림 상태를 불러오지 못했어요',
+        description: '잠시 후 다시 시도해주세요',
+        onPressed: null,
       ),
     );
   }
 
   String _label(List<PolicyReminder> reminders) {
     if (reminders.isEmpty) {
-      return '신청 알림이 꺼져 있어요';
+      return '신청 알림 받기';
     }
     final first = reminders.first;
     if (first.status == PolicyReminderStatus.expired) {
       return '알림 만료됨';
+    }
+    if (first.status == PolicyReminderStatus.fired) {
+      return '알림 도착함';
+    }
+    if (first.status == PolicyReminderStatus.canceled) {
+      return '알림 취소됨';
     }
     if (reminders.length == 1) {
       return '알림 설정됨 · ${first.timeKind.label}';
@@ -300,6 +294,15 @@ class _ReminderButton extends StatelessWidget {
     final next = reminders.first;
     final dateText =
         PolicyDateFormatter.formatDateTime(next.scheduledAt.toLocal());
+    if (next.status == PolicyReminderStatus.expired) {
+      return '${next.timeKind.label} · $dateText · 만료됨';
+    }
+    if (next.status == PolicyReminderStatus.fired) {
+      return '${next.timeKind.label} · $dateText · 이미 알림을 보냈어요';
+    }
+    if (next.status == PolicyReminderStatus.canceled) {
+      return '${next.timeKind.label} · $dateText · 사용자가 취소했어요';
+    }
     if (reminders.length == 1) {
       return '${next.timeKind.label} · $dateText';
     }
@@ -307,39 +310,104 @@ class _ReminderButton extends StatelessWidget {
   }
 }
 
-class _IconActionButton extends StatelessWidget {
-  const _IconActionButton({
+enum PolicyActionButtonVariant { tonal, primary }
+
+class PolicyActionButton extends StatelessWidget {
+  const PolicyActionButton({
+    super.key,
     required this.icon,
-    required this.active,
     required this.label,
-    required this.onTap,
+    this.description,
+    this.onPressed,
+    this.active = false,
+    this.variant = PolicyActionButtonVariant.tonal,
+    this.trailing,
   });
 
   final IconData icon;
-  final bool active;
   final String label;
-  final VoidCallback? onTap;
+  final String? description;
+  final VoidCallback? onPressed;
+  final bool active;
+  final PolicyActionButtonVariant variant;
+  final Widget? trailing;
 
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final enabled = onPressed != null;
+
+    Color resolveBackground() {
+      if (!enabled) return colors.surfaceVariant.withOpacity(0.6);
+      if (variant == PolicyActionButtonVariant.primary) return colors.primary;
+      if (active) return colors.primaryContainer;
+      return colors.surfaceVariant;
+    }
+
+    Color resolveForeground() {
+      if (variant == PolicyActionButtonVariant.primary) {
+        return enabled ? colors.onPrimary : colors.onSurface.withOpacity(0.4);
+      }
+      if (!enabled) return colors.onSurface.withOpacity(0.38);
+      if (active) return colors.onPrimaryContainer;
+      return colors.onSurface;
+    }
+
+    final background = resolveBackground();
+    final foreground = resolveForeground();
+
     return SizedBox(
-      width: 48,
-      height: 48,
+      height: 64,
       child: Material(
-        color: active
-            ? Theme.of(context).colorScheme.primary.withOpacity(0.12)
-            : Colors.grey.shade200,
-        shape: const CircleBorder(),
+        color: background,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(14),
+          side: variant == PolicyActionButtonVariant.tonal && !active
+              ? BorderSide(color: colors.outlineVariant)
+              : BorderSide.none,
+        ),
         child: InkWell(
-          customBorder: const CircleBorder(),
-          onTap: onTap,
-          child: Tooltip(
-            message: label,
-            child: Icon(
-              icon,
-              color: active
-                  ? Theme.of(context).colorScheme.primary
-                  : Colors.grey.shade700,
+          onTap: onPressed,
+          borderRadius: BorderRadius.circular(14),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            child: Row(
+              children: [
+                Icon(icon, color: foreground),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    mainAxisAlignment: description == null
+                        ? MainAxisAlignment.center
+                        : MainAxisAlignment.spaceEvenly,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        label,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: AppText.textTheme.labelLarge?.copyWith(
+                          color: foreground,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      if (description != null)
+                        Text(
+                          description!,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: AppText.textTheme.bodySmall?.copyWith(
+                            color: foreground.withOpacity(0.82),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                if (trailing != null) ...[
+                  const SizedBox(width: 8),
+                  trailing!,
+                ],
+              ],
             ),
           ),
         ),

--- a/lib/features/policy_new/presentation/explore/policy_explore_screen.dart
+++ b/lib/features/policy_new/presentation/explore/policy_explore_screen.dart
@@ -8,6 +8,7 @@ import '../../application/explore/explore_state.dart';
 import '../../application/filters/policy_filter_ui_state.dart';
 import '../../application/filters/policy_search_keyword_provider.dart';
 import '../../application/providers.dart';
+import '../../../../application/notifiers/region_notifier.dart';
 import '../../domain/values/policy_feed_type.dart';
 import '../../domain/values/policy_category.dart';
 import '../../domain/values/policy_sort.dart';
@@ -25,6 +26,7 @@ class PolicyExploreScreen extends ConsumerStatefulWidget {
 
 class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
   late final TextEditingController _searchController;
+  ProviderSubscription<String?>? _regionSubscription;
 
   static const _categories = [
     (id: 'employment', label: '취업'),
@@ -39,10 +41,23 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
     super.initState();
     final state = ref.read(exploreStateProvider);
     _searchController = TextEditingController(text: state.keyword);
+
+    final controller = ref.read(exploreStateProvider.notifier);
+    final initialRegion = ref.read(regionProvider);
+    controller.ensureRegionMode(hasSelection: initialRegion?.isNotEmpty ?? false);
+
+    _regionSubscription = ref.listen<String?>(
+      regionProvider,
+      (previous, next) {
+        final hasSelection = next?.isNotEmpty ?? false;
+        controller.ensureRegionMode(hasSelection: hasSelection);
+      },
+    );
   }
 
   @override
   void dispose() {
+    _regionSubscription?.close();
     _searchController.dispose();
     super.dispose();
   }
@@ -52,6 +67,8 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
     final state = ref.watch(exploreStateProvider);
     final controller = ref.read(exploreStateProvider.notifier);
     final filterUi = ref.watch(globalFilterProvider);
+    ref.watch(regionProvider);
+    final regionNotifier = ref.read(regionProvider.notifier);
 
     final keyword = ref.watch(policySearchKeywordProvider(PolicyFeedType.search));
 
@@ -63,7 +80,10 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
       );
     }
 
-    final feedType = _feedTypeFor(state, keyword: keyword);
+    final feedType = _feedTypeFor(
+      state,
+      keyword: keyword,
+    );
     final queryState = ref.watch(policyQueryProvider(feedType));
     final summary = queryState.summary;
     final statusFilter = filterUi.status;
@@ -96,17 +116,20 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
                   const SizedBox(height: 12),
                   _QuickFilterChips(
                     statusFilter: statusFilter,
-                    regionName: filterUi.regionSummary,
-                    isRegionMode: state.mode == ExploreSubMode.region,
                     onToggleStatus: (value) =>
                         controller.setStatusFilter(value),
-                    onToggleRegion: () {
-                      final isRegion = state.mode == ExploreSubMode.region;
-                      if (isRegion) {
-                        controller.setMode(ExploreSubMode.all);
-                      } else {
-                        controller.setMode(ExploreSubMode.region);
+                  ),
+                  const SizedBox(height: 12),
+                  _RegionDropdown(
+                    summary: filterUi.regionSummary,
+                    selectedCity: regionNotifier.selectedCity,
+                    availableCities: regionNotifier.availableCities,
+                    onRegionChanged: (city) {
+                      if (city == null || city.isEmpty) {
+                        regionNotifier.resetCity();
+                        return;
                       }
+                      regionNotifier.selectCity(city);
                     },
                   ),
                   const SizedBox(height: 10),
@@ -164,7 +187,10 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
     return PolicyFeedListView(feedType: feedType);
   }
 
-  PolicyFeedType _feedTypeFor(ExploreState state, {String keyword = ''}) {
+  PolicyFeedType _feedTypeFor(
+    ExploreState state, {
+    String keyword = '',
+  }) {
     if (state.mode == ExploreSubMode.search && keyword.isNotEmpty) {
       return PolicyFeedType.search;
     }
@@ -511,17 +537,11 @@ class _SearchBarRow extends StatelessWidget {
 class _QuickFilterChips extends StatelessWidget {
   const _QuickFilterChips({
     required this.statusFilter,
-    required this.regionName,
-    required this.isRegionMode,
     required this.onToggleStatus,
-    required this.onToggleRegion,
   });
 
   final PolicyStatusFilter statusFilter;
-  final String regionName;
-  final bool isRegionMode;
   final void Function(PolicyStatusFilter) onToggleStatus;
-  final VoidCallback onToggleRegion;
 
   @override
   Widget build(BuildContext context) {
@@ -541,11 +561,6 @@ class _QuickFilterChips extends StatelessWidget {
         selected: statusFilter == PolicyStatusFilter.closedOnly,
         onSelected: (_) => onToggleStatus(PolicyStatusFilter.closedOnly),
       ),
-      ChoiceChip(
-        label: Text('내 지역 ($regionName)'),
-        selected: isRegionMode,
-        onSelected: (_) => onToggleRegion(),
-      ),
     ];
 
     return SingleChildScrollView(
@@ -562,6 +577,86 @@ class _QuickFilterChips extends StatelessWidget {
           const SizedBox(width: 4),
         ],
       ),
+    );
+  }
+}
+
+class _RegionDropdown extends ConsumerWidget {
+  const _RegionDropdown({
+    required this.summary,
+    required this.selectedCity,
+    required this.availableCities,
+    required this.onRegionChanged,
+  });
+
+  final String summary;
+  final String? selectedCity;
+  final List<String> availableCities;
+  final void Function(String? city) onRegionChanged;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(regionProvider);
+    final scheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    final items = <DropdownMenuItem<String>>[
+      const DropdownMenuItem(
+        value: '',
+        child: Text('경북 전체'),
+      ),
+      ...availableCities.map(
+        (city) => DropdownMenuItem(
+          value: city,
+          child: Text(city),
+        ),
+      ),
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Text(
+              '지역',
+              style:
+                  textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(width: 8),
+            Flexible(
+              child: Text(
+                summary,
+                style: textTheme.bodySmall,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        DropdownButtonFormField<String>(
+          value: selectedCity ?? '',
+          items: items,
+          onChanged: onRegionChanged,
+          isExpanded: true,
+          decoration: InputDecoration(
+            isDense: true,
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: 12,
+              vertical: 10,
+            ),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide(
+                color: scheme.outlineVariant,
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- set explore mode to region when re-exploring from detail with a region selection and clear any stale keywords

## Testing
- not run (flutter not available)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69363736c6548324ac7be28f7fa0163a)