### PR TITLE
Fix build errors for map highlight and policy action bar

### DIFF
--- a/lib/features/map_v2/kakao_map_screen.dart
+++ b/lib/features/map_v2/kakao_map_screen.dart
@@ -1316,8 +1316,6 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
       markerId,
       position,
       tooltipName: center.name,
-      updateCircle: false,
-      animate: true,
     );
     await _updateSearchCircle(position);
     ref.refresh(youthCenterMapProvider(request));

--- a/lib/features/policy_new/presentation/detail/widgets/policy_action_bar.dart
+++ b/lib/features/policy_new/presentation/detail/widgets/policy_action_bar.dart
@@ -9,7 +9,7 @@ import '../../../application/controllers/policy_action_controller.dart';
 import '../../../application/controllers/policy_reminder_controller.dart';
 import '../../../application/providers.dart';
 import '../../utils/policy_date_formatter.dart';
-import '../../../../ui/theme/app_text.dart';
+import '../../../../../ui/theme/app_text.dart';
 
 class PolicyActionBar extends ConsumerWidget {
   const PolicyActionBar({super.key, required this.policy});


### PR DESCRIPTION
## Summary
- Remove unsupported named arguments from center highlight invocation
- Correct AppText import path in the policy action bar widget

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693649792ec883248b51c720263f7e8a)