### PR TITLE
fix: 정책 비교 화면 줌 제스처 반응 개선

### DIFF
--- a/lib/features/policy_new/compare/presentation/widgets/compare_screen.dart
+++ b/lib/features/policy_new/compare/presentation/widgets/compare_screen.dart
@@ -104,6 +104,9 @@ class _CompareScreenState extends State<CompareScreen> {
         Expanded(
           child: LayoutBuilder(
             builder: (context, constraints) {
+              final scrollPhysics = _isZoomed
+                  ? const NeverScrollableScrollPhysics()
+                  : const ClampingScrollPhysics();
               return ClipRect(
                 child: InteractiveViewer(
                   transformationController: _transformationController,
@@ -111,11 +114,13 @@ class _CompareScreenState extends State<CompareScreen> {
                   minScale: 1.0,
                   maxScale: 2.5,
                   panEnabled: _isZoomed,
+                  onInteractionStart: (_) => _setZoomed(true),
                   onInteractionUpdate: (_) => _updateZoomState(),
                   onInteractionEnd: (_) => _updateZoomState(),
                   child: ConstrainedBox(
                     constraints: BoxConstraints(minHeight: constraints.maxHeight),
                     child: SingleChildScrollView(
+                      physics: scrollPhysics,
                       padding:
                           const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
                       child: Column(
@@ -152,13 +157,17 @@ class _CompareScreenState extends State<CompareScreen> {
     );
   }
 
+  void _setZoomed(bool value) {
+    if (_isZoomed != value) {
+      setState(() {
+        _isZoomed = value;
+      });
+    }
+  }
+
   void _updateZoomState() {
     final scale = _transformationController.value.getMaxScaleOnAxis();
     final shouldEnablePan = scale > 1.01;
-    if (_isZoomed != shouldEnablePan) {
-      setState(() {
-        _isZoomed = shouldEnablePan;
-      });
-    }
+    _setZoomed(shouldEnablePan);
   }
 }


### PR DESCRIPTION
## Summary
- 인터랙션 시작 시 스크롤을 즉시 잠그고 확대 상태를 반영해 핀치 줌 제스처 반응을 개선했습니다.
- 제스처 진행/종료 시 스케일을 다시 계산해 팬 가능 여부를 자연스럽게 전환하도록 정리했습니다.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936555178a8832482a5bc5582da59e4)