### PR TITLE
Fix policy filter listener for riverpod 2.6

### DIFF
--- a/lib/features/policy_new/application/filters/policy_filter_ui_state.dart
+++ b/lib/features/policy_new/application/filters/policy_filter_ui_state.dart
@@ -176,7 +176,7 @@ final globalFilterProvider =
       ),
     );
 
-    final regionSubscription = ref.listenManual<String?>(
+    final regionSubscription = ref.listen<String?>(
       regionProvider,
       (previous, next) {
         notifier.setRegionStrings(


### PR DESCRIPTION
## Summary
- replace deprecated listenManual usage with listen in policy filter provider

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69365738c24c8324b99e88d892bc93d8)