### PR TITLE
Region 필터 초기화 동기화 안정화

### DIFF
--- a/lib/application/notifiers/region_notifier.dart
+++ b/lib/application/notifiers/region_notifier.dart
@@ -3,8 +3,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../constants/regions_gyeongbuk.dart';
 import '../di.dart';
-import '../../features/policy_new/application/filters/policy_filter_ui_state.dart'
-    as filter_ui;
 
 final regionProvider =
     NotifierProvider.autoDispose<RegionNotifier, String?>(RegionNotifier.new);
@@ -47,7 +45,6 @@ class RegionNotifier extends AutoDisposeNotifier<String?> {
     _selectedDistrict = storedDistrict != null && storedDistrict.isNotEmpty
         ? storedDistrict
         : null;
-    applyToFilter();
     // state는 기존 호환성을 위해 city만 저장
     return _selectedCity;
   }
@@ -60,7 +57,6 @@ class RegionNotifier extends AutoDisposeNotifier<String?> {
     _selectedCity = city;
     _selectedDistrict = null;
     state = city;
-    applyToFilter();
   }
 
   void resetCity() {
@@ -71,7 +67,6 @@ class RegionNotifier extends AutoDisposeNotifier<String?> {
     _selectedCity = null;
     _selectedDistrict = null;
     state = null;
-    applyToFilter();
   }
 
   void selectDistrict(String? district) {
@@ -86,21 +81,9 @@ class RegionNotifier extends AutoDisposeNotifier<String?> {
       _selectedDistrict = district;
       state = '${_selectedCity ?? ''}|$district';
     }
-    applyToFilter();
   }
 
   void clear() {
     resetCity();
-  }
-
-  /// 현재 지역을 필터 상태에 반영
-  void applyToFilter() {
-    final notifier =
-        ref.read(filter_ui.policyFilterUiStateProvider.notifier);
-    notifier.setRegionStrings(
-      province: selectedProvince,
-      city: _selectedCity,
-      district: _selectedDistrict,
-    );
   }
 }

--- a/lib/features/policy_new/application/filters/policy_filter_ui_state.dart
+++ b/lib/features/policy_new/application/filters/policy_filter_ui_state.dart
@@ -7,6 +7,7 @@ import '../../domain/values/policy_region.dart';
 import '../../domain/values/policy_sort.dart';
 import '../../domain/values/policy_status_filter.dart';
 import '../reexplore/policy_reexplore.dart';
+import '../../../../application/notifiers/region_notifier.dart';
 
 @immutable
 class PolicyFilterUiState {
@@ -98,7 +99,9 @@ class PolicyFilterUiState {
 }
 
 class PolicyFilterUiStateNotifier extends StateNotifier<PolicyFilterUiState> {
-  PolicyFilterUiStateNotifier() : super(const PolicyFilterUiState());
+  PolicyFilterUiStateNotifier({
+    PolicyFilterUiState initialState = const PolicyFilterUiState(),
+  }) : super(initialState);
 
   void setRegion(PolicyRegion region) => state = state.copyWith(
         region: region,
@@ -162,7 +165,33 @@ class PolicyFilterUiStateNotifier extends StateNotifier<PolicyFilterUiState> {
 
 final globalFilterProvider =
     StateNotifierProvider<PolicyFilterUiStateNotifier, PolicyFilterUiState>(
-  (ref) => PolicyFilterUiStateNotifier(),
+  (ref) {
+    final regionNotifier = ref.read(regionProvider.notifier);
+    final notifier = PolicyFilterUiStateNotifier(
+      initialState: PolicyFilterUiState(
+        region: PolicyRegion.gyeongbuk,
+        province: regionNotifier.selectedProvince,
+        city: regionNotifier.selectedCity,
+        district: regionNotifier.selectedDistrict,
+      ),
+    );
+
+    final regionSubscription = ref.listenManual<String?>(
+      regionProvider,
+      (previous, next) {
+        notifier.setRegionStrings(
+          province: regionNotifier.selectedProvince,
+          city: regionNotifier.selectedCity,
+          district: regionNotifier.selectedDistrict,
+        );
+      },
+      fireImmediately: false,
+    );
+
+    ref.onDispose(regionSubscription.close);
+
+    return notifier;
+  },
 );
 
 @Deprecated('Use globalFilterProvider instead')

--- a/lib/features/policy_new/presentation/filters/policy_filter_bottom_sheet.dart
+++ b/lib/features/policy_new/presentation/filters/policy_filter_bottom_sheet.dart
@@ -463,8 +463,6 @@ class _PolicyFilterBottomSheetState
       hasChanged = true;
     }
 
-    ref.read(regionProvider.notifier).applyToFilter();
-
     Navigator.of(context).pop();
     _notifyReaction(hasChanged
         ? '필터가 적용됐어요. 결과를 새로 불러옵니다.'

--- a/lib/ui/screens/region/region_select_screen.dart
+++ b/lib/ui/screens/region/region_select_screen.dart
@@ -21,7 +21,6 @@ class RegionSelectScreen extends ConsumerWidget {
         actions: [
           TextButton(
             onPressed: () {
-              notifier.applyToFilter();
               ref.invalidate(policyListNotifierProvider);
               context.go(RoutePaths.home);
             },
@@ -42,7 +41,6 @@ class RegionSelectScreen extends ConsumerWidget {
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: () {
-                notifier.applyToFilter();
                 ref.invalidate(policyListNotifierProvider);
                 context.go(RoutePaths.home);
               },


### PR DESCRIPTION
## Summary
- PolicyFilterUiStateNotifier의 regionProvider 리스너를 수동 구독으로 바꿔 초기 빌드 중 교차 업데이트가 발생하지 않도록 조정

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693653926188832493cecefa0f6d765c)