### PR TITLE
카카오맵 캐시 프리로드 및 버튼 위치 조정

### DIFF
--- a/lib/features/map_v2/kakao_map_screen.dart
+++ b/lib/features/map_v2/kakao_map_screen.dart
@@ -13,6 +13,7 @@ import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../application/providers.dart';
+import '../../application/di.dart' as app_di;
 import '../../debug/debug_settings_provider.dart';
 import '../../navigation/route_paths.dart';
 import '../../ui/widgets/app_appbar.dart';
@@ -47,7 +48,6 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   static final _defaultCenter = KakaoMapLatLng(36.4919, 128.8889);
   static const _debounceMs = 400;
   static const _centerListHeight = 210.0;
-  static const _floatingActionButtonBottomSpacing = 140.0;
   static const _gpsService = GpsService();
   static const _permissionService = LocationPermissionService();
   static const _locationZoomLevel = 6;
@@ -69,6 +69,9 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   Timer? _moveDebounce;
   Timer? _tooltipTimer;
   String? _activeTooltipName;
+  List<CenterMarkerPoint> _cachedCenterPoints = const [];
+  bool _mapReady = false;
+  _PendingMove? _pendingMove;
 
   @override
   void initState() {
@@ -81,7 +84,9 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
       'len=${AppEnv.kakaoRestApiKey.length}',
     );
 
+    _initRequestWithRegion();
     _prepareCenterMarkerIcon();
+    _preloadCachedCenterMarkers();
     _loadInitialPosition();
   }
 
@@ -108,7 +113,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
             if (_locationError != null) _buildLocationErrorBanner(),
           ],
         ),
-        floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+        floatingActionButtonLocation: FloatingActionButtonLocation.startTop,
         floatingActionButton: _buildPositionedGpsButton(),
       );
     }
@@ -150,8 +155,10 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         final policies = _policyMarkers(fallbackCenter, policyState);
         final polylines = _polylinesFromMarkers(policies);
         final locationMarker = _currentLocationMarker;
+        final cachedCenters = _buildCenterMarkers(_cachedCenterPoints);
         final fallbackMarkers = <KakaoMapMarker>[
           if (locationMarker != null) locationMarker,
+          ...cachedCenters,
           ...policies,
         ];
 
@@ -181,17 +188,8 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
                   context.push(RoutePaths.policyDetail(id));
                 },
                 onMarkerClicked: _handleCenterMarkerClicked,
-                onReady: () {
-                  debugPrint('[KakaoMap] WebView Ready! (LOADING state)');
-                  _setLoading(false);
-                  _showMyPositionOnMap();
-                },
-                onLoadingChanged: (isLoading) {
-                  debugPrint(
-                    '[KakaoMap] WebView LoadingChanged(LOADING) → $isLoading',
-                  );
-                  _setLoading(isLoading);
-                },
+                onReady: _onWebViewReady,
+                onLoadingChanged: _onWebViewLoadingChanged,
                 onError: (code) {
                   debugPrint(
                     '[KakaoMap:ERROR][LOADING] WebView error code=$code',
@@ -223,7 +221,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
               ),
             ],
           ),
-          floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+          floatingActionButtonLocation: FloatingActionButtonLocation.startTop,
           floatingActionButton: _buildPositionedGpsButton(),
         );
       },
@@ -239,8 +237,10 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         final policies = _policyMarkers(fallbackCenter, policyState);
         final polylines = _polylinesFromMarkers(policies);
         final locationMarker = _currentLocationMarker;
+        final cachedCenters = _buildCenterMarkers(_cachedCenterPoints);
         final fallbackMarkers = <KakaoMapMarker>[
           if (locationMarker != null) locationMarker,
+          ...cachedCenters,
           ...policies,
         ];
 
@@ -270,17 +270,8 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
                   context.push(RoutePaths.policyDetail(id));
                 },
                 onMarkerClicked: _handleCenterMarkerClicked,
-                onReady: () {
-                  debugPrint('[KakaoMap] WebView Ready! (ERROR state)');
-                  _setLoading(false);
-                  _showMyPositionOnMap();
-                },
-                onLoadingChanged: (isLoading) {
-                  debugPrint(
-                    '[KakaoMap] WebView LoadingChanged(ERROR) → $isLoading',
-                  );
-                  _setLoading(isLoading);
-                },
+                onReady: _onWebViewReady,
+                onLoadingChanged: _onWebViewLoadingChanged,
                 onError: (code) {
                   debugPrint(
                     '[KakaoMap:ERROR][ERROR_STATE] WebView error code=$code',
@@ -312,7 +303,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
               ),
             ],
           ),
-          floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+          floatingActionButtonLocation: FloatingActionButtonLocation.startTop,
           floatingActionButton: _buildPositionedGpsButton(),
         );
       },
@@ -323,15 +314,12 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
           '[YCMAP] centerMarkersAsync: DATA, rawCount=${centerPoints.length}',
         );
 
-        final validCenters =
-            centerPoints.where((c) => c.lat != null && c.lng != null).toList();
-
         final currentCenter = _latestCenter ?? defaultCenter;
         debugPrint(
           '[YCMAP] DATA currentCenter=(${currentCenter.lat}, ${currentCenter.lng})',
         );
 
-        final sortedCenters = validCenters
+        final sortedCenters = centerPoints
             .map(
               (c) => (
                 point: c,
@@ -349,6 +337,16 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         final sortedCenterPoints =
             sortedCenters.map((entry) => entry.point).toList();
 
+        final hasNewCenters = sortedCenterPoints.isNotEmpty;
+        final visibleCenterPoints =
+            hasNewCenters ? sortedCenterPoints : _cachedCenterPoints;
+
+        if (hasNewCenters) {
+          _cachedCenterPoints = sortedCenterPoints;
+        } else if (_cachedCenterPoints.isNotEmpty) {
+          debugPrint('[YCMAP] 새 데이터 없음 → 캐시된 센터 마커 유지');
+        }
+
         final centerIconBase64 =
             _centerMarkerIconBase64 ?? _centerMarkerFallbackBase64;
         final centerMarkerImage = KakaoMapMarkerImage(
@@ -358,27 +356,12 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
           offset: const Offset(18, 36),
         );
 
-        final centerMarkers = List.generate(sortedCenterPoints.length, (index) {
-          final c = sortedCenterPoints[index];
-          final markerId = 'CENTER-$index';
-          return KakaoMapMarker(
-            id: markerId,
-            title: c.name,
-            position: KakaoMapLatLng(c.lat, c.lng),
-            image: centerMarkerImage,
-            extra: {
-              'name': c.name,
-              'fullAddress': c.fullAddress,
-              'phone': c.phone,
-              'url': c.url,
-              'regionLabel': c.regionLabel,
-            },
-          );
-        });
+        final centerMarkers =
+            _buildCenterMarkers(visibleCenterPoints, image: centerMarkerImage);
 
         debugPrint(
           '[YCMAP] centerPoints=${centerPoints.length} '
-          'validCenters=${validCenters.length}',
+          'validCenters=${centerPoints.length}',
         );
         debugPrint(
           '[YCMAP] centerMarkers=${centerMarkers.length} (지도에 찍을 센터 마커 수)',
@@ -408,18 +391,10 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         KakaoMapLatLng mapCenter = currentCenter;
         int mapLevel = _latestZoom ?? 6;
 
-        if (_latestCenter == null && validCenters.isNotEmpty) {
-          final avgLat = validCenters
-                  .map((c) => c.lat)
-                  .fold<double>(0, (prev, lat) => prev + lat) /
-              validCenters.length;
-          final avgLng = validCenters
-                  .map((c) => c.lng)
-                  .fold<double>(0, (prev, lng) => prev + lng) /
-              validCenters.length;
-
-          mapCenter = KakaoMapLatLng(avgLat, avgLng);
-          mapLevel = _latestZoom ?? 12;
+        if (_latestCenter == null && visibleCenterPoints.isNotEmpty) {
+          final nearest = visibleCenterPoints.first;
+          mapCenter = KakaoMapLatLng(nearest.lat, nearest.lng);
+          mapLevel = _locationZoomLevel;
 
           debugPrint(
             '[YCMAP] mapInitialCenter(centersBased)=(${mapCenter.lat}, ${mapCenter.lng}) zoom=$mapLevel',
@@ -445,41 +420,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
                   showZoomControl: true,
                   showMapTypeControl: true,
                 ),
-                onMapMoved: (center, zoom) {
-                  debugPrint(
-                    '[YCMAP] onMapMoved center=(${center.lat}, ${center.lng}) zoom=$zoom',
-                  );
-                  _latestCenter = center;
-                  _latestZoom = zoom;
-
-                  _moveDebounce?.cancel();
-                  debugPrint(
-                    '[YCMAP] onMapMoved → debounce ${_debounceMs}ms 후 CenterFetchRequest 갱신 예정',
-                  );
-
-                  _moveDebounce = Timer(
-                    const Duration(milliseconds: _debounceMs),
-                    () {
-                      final req = CenterFetchRequest(
-                        lat: center.lat,
-                        lng: center.lng,
-                        radiusKm: kCenterRangeKm,
-                      );
-                      debugPrint(
-                        '[YCMAP] debounce 완료 → provider 재요청 '
-                        'CenterFetchRequest(lat=${req.lat}, lng=${req.lng}, radius=${req.radiusKm})',
-                      );
-
-                      setState(() {
-                        _currentRequest = req;
-                      });
-
-                      final circleCenter = _deviceLocation ?? center;
-                      unawaited(_updateSearchCircle(circleCenter));
-                      ref.refresh(youthCenterMapProvider(req));
-                    },
-                  );
-                },
+                onMapMoved: _handleMapMoved,
                 onMarkerTap: (id) {
                   if (id.startsWith('CENTER-')) {
                     debugPrint(
@@ -491,19 +432,8 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
                   context.push(RoutePaths.policyDetail(id));
                 },
                 onMarkerClicked: _handleCenterMarkerClicked,
-                onReady: () {
-                  debugPrint(
-                    '[KakaoMap] WebView Ready! 지도 로딩 완료 (DATA)',
-                  );
-                  _setLoading(false);
-                  _showMyPositionOnMap();
-                },
-                onLoadingChanged: (isLoading) {
-                  debugPrint(
-                    '[KakaoMap] WebView LoadingChanged(DATA) → $isLoading',
-                  );
-                  _setLoading(isLoading);
-                },
+                onReady: _onWebViewReady,
+                onLoadingChanged: _onWebViewLoadingChanged,
                 onError: (code) {
                   debugPrint('[KakaoMap:ERROR][DATA] SDK Fail code=$code');
                   setState(() => _errorCode = code);
@@ -556,13 +486,13 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
               Align(
                 alignment: Alignment.bottomCenter,
                 child: _buildCenterList(
-                  sortedCenterPoints,
+                  visibleCenterPoints,
                   radiusKm: _currentRequest?.radiusKm ?? kCenterRangeKm,
                 ),
               ),
             ],
           ),
-          floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+          floatingActionButtonLocation: FloatingActionButtonLocation.startTop,
           floatingActionButton: _buildPositionedGpsButton(),
         );
       },
@@ -577,6 +507,19 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     });
   }
 
+  void _initRequestWithRegion() {
+    final regionName = ref.read(regionProvider);
+    final regionCenter = _centerForRegion(regionName);
+
+    _latestCenter ??= regionCenter;
+    _latestZoom ??= _locationZoomLevel;
+    _currentRequest ??= CenterFetchRequest(
+      lat: regionCenter.lat,
+      lng: regionCenter.lng,
+      radiusKm: kCenterRangeKm,
+    );
+  }
+
   List<KakaoMapMarker> _policyMarkers(
     KakaoMapLatLng center,
     PolicyListState asyncPolicies,
@@ -584,6 +527,39 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     debugPrint(
         '[KakaoMap] Policy markers disabled (replacement logic removed)');
     return const [];
+  }
+
+  List<KakaoMapMarker> _buildCenterMarkers(
+    List<CenterMarkerPoint> points, {
+    KakaoMapMarkerImage? image,
+  }) {
+    final markerImage = image ??
+        KakaoMapMarkerImage(
+          url:
+              'data:image/png;base64,${_centerMarkerIconBase64 ?? _centerMarkerFallbackBase64}',
+          width: 36,
+          height: 36,
+          offset: const Offset(18, 36),
+        );
+
+    return List.generate(points.length, (index) {
+      final center = points[index];
+      final markerId = 'CENTER-${center.id}';
+      return KakaoMapMarker(
+        id: markerId,
+        title: center.name,
+        position: KakaoMapLatLng(center.lat, center.lng),
+        image: markerImage,
+        extra: {
+          'id': center.id,
+          'name': center.name,
+          'fullAddress': center.fullAddress,
+          'phone': center.phone,
+          'url': center.url,
+          'regionLabel': center.regionLabel,
+        },
+      );
+    });
   }
 
   List<KakaoMapPolyline> _polylinesFromMarkers(List<KakaoMapMarker> markers) {
@@ -803,7 +779,11 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         _currentRequest = request;
       });
 
-      await _moveMapToLocation(location, level: _locationZoomLevel);
+      await _moveMapToLocation(
+        location,
+        level: _locationZoomLevel,
+        animate: true,
+      );
       await _updateSearchCircle(location);
       ref.refresh(youthCenterMapProvider(request));
       debugPrint(
@@ -873,7 +853,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
 
   Future<void> _applyFallbackCenter() async {
     if (!mounted) return;
-    final fallback = _defaultCenter;
+    final fallback = _centerForRegion(ref.read(regionProvider));
     final request = CenterFetchRequest(
       lat: fallback.lat,
       lng: fallback.lng,
@@ -885,7 +865,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
       _latestCenter = fallback;
       _latestZoom = _locationZoomLevel;
       _currentRequest = request;
-      _locationError ??= '기본 위치(대구)를 기준으로 지도를 표시합니다.';
+      _locationError ??= '기본 위치(경북 중심)를 기준으로 지도를 표시합니다.';
     });
 
     await _moveMapToLocation(fallback, level: _locationZoomLevel);
@@ -898,12 +878,31 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     int? level,
     bool updateMyPosition = true,
     bool updateCircle = true,
+    bool animate = false,
   }) async {
+    _latestCenter = location;
+    if (level != null) {
+      _latestZoom = level;
+    }
+
+    if (!_mapReady) {
+      _pendingMove = _PendingMove(
+        target: location,
+        level: level,
+        updateMyPosition: updateMyPosition,
+        updateCircle: updateCircle,
+        animate: animate,
+      );
+      debugPrint('[KakaoMapScreen] map not ready → move queued $_pendingMove');
+      return;
+    }
+
     try {
       final controller = ref.read(kakaoMapControllerProvider);
-      await controller.moveMapTo(location, level: level);
-      if (level != null) {
-        _latestZoom = level;
+      if (animate) {
+        await controller.animateTo(location, level: level);
+      } else {
+        await controller.moveMapTo(location, level: level);
       }
       if (updateMyPosition) {
         await controller.showMyPosition(location);
@@ -937,6 +936,53 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
           _centerMarkerIconBase64 ??= _centerMarkerFallbackBase64;
         });
       }
+    }
+  }
+
+  Future<void> _preloadCachedCenterMarkers() async {
+    try {
+      final prefs = ref.read(app_di.sharedPreferencesProvider);
+      final cached = prefs.getString('yc_center_marker_cache_v1');
+      if (cached == null || cached.isEmpty) return;
+
+      final decoded = jsonDecode(cached) as List<dynamic>;
+      final markers = decoded
+          .map((e) => _decodeCachedMarker(e as Map<String, dynamic>))
+          .whereType<CenterMarkerPoint>()
+          .toList();
+
+      if (markers.isEmpty || !mounted) return;
+
+      setState(() {
+        _cachedCenterPoints = markers;
+      });
+      debugPrint('[KakaoMapScreen] preload marker cache -> ${markers.length} entries');
+    } catch (error, stack) {
+      debugPrint('[KakaoMapScreen] preload marker cache failed: $error');
+      if (stack != null) {
+        debugPrint(stack.toString());
+      }
+    }
+  }
+
+  Future<KakaoMapLatLng?> _loadLastKnownPosition() async {
+    try {
+      final position = await _gpsService.getLastKnownPosition();
+      if (position == null) return null;
+
+      final location = KakaoMapLatLng(position.latitude, position.longitude);
+      if (mounted) {
+        setState(() {
+          _deviceLocation ??= location;
+        });
+      }
+      return location;
+    } catch (error, stack) {
+      debugPrint('[KakaoMapScreen] last known location unavailable: $error');
+      if (stack != null) {
+        debugPrint(stack.toString());
+      }
+      return null;
     }
   }
 
@@ -992,9 +1038,18 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   Widget _buildGpsButton() {
     return FloatingActionButton(
       heroTag: 'kakao_map_gps',
-      onPressed: _isRequestingLocation ? null : _loadInitialPosition,
+      onPressed: _handleGpsButtonPressed,
       tooltip: '내 위치로 이동',
-      child: const Icon(Icons.my_location),
+      child: _isRequestingLocation
+          ? const SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(
+                strokeWidth: 2.5,
+                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+              ),
+            )
+          : const Icon(Icons.my_location),
     );
   }
 
@@ -1002,11 +1057,102 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     return SafeArea(
       child: Padding(
         padding: const EdgeInsets.only(
-          bottom: _floatingActionButtonBottomSpacing,
-          right: 4,
+          top: 8,
+          left: 8,
         ),
         child: _buildGpsButton(),
       ),
+    );
+  }
+
+  Future<void> _handleGpsButtonPressed() async {
+    final cached = _deviceLocation ?? await _loadLastKnownPosition();
+    final anchor = cached ?? _latestCenter ?? _centerForRegion(ref.read(regionProvider));
+
+    await _moveMapToLocation(
+      anchor,
+      level: _locationZoomLevel,
+      updateMyPosition: cached != null,
+      updateCircle: true,
+      animate: true,
+    );
+
+    if (cached == null && _currentRequest == null) {
+      setState(() {
+        _currentRequest = CenterFetchRequest(
+          lat: anchor.lat,
+          lng: anchor.lng,
+          radiusKm: kCenterRangeKm,
+        );
+      });
+    }
+
+    if (_isRequestingLocation) return;
+    await _loadInitialPosition();
+  }
+
+  void _handleMapMoved(KakaoMapLatLng center, int zoom) {
+    debugPrint('[YCMAP] onMapMoved center=(${center.lat}, ${center.lng}) zoom=$zoom');
+    _latestCenter = center;
+    _latestZoom = zoom;
+
+    _moveDebounce?.cancel();
+    debugPrint(
+      '[YCMAP] onMapMoved → debounce ${_debounceMs}ms 후 CenterFetchRequest 갱신 예정',
+    );
+
+    _moveDebounce = Timer(
+      const Duration(milliseconds: _debounceMs),
+      () {
+        final req = CenterFetchRequest(
+          lat: center.lat,
+          lng: center.lng,
+          radiusKm: kCenterRangeKm,
+        );
+        debugPrint(
+          '[YCMAP] debounce 완료 → provider 재요청 '
+          'CenterFetchRequest(lat=${req.lat}, lng=${req.lng}, radius=${req.radiusKm})',
+        );
+
+        setState(() {
+          _currentRequest = req;
+        });
+
+        final circleCenter = _deviceLocation ?? center;
+        unawaited(_updateSearchCircle(circleCenter));
+        ref.refresh(youthCenterMapProvider(req));
+      },
+    );
+  }
+
+  void _onWebViewLoadingChanged(bool isLoading) {
+    debugPrint('[KakaoMap] WebView LoadingChanged → $isLoading');
+    if (isLoading) {
+      _mapReady = false;
+    }
+    _setLoading(isLoading);
+  }
+
+  Future<void> _onWebViewReady() async {
+    debugPrint('[KakaoMap] WebView Ready!');
+    _mapReady = true;
+    _setLoading(false);
+    await _flushPendingMove();
+    await _showMyPositionOnMap();
+  }
+
+  Future<void> _flushPendingMove() async {
+    final pending = _pendingMove;
+    if (!_mapReady || pending == null) return;
+
+    debugPrint('[KakaoMapScreen] applying queued move: $pending');
+    _pendingMove = null;
+    await _moveMapToLocation(
+      pending.target,
+      level: pending.level,
+      updateMyPosition: pending.updateMyPosition,
+      updateCircle: pending.updateCircle,
+      animate: pending.animate,
     );
   }
 
@@ -1034,19 +1180,30 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     CenterMarkerPoint center,
     int index,
   ) async {
-    final markerId = 'CENTER-$index';
+    final markerId = 'CENTER-${center.id}';
     final position = KakaoMapLatLng(center.lat, center.lng);
+    final radius = _currentRequest?.radiusKm ?? kCenterRangeKm;
+    final request = CenterFetchRequest(
+      lat: position.lat,
+      lng: position.lng,
+      radiusKm: radius,
+    );
     setState(() {
       _latestCenter = position;
       _latestZoom = _locationZoomLevel;
+      _currentRequest = request;
     });
     await _moveMapToLocation(
       position,
       level: _locationZoomLevel,
       updateMyPosition: false,
       updateCircle: false,
+      animate: true,
     );
+    await _updateSearchCircle(position);
+    ref.refresh(youthCenterMapProvider(request));
     await _highlightCenterMarker(markerId, position);
+    _showMarkerTooltip(center.name);
     _showCenterDetailSheet(
       name: center.name,
       address: center.fullAddress,
@@ -1129,5 +1286,49 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
       homepageUrl: extra['url']?.toString(),
       regionLabel: extra['regionLabel']?.toString() ?? '',
     );
+  }
+
+  CenterMarkerPoint? _decodeCachedMarker(Map<String, dynamic> json) {
+    try {
+      return CenterMarkerPoint(
+        id: json['id'] as String,
+        name: json['name'] as String,
+        rawAddress: json['rawAddress'] as String,
+        lat: (json['lat'] as num).toDouble(),
+        lng: (json['lng'] as num).toDouble(),
+        fullAddress: json['fullAddress'] as String,
+        phone: json['phone'] as String?,
+        url: json['url'] as String?,
+        regionLabel: json['regionLabel'] as String,
+      );
+    } catch (error, stack) {
+      debugPrint('[KakaoMapScreen] marker cache decode failed: $error');
+      if (stack != null) {
+        debugPrint(stack.toString());
+      }
+      return null;
+    }
+  }
+}
+
+class _PendingMove {
+  const _PendingMove({
+    required this.target,
+    this.level,
+    this.updateMyPosition = true,
+    this.updateCircle = true,
+    this.animate = false,
+  });
+
+  final KakaoMapLatLng target;
+  final int? level;
+  final bool updateMyPosition;
+  final bool updateCircle;
+  final bool animate;
+
+  @override
+  String toString() {
+    return 'target=(${target.lat}, ${target.lng}), level=$level, '
+        'updateMyPosition=$updateMyPosition, updateCircle=$updateCircle, animate=$animate';
   }
 }

--- a/lib/features/map_v2/services/gps_service.dart
+++ b/lib/features/map_v2/services/gps_service.dart
@@ -8,4 +8,6 @@ class GpsService {
   Future<Position> getCurrentPosition() => Geolocator.getCurrentPosition(
         desiredAccuracy: LocationAccuracy.best,
       );
+
+  Future<Position?> getLastKnownPosition() => Geolocator.getLastKnownPosition();
 }

--- a/lib/features/policy_new/data/mappers/youth_center_mapper.dart
+++ b/lib/features/policy_new/data/mappers/youth_center_mapper.dart
@@ -40,6 +40,7 @@ extension YouthCenterDetailMapper on YouthCenterEntity {
 }
 
 class CenterMarkerPoint {
+  final String id;
   final String name;
   final String rawAddress;
   final double lat;
@@ -50,6 +51,7 @@ class CenterMarkerPoint {
   final String regionLabel;
 
   const CenterMarkerPoint({
+    required this.id,
     required this.name,
     required this.rawAddress,
     required this.lat,
@@ -66,14 +68,22 @@ extension YouthCenterMarkerMapper on YouthCenterEntity {
     required double lat,
     required double lng,
   }) {
+    final detail = detailAddress?.trim().isNotEmpty == true
+        ? ' ${detailAddress!.trim()}'
+        : '';
+    final fullAddress = '${address.trim()}$detail'.trim();
+    final normalizedName = centerName.trim().replaceAll(' ', '_');
+    final normalizedAddr = fullAddress.replaceAll(' ', '_');
+    final id =
+        '${normalizedName}_${normalizedAddr}_${lat.toStringAsFixed(5)}_${lng.toStringAsFixed(5)}';
+
     return CenterMarkerPoint(
+      id: id,
       name: centerName,
       rawAddress: address.trim(),
       lat: lat,
       lng: lng,
-      fullAddress: detailAddress?.trim().isNotEmpty == true
-          ? '$address ${detailAddress!.trim()}'
-          : address.trim(),
+      fullAddress: fullAddress,
       phone: phoneNumber,
       url: websiteUrl,
       regionLabel: '${sidoName ?? ''} ${sigunguName ?? ''}'.trim(),

--- a/lib/features/policy_new/presentation/map/youth_center_map_provider.dart
+++ b/lib/features/policy_new/presentation/map/youth_center_map_provider.dart
@@ -11,6 +11,7 @@ import '../../../../env/app_env.dart';
 import '../../application/youthcenter_providers.dart';
 import '../../data/mappers/youth_center_mapper.dart';
 import '../../data/remote/youth_center_geocode_remote.dart';
+import '../../domain/youthcenter/youth_center_entity.dart';
 
 const double kCenterRangeKm = 40.0;
 
@@ -65,11 +66,22 @@ final youthCenterMapProvider = FutureProvider.autoDispose
   // 캐시 로드
   // ───────────────────────────────────────
   Map<String, dynamic> cache = {};
+  List<CenterMarkerPoint> cachedMarkers = const [];
   try {
     final raw = prefs.getString('yc_center_geocode_cache_v1');
     if (raw != null) {
       cache = jsonDecode(raw);
       debugPrint('[YCMAP] Cache loaded: ${cache.length} entries');
+    }
+
+    final markerRaw = prefs.getString('yc_center_marker_cache_v1');
+    if (markerRaw != null) {
+      final decoded = jsonDecode(markerRaw) as List<dynamic>;
+      cachedMarkers = decoded
+          .map((e) => _markerFromJson(e as Map<String, dynamic>))
+          .whereType<CenterMarkerPoint>()
+          .toList();
+      debugPrint('[YCMAP] Marker cache loaded: ${cachedMarkers.length} entries');
     }
   } catch (e) {
     debugPrint('[YCMAP] ⚠ Cache decode error → reset cache: $e');
@@ -79,10 +91,21 @@ final youthCenterMapProvider = FutureProvider.autoDispose
   // ───────────────────────────────────────
   // 전체 센터 정보 조회
   // ───────────────────────────────────────
-  final items = await repo.getCentersV2(pageSize: 300);
+  List<YouthCenterEntity> items;
+  try {
+    items = await repo.getCentersV2(pageSize: 300);
+  } catch (error) {
+    debugPrint('[YCMAP] ❌ API 실패 → 마커 캐시 사용 시도: $error');
+    if (cachedMarkers.isNotEmpty) {
+      debugPrint('[YCMAP] 캐시된 마커 반환 (${cachedMarkers.length}개)');
+      return cachedMarkers;
+    }
+    rethrow;
+  }
   debugPrint('[YCMAP] API success, item count=${items.length}');
 
   final result = <CenterMarkerPoint>[];
+  final candidates = <({CenterMarkerPoint point, double distance})>[];
 
   for (final center in items) {
     final addr = center.address.trim();
@@ -145,12 +168,31 @@ final youthCenterMapProvider = FutureProvider.autoDispose
     final dist = _distanceKm(request.lat, request.lng, lat, lng);
     debugPrint('[YCMAP] Distance = ${dist.toStringAsFixed(2)}km');
 
+    final markerPoint = center.toMarkerPoint(lat: lat, lng: lng);
+
+    candidates.add((point: markerPoint, distance: dist));
+
     if (dist <= request.radiusKm) {
-      result.add(center.toMarkerPoint(lat: lat, lng: lng));
+      result.add(markerPoint);
       debugPrint('[YCMAP] ✔ Added to result');
     } else {
       debugPrint('[YCMAP] Skip: too far');
     }
+  }
+
+  if (result.isEmpty && candidates.isNotEmpty) {
+    debugPrint('[YCMAP] 🔍 반경 내 결과 없음 → 가장 가까운 센터 3곳 노출');
+
+    candidates.sort((a, b) => a.distance.compareTo(b.distance));
+    final fallbackCenters = candidates.take(3).map((c) => c.point).toList();
+
+    debugPrint('[YCMAP] fallback count=${fallbackCenters.length}');
+    return fallbackCenters;
+  }
+
+  if (result.isEmpty && cachedMarkers.isNotEmpty) {
+    debugPrint('[YCMAP] 새 결과 없음 → 캐시된 마커 사용 (${cachedMarkers.length}개)');
+    return cachedMarkers;
   }
 
   // ─────────────────────────────────────────────
@@ -158,7 +200,11 @@ final youthCenterMapProvider = FutureProvider.autoDispose
   // ─────────────────────────────────────────────
   try {
     await prefs.setString('yc_center_geocode_cache_v1', jsonEncode(cache));
-    debugPrint('[YCMAP] Cache saved (${cache.length} entries)');
+    await prefs.setString(
+      'yc_center_marker_cache_v1',
+      jsonEncode(result.map(_markerToJson).toList()),
+    );
+    debugPrint('[YCMAP] Cache saved (geocode=${cache.length}, markers=${result.length})');
   } catch (e) {
     debugPrint('[YCMAP] ⚠ Cache save error: $e');
   }
@@ -180,3 +226,36 @@ double _distanceKm(double lat1, double lon1, double lat2, double lon2) {
 }
 
 double _deg(double deg) => deg * (pi / 180.0);
+
+CenterMarkerPoint? _markerFromJson(Map<String, dynamic> json) {
+  try {
+    return CenterMarkerPoint(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      rawAddress: json['rawAddress'] as String,
+      lat: (json['lat'] as num).toDouble(),
+      lng: (json['lng'] as num).toDouble(),
+      fullAddress: json['fullAddress'] as String,
+      phone: json['phone'] as String?,
+      url: json['url'] as String?,
+      regionLabel: json['regionLabel'] as String,
+    );
+  } catch (error) {
+    debugPrint('[YCMAP] ⚠ Marker cache decode failed: $error');
+    return null;
+  }
+}
+
+Map<String, dynamic> _markerToJson(CenterMarkerPoint point) {
+  return {
+    'id': point.id,
+    'name': point.name,
+    'rawAddress': point.rawAddress,
+    'lat': point.lat,
+    'lng': point.lng,
+    'fullAddress': point.fullAddress,
+    'phone': point.phone,
+    'url': point.url,
+    'regionLabel': point.regionLabel,
+  };
+}


### PR DESCRIPTION
## Summary
- 앱 진입 시 청년센터 마커 캐시를 선로드해 로딩 단계에서도 지도에 바로 노출되도록 했습니다.
- 위치 오류 안내 문구를 기본 위치와 맞게 수정하고 GPS 버튼을 좌상단으로 더 붙여 누르기 쉽게 조정했습니다.
- 마커 캐시 디코더를 추가해 저장된 센터 데이터를 안전하게 재사용하도록 했습니다.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936365f7c1883248ccd66cc275e142f)