### PR TITLE
fix: enforce policy search status logic

### DIFF
--- a/lib/features/policy_new/application/controllers/policy_feed_memory_cache.dart
+++ b/lib/features/policy_new/application/controllers/policy_feed_memory_cache.dart
@@ -7,11 +7,13 @@ class PolicyFeedCacheEntry {
     required this.query,
     required this.state,
     required this.page,
+    required this.storedAt,
   });
 
   final PolicyQueryState query;
   final PolicyPagingState state;
   final int page;
+  final DateTime storedAt;
 }
 
 class PolicyFeedMemoryCache {
@@ -20,7 +22,15 @@ class PolicyFeedMemoryCache {
   PolicyFeedCacheEntry? restore(PolicyFeedType feedType, String hash) {
     final scope = _store[feedType];
     if (scope == null) return null;
-    return scope[hash];
+    final entry = scope[hash];
+    if (entry == null) return null;
+
+    if (_isExpired(feedType, entry)) {
+      scope.remove(hash);
+      return null;
+    }
+
+    return entry;
   }
 
   void save(PolicyFeedType feedType, PolicyQueryState query, PolicyPagingState state,
@@ -30,6 +40,7 @@ class PolicyFeedMemoryCache {
       query: query,
       state: state,
       page: page,
+      storedAt: DateTime.now(),
     );
   }
 
@@ -39,5 +50,11 @@ class PolicyFeedMemoryCache {
 
   void clear() {
     _store.clear();
+  }
+
+  bool _isExpired(PolicyFeedType feedType, PolicyFeedCacheEntry entry) {
+    if (feedType != PolicyFeedType.search) return false;
+    final age = DateTime.now().difference(entry.storedAt);
+    return age.inSeconds > 120;
   }
 }

--- a/lib/features/policy_new/application/controllers/policy_query_engine.dart
+++ b/lib/features/policy_new/application/controllers/policy_query_engine.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../domain/entities/policy.dart';
+import '../../domain/policy_state_utils.dart';
 import '../../domain/values/policy_feed_type.dart';
 import '../../domain/values/policy_result.dart';
 import '../../domain/values/policy_status_filter.dart';
@@ -48,10 +49,18 @@ class PolicyQueryEngine {
 
     debugPrint(logBuffer.toString());
 
-    return repo.fetchPoliciesByQuery(
+    final result = await repo.fetchPoliciesByQuery(
       query: query,
       page: page,
       pageSize: pageSize,
+    );
+
+    return result.fold(
+      onSuccess: (policies) {
+        final filtered = _filterByStatus(policies, query.filter.status);
+        return PolicyResult.success(filtered);
+      },
+      onFailure: PolicyResult.failure,
     );
   }
 
@@ -63,6 +72,26 @@ class PolicyQueryEngine {
         return 'closed-only';
       case PolicyStatusFilter.includeClosed:
         return 'all';
+    }
+  }
+
+  List<Policy> _filterByStatus(
+    List<Policy> policies,
+    PolicyStatusFilter status,
+  ) {
+    switch (status) {
+      case PolicyStatusFilter.inProgressOnly:
+        return policies
+            .where((policy) =>
+                policy.activeState == PolicyActiveState.active ||
+                policy.activeState == PolicyActiveState.closingSoon)
+            .toList();
+      case PolicyStatusFilter.closedOnly:
+        return policies
+            .where((policy) => policy.activeState == PolicyActiveState.closed)
+            .toList();
+      case PolicyStatusFilter.includeClosed:
+        return policies;
     }
   }
 }

--- a/lib/features/policy_new/application/providers.dart
+++ b/lib/features/policy_new/application/providers.dart
@@ -52,6 +52,8 @@ import 'services/policy_reminder_service.dart';
 import 'filters/policy_filter_ui_state.dart';
 import 'filters/policy_search_keyword_provider.dart';
 import 'filters/policy_filter_summary.dart';
+import 'search/search_controller.dart';
+import 'search/search_label_builder.dart';
 import 'models/user_collections.dart';
 import 'controllers/policy_feed_memory_cache.dart';
 import '../data/cache/policy_cache.dart';
@@ -417,6 +419,9 @@ final notificationCenterControllerProvider = StateNotifierProvider<
   (ref) => NotificationCenterController(ref: ref),
 );
 
+final policySearchControllerProvider =
+    Provider<PolicySearchController>((ref) => const PolicySearchController());
+
 final policyQueryProvider = Provider.family<PolicyQueryState, PolicyFeedType>(
   (ref, feedType) {
     final filter = ref.watch(globalFilterProvider);
@@ -430,13 +435,32 @@ final policyQueryProvider = Provider.family<PolicyQueryState, PolicyFeedType>(
 
     final orchestrator = ref.read(policyQueryOrchestratorProvider);
     final query = orchestrator.buildQuery(feedType, keyword: keyword);
+    final searchController = ref.read(policySearchControllerProvider);
+
+    final summary = feedType == PolicyFeedType.search
+        ? SearchLabelBuildContext.makeLabel(
+            filter.regionSummary,
+            SearchLabelBuildContext.filterLabelFromStatus(filter.status),
+            SearchLabelBuildContext.sortLabel(filter.sort),
+          )
+        : buildPolicyFilterSummary(filter, keyword: keyword);
+
+    final conditionSummary = feedType == PolicyFeedType.search
+        ? summary
+        : buildPolicyFilterConditionSummary(filter, keyword: keyword);
+
+    final hash = feedType == PolicyFeedType.search
+        ? searchController.buildCacheKey(
+            filter: query.filter,
+            sort: query.sort,
+          )
+        : query.cacheScopeKey;
 
     final baseState = PolicyQueryState(
       query: query,
-      hash: query.cacheScopeKey,
-      summary: buildPolicyFilterSummary(filter, keyword: keyword),
-      conditionSummary:
-          buildPolicyFilterConditionSummary(filter, keyword: keyword),
+      hash: hash,
+      summary: summary,
+      conditionSummary: conditionSummary,
     );
 
     ref

--- a/lib/features/policy_new/application/search/search_controller.dart
+++ b/lib/features/policy_new/application/search/search_controller.dart
@@ -1,0 +1,54 @@
+import '../../domain/values/policy_filter.dart';
+import '../../domain/values/policy_sort.dart';
+import '../../domain/values/policy_status_filter.dart';
+
+class PolicySearchController {
+  const PolicySearchController();
+
+  /// 검색 캐시 키를 표준 형태로 생성한다.
+  ///
+  /// key format: `search:{regionCode}:{filterCode}:{orderCode}`
+  String buildCacheKey({
+    required PolicyFilter filter,
+    required PolicySortOption sort,
+  }) {
+    final regionCode = _regionCode(filter);
+    final filterCode = _filterCode(filter.status);
+    final orderCode = sort.name;
+    return 'search:$regionCode:$filterCode:$orderCode';
+  }
+
+  PolicyStatusFilter mapStatusFromChip(PolicyStatusFilter selected) {
+    switch (selected) {
+      case PolicyStatusFilter.inProgressOnly:
+        return PolicyStatusFilter.inProgressOnly;
+      case PolicyStatusFilter.closedOnly:
+        return PolicyStatusFilter.closedOnly;
+      case PolicyStatusFilter.includeClosed:
+        return PolicyStatusFilter.includeClosed;
+    }
+  }
+
+  String _regionCode(PolicyFilter filter) {
+    final buffer = StringBuffer(filter.region.name);
+    if (filter.province.isNotEmpty) buffer.write('-${filter.province}');
+    if (filter.city != null && filter.city!.isNotEmpty) {
+      buffer.write('-${filter.city}');
+    }
+    if (filter.district != null && filter.district!.isNotEmpty) {
+      buffer.write('-${filter.district}');
+    }
+    return buffer.toString();
+  }
+
+  String _filterCode(PolicyStatusFilter status) {
+    switch (status) {
+      case PolicyStatusFilter.inProgressOnly:
+        return 'active';
+      case PolicyStatusFilter.includeClosed:
+        return 'all';
+      case PolicyStatusFilter.closedOnly:
+        return 'closed';
+    }
+  }
+}

--- a/lib/features/policy_new/application/search/search_label_builder.dart
+++ b/lib/features/policy_new/application/search/search_label_builder.dart
@@ -1,0 +1,45 @@
+import '../../domain/values/policy_sort.dart';
+import '../../domain/values/policy_status_filter.dart';
+
+class SearchLabelBuildContext {
+  const SearchLabelBuildContext._();
+
+  static String makeLabel(
+    String regionName,
+    String filterLabel,
+    String sortLabel,
+  ) {
+    final parts = <String>[regionName];
+    if (filterLabel.isNotEmpty) {
+      parts.add(filterLabel);
+    }
+    if (sortLabel.isNotEmpty) {
+      parts.add(sortLabel);
+    }
+    return parts.join(' · ');
+  }
+
+  static String filterLabelFromStatus(PolicyStatusFilter status) {
+    switch (status) {
+      case PolicyStatusFilter.inProgressOnly:
+        return '진행중';
+      case PolicyStatusFilter.includeClosed:
+        return '마감 포함';
+      case PolicyStatusFilter.closedOnly:
+        return '마감된 정책';
+    }
+  }
+
+  static String sortLabel(PolicySortOption sort) {
+    switch (sort) {
+      case PolicySortOption.latest:
+        return '최신순';
+      case PolicySortOption.deadline:
+        return '마감 임박 우선순';
+      case PolicySortOption.popularity:
+        return '인기순';
+      case PolicySortOption.recommendation:
+        return '추천순';
+    }
+  }
+}

--- a/lib/features/policy_new/domain/entities/policy.dart
+++ b/lib/features/policy_new/domain/entities/policy.dart
@@ -1,3 +1,4 @@
+import '../policy_state_utils.dart';
 import '../values/policy_category.dart';
 import '../values/policy_region.dart';
 
@@ -82,5 +83,12 @@ class Policy {
     final now = DateTime.now();
     if (applicationEndDate == null) return false;
     return applicationEndDate!.isBefore(now);
+  }
+
+  PolicyActiveState get activeState {
+    if (applicationEndDate == null) {
+      return PolicyActiveState.closed;
+    }
+    return resolvePolicyState(DateTime.now(), applicationEndDate!);
   }
 }

--- a/lib/features/policy_new/domain/policy_state_utils.dart
+++ b/lib/features/policy_new/domain/policy_state_utils.dart
@@ -1,0 +1,28 @@
+/// 정책 진행 상태 분류를 위한 상태값.
+enum PolicyActiveState {
+  active,
+  closingSoon,
+  closed,
+}
+
+/// 정책 마감일을 기준으로 진행 상태를 계산한다.
+///
+/// 규칙:
+/// - endDate가 오늘보다 이전이면 [PolicyActiveState.closed]
+/// - 오늘을 포함해 D-Day가 0~3일이면 [PolicyActiveState.closingSoon]
+/// - 그 외에는 [PolicyActiveState.active]
+PolicyActiveState resolvePolicyState(DateTime now, DateTime endDate) {
+  final normalizedNow = DateTime.utc(now.year, now.month, now.day);
+  final normalizedEnd = DateTime.utc(endDate.year, endDate.month, endDate.day);
+
+  if (normalizedEnd.isBefore(normalizedNow)) {
+    return PolicyActiveState.closed;
+  }
+
+  final days = normalizedEnd.difference(normalizedNow).inDays;
+  if (days >= 0 && days <= 3) {
+    return PolicyActiveState.closingSoon;
+  }
+
+  return PolicyActiveState.active;
+}

--- a/lib/features/policy_new/presentation/search/policy_search_screen.dart
+++ b/lib/features/policy_new/presentation/search/policy_search_screen.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../application/providers.dart';
+import '../../application/search/search_label_builder.dart';
+import '../../domain/values/policy_feed_type.dart';
+import '../tabs/policy_feed_tab.dart';
+
+class PolicySearchScreen extends ConsumerWidget {
+  const PolicySearchScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filter = ref.watch(globalFilterProvider);
+    final filterLabel = SearchLabelBuildContext.filterLabelFromStatus(filter.status);
+    final sortLabel = SearchLabelBuildContext.sortLabel(filter.sort);
+    final summary = SearchLabelBuildContext.makeLabel(
+      filter.regionSummary,
+      filterLabel,
+      sortLabel,
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(summary),
+      ),
+      body: const PolicyFeedTab(feedType: PolicyFeedType.search),
+    );
+  }
+}

--- a/lib/features/policy_new/presentation/widgets/policy_feed_list_view.dart
+++ b/lib/features/policy_new/presentation/widgets/policy_feed_list_view.dart
@@ -17,6 +17,7 @@ import 'policy_list_error.dart';
 import 'policy_list_loading.dart';
 import 'policy_list_skeleton.dart';
 import 'policy_search_empty_view.dart';
+import '../../../../ui/common/empty_result_view.dart';
 
 class PolicyFeedListView extends ConsumerStatefulWidget {
   const PolicyFeedListView({
@@ -118,17 +119,18 @@ class _PolicyFeedListViewState extends ConsumerState<PolicyFeedListView>
         feedType: widget.feedType,
       );
     } else if (!state.isLoading && visibleItems.isEmpty) {
-      final emptyMessage = widget.feedType == PolicyFeedType.favorite
-          ? '즐겨찾기한 정책이 없습니다.\n마음에 드는 정책의 하트 버튼을 눌러 저장해보세요.'
-          : '조건에 맞는 정책이 없습니다.\n${queryState.conditionSummary} 조건을 조정해보세요.';
-
-      content = PolicyListEmpty(
-        key: const ValueKey('policy-list-empty'),
-        message: emptyMessage,
-        summary: widget.feedType == PolicyFeedType.favorite
-            ? null
-            : queryState.summary,
-      );
+      if (widget.feedType == PolicyFeedType.favorite) {
+        content = PolicyListEmpty(
+          key: const ValueKey('policy-list-empty-favorite'),
+          message:
+              '즐겨찾기한 정책이 없습니다.\n마음에 드는 정책의 하트 버튼을 눌러 저장해보세요.',
+          summary: null,
+        );
+      } else {
+        content = const EmptyResultView(
+          key: ValueKey('policy-list-empty-standard'),
+        );
+      }
     } else {
       content = RefreshIndicator(
         key: const ValueKey('policy-list-content'),

--- a/lib/ui/common/empty_result_view.dart
+++ b/lib/ui/common/empty_result_view.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class EmptyResultView extends StatelessWidget {
+  const EmptyResultView({
+    super.key,
+    this.primaryMessage = '조건에 맞는 정책이 없습니다.',
+    this.secondaryMessage = '검색 조건(지역/상태/정렬)을 변경해보세요.',
+  });
+
+  final String primaryMessage;
+  final String secondaryMessage;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      bottom: true,
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(32),
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                primaryMessage,
+                style: Theme.of(context)
+                    .textTheme
+                    .titleMedium
+                    ?.copyWith(fontWeight: FontWeight.w700),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                secondaryMessage,
+                style: Theme.of(context).textTheme.bodyMedium,
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- apply unified policy state resolution to filter results by the selected status
- expose derived active state on Policy entities for consistent status checks
- align search status label text with standardized wording

## Testing
- not run (environment missing dart/flutter tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693662f477688324909db3999189c14e)