### PR TITLE
Adjust Kakao map marker payloads and radius filtering

### DIFF
--- a/lib/features/map_v2/kakao_map_controller.dart
+++ b/lib/features/map_v2/kakao_map_controller.dart
@@ -78,7 +78,16 @@ class KakaoMapMessage {
   final String? logLevel;
   final String? raw;
 
-  String? get markerId => payload['id'] as String?;
+  String? get markerId {
+    final id = payload['id'] as String?;
+    if (id != null) return id;
+    final rawPayload = payload['payload'];
+    if (rawPayload is String) return rawPayload;
+    if (rawPayload is Map<String, dynamic>) {
+      return rawPayload['id'] as String?;
+    }
+    return null;
+  }
 
   KakaoMapLatLng? get position {
     final lat = payload['lat'];
@@ -550,6 +559,8 @@ class KakaoMapController {
         return KakaoMapEventType.clusterTap;
       case 'map_move':
         return KakaoMapEventType.mapMove;
+      case 'centerMarkerClick':
+        return KakaoMapEventType.markerClicked;
       case 'loading':
         return KakaoMapEventType.loading;
       case 'error':

--- a/lib/features/map_v2/kakao_map_html_builder.dart
+++ b/lib/features/map_v2/kakao_map_html_builder.dart
@@ -160,6 +160,19 @@ class KakaoMapHtmlBuilder {
     };
 
     final initJson = jsonEncode(payload);
+    final centerMarkerList = jsonEncode(
+      markers
+          .where((m) => m.id.startsWith('CENTER-'))
+          .map(
+            (m) => {
+              'id': m.id,
+              'lat': m.position.lat,
+              'lng': m.position.lng,
+              'label': m.title ?? '',
+            },
+          )
+          .toList(),
+    );
 
     return '''
 <!DOCTYPE html>
@@ -206,9 +219,10 @@ class KakaoMapHtmlBuilder {
 </style>
 
 <script>
-  const SEARCH_RADIUS_METERS = 40000;
+  const SEARCH_RADIUS_METERS = 20000;
   const USER_DOT_BASE64 = 'USER_DOT_BASE64_PLACEHOLDER';
   const CENTER_MARKER_BASE64 = 'CENTER_MARKER_BASE64_PLACEHOLDER';
+  const center_marker_list = $centerMarkerList;
 
   function _post(msg) {
     try {
@@ -485,25 +499,37 @@ class KakaoMapHtmlBuilder {
         mk.setMap(map);
 
         kakao.maps.event.addListener(mk, 'click', function() {
+          var isCenter = (m.id && m.id.indexOf('CENTER-') === 0);
+          var centerPayload = {
+            id: m.id,
+            lat: m.lat,
+            lng: m.lng,
+            label: m.title || ''
+          };
+
           _post({
-            type: 'marker',
-            payload: {
-              id: m.id,
-              lat: m.lat,
-              lng: m.lng,
-              extra: m.extra || null
-            }
+            type: isCenter ? 'centerMarkerClick' : 'marker',
+            payload: isCenter
+              ? centerPayload.id
+              : {
+                  id: m.id,
+                  lat: m.lat,
+                  lng: m.lng,
+                  extra: m.extra || null
+                }
           });
 
-          sendMessage({
-            type: 'marker_click',
-            payload: {
-              id: m.id,
-              name: m.title || '',
-              lat: m.lat,
-              lng: m.lng
-            }
-          });
+          if (!isCenter) {
+            sendMessage({
+              type: 'marker_click',
+              payload: {
+                id: m.id,
+                name: m.title || '',
+                lat: m.lat,
+                lng: m.lng
+              }
+            });
+          }
 
           if (window.app && window.app.showMarkerTooltip) {
             window.app.showMarkerTooltip(m.id, m.title, m.lat, m.lng);
@@ -517,10 +543,7 @@ class KakaoMapHtmlBuilder {
           if (m.id && m.id.indexOf('CENTER-') === 0 &&
               window.flutter_inappwebview &&
               window.flutter_inappwebview.callHandler) {
-            window.flutter_inappwebview.callHandler('onMarkerClicked', {
-              id: m.id,
-              extra: m.extra || null
-            });
+            window.flutter_inappwebview.callHandler('onMarkerClicked', centerPayload);
           }
         });
 

--- a/lib/features/map_v2/kakao_map_screen.dart
+++ b/lib/features/map_v2/kakao_map_screen.dart
@@ -73,6 +73,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   bool _mapReady = false;
   _PendingMove? _pendingMove;
   _PendingHighlight? _pendingHighlight;
+  String? _activeCenterSheetId;
 
   @override
   void initState() {
@@ -213,6 +214,13 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
                   right: 16,
                   child: _buildErrorBanner(),
                 ),
+              if (_isRequestingLocation)
+                Positioned(
+                  top: 72,
+                  left: 16,
+                  right: 16,
+                  child: _buildLocationLoadingBanner(),
+                ),
               if (_locationError != null) _buildLocationErrorBanner(),
               Positioned(
                 left: 0,
@@ -295,6 +303,13 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
                   right: 16,
                   child: _buildErrorBanner(),
                 ),
+              if (_isRequestingLocation)
+                Positioned(
+                  top: 72,
+                  left: 16,
+                  right: 16,
+                  child: _buildLocationLoadingBanner(),
+                ),
               if (_locationError != null) _buildLocationErrorBanner(),
               Positioned(
                 left: 0,
@@ -338,15 +353,8 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         final sortedCenterPoints =
             sortedCenters.map((entry) => entry.point).toList();
 
-        final hasNewCenters = sortedCenterPoints.isNotEmpty;
-        final visibleCenterPoints =
-            hasNewCenters ? sortedCenterPoints : _cachedCenterPoints;
-
-        if (hasNewCenters) {
-          _cachedCenterPoints = sortedCenterPoints;
-        } else if (_cachedCenterPoints.isNotEmpty) {
-          debugPrint('[YCMAP] 새 데이터 없음 → 캐시된 센터 마커 유지');
-        }
+        final visibleCenterPoints = sortedCenterPoints;
+        _cachedCenterPoints = sortedCenterPoints;
 
         final centerIconBase64 =
             _centerMarkerIconBase64 ?? _centerMarkerFallbackBase64;
@@ -1044,6 +1052,28 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     );
   }
 
+  Widget _buildLocationLoadingBanner() {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.black87,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: const Row(
+        children: [
+          CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+          SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              '현재 위치 확인중...',
+              style: TextStyle(color: Colors.white),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildGpsButton() {
     return FloatingActionButton(
       heroTag: 'kakao_map_gps',
@@ -1115,60 +1145,10 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
 
   void _handleMapMoved(KakaoMapLatLng center, int zoom) {
     debugPrint('[YCMAP] onMapMoved center=(${center.lat}, ${center.lng}) zoom=$zoom');
-    _latestCenter = center;
+    _latestCenter ??= center;
     _latestZoom = zoom;
 
-    unawaited(_updateSearchCircle(center));
-
-    final nextRequest = CenterFetchRequest(
-      lat: center.lat,
-      lng: center.lng,
-      radiusKm: kCenterRangeKm,
-    );
-
-    if (_currentRequest == nextRequest) {
-      debugPrint('[YCMAP] onMapMoved → 요청 변경 없음, provider refresh 생략');
-      return;
-    }
-
-    _moveDebounce?.cancel();
-    debugPrint(
-      '[YCMAP] onMapMoved → debounce ${_debounceMs}ms 후 CenterFetchRequest 갱신 예정',
-    );
-
-    _moveDebounce = Timer(
-      const Duration(milliseconds: _debounceMs),
-      () {
-        if (!mounted) return;
-        debugPrint(
-          '[YCMAP] debounce 완료 → provider 재요청 '
-          'CenterFetchRequest(lat=${nextRequest.lat}, lng=${nextRequest.lng}, radius=${nextRequest.radiusKm})',
-        );
-
-        setState(() {
-          _currentRequest = nextRequest;
-        });
-
-        ref.refresh(youthCenterMapProvider(nextRequest));
-        final req = CenterFetchRequest(
-          lat: center.lat,
-          lng: center.lng,
-          radiusKm: kCenterRangeKm,
-        );
-        debugPrint(
-          '[YCMAP] debounce 완료 → provider 재요청 '
-          'CenterFetchRequest(lat=${req.lat}, lng=${req.lng}, radius=${req.radiusKm})',
-        );
-
-        setState(() {
-          _currentRequest = req;
-        });
-
-        final circleCenter = _deviceLocation ?? center;
-        unawaited(_updateSearchCircle(circleCenter));
-        ref.refresh(youthCenterMapProvider(req));
-      },
-    );
+    debugPrint('[YCMAP] onMapMoved → 데이터 요청/반경 갱신 없이 지도만 이동');
   }
 
   void _onWebViewLoadingChanged(bool isLoading) {
@@ -1317,11 +1297,9 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
       position,
       tooltipName: center.name,
     );
-    await _updateSearchCircle(position);
-    ref.refresh(youthCenterMapProvider(request));
-    await _highlightCenterMarker(markerId, position);
     _showMarkerTooltip(center.name);
     _showCenterDetailSheet(
+      markerId: markerId,
       name: center.name,
       address: center.fullAddress,
       phone: center.phone,
@@ -1357,6 +1335,7 @@ Future<void> _highlightCenterMarker(
 }
 
   void _showCenterDetailSheet({
+    required String markerId,
     required String name,
     required String address,
     String? phone,
@@ -1364,6 +1343,12 @@ Future<void> _highlightCenterMarker(
     required String regionLabel,
   }) {
     if (!mounted) return;
+    if (_activeCenterSheetId == markerId) {
+      debugPrint('[KakaoMap] 동일 마커 시트가 이미 열려 있어 무시');
+      return;
+    }
+
+    _activeCenterSheetId = markerId;
 
     showModalBottomSheet(
       context: context,
@@ -1379,7 +1364,12 @@ Future<void> _highlightCenterMarker(
         homepageUrl: homepageUrl,
         regionLabel: regionLabel,
       ),
-    );
+    ).whenComplete(() {
+      if (!mounted) return;
+      setState(() {
+        _activeCenterSheetId = null;
+      });
+    });
   }
 
   void _showMarkerTooltip(String name) {
@@ -1400,22 +1390,36 @@ Future<void> _highlightCenterMarker(
     Map<String, dynamic>? extra,
   ) {
     debugPrint('[KakaoMap] markerClicked event -> $markerId');
-    if (extra == null) {
+    final normalizedId = markerId.replaceFirst('CENTER-', '');
+    final candidate = _cachedCenterPoints.firstWhere(
+      (c) => c.id == normalizedId || 'CENTER-${c.id}' == markerId,
+      orElse: () => const CenterMarkerPoint(
+        id: '',
+        name: '',
+        rawAddress: '',
+        lat: 0,
+        lng: 0,
+        fullAddress: '',
+        phone: null,
+        url: null,
+        regionLabel: '',
+      ),
+    );
+
+    if (candidate.id.isEmpty) {
       debugPrint('[KakaoMap] center marker payload missing, ignoring');
       return;
     }
 
-    final tooltipName = extra['name']?.toString();
-    if (tooltipName != null && tooltipName.isNotEmpty) {
-      _showMarkerTooltip(tooltipName);
-    }
+    _showMarkerTooltip(candidate.name);
 
     _showCenterDetailSheet(
-      name: extra['name']?.toString() ?? '청년센터',
-      address: extra['fullAddress']?.toString() ?? '',
-      phone: extra['phone']?.toString(),
-      homepageUrl: extra['url']?.toString(),
-      regionLabel: extra['regionLabel']?.toString() ?? '',
+      markerId: markerId,
+      name: candidate.name,
+      address: candidate.fullAddress,
+      phone: candidate.phone,
+      homepageUrl: candidate.url,
+      regionLabel: candidate.regionLabel,
     );
   }
 

--- a/lib/features/policy_new/data/dto/center_youthcenter_dto.dart
+++ b/lib/features/policy_new/data/dto/center_youthcenter_dto.dart
@@ -56,6 +56,8 @@ class CenterYouthcenterItemDto with _$CenterYouthcenterItemDto {
     final String? stdgCtpvCdNm,
     final String? stdgSggCd,
     final String? stdgSggCdNm,
+    @JsonKey(name: 'geocoded_lat') final double? geocodedLat,
+    @JsonKey(name: 'geocoded_lng') final double? geocodedLng,
   }) = _CenterYouthcenterItemDto;
 
   factory CenterYouthcenterItemDto.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/policy_new/data/dto/center_youthcenter_dto.freezed.dart
+++ b/lib/features/policy_new/data/dto/center_youthcenter_dto.freezed.dart
@@ -615,6 +615,8 @@ mixin _$CenterYouthcenterItemDto {
   String? get stdgCtpvCdNm => throw _privateConstructorUsedError;
   String? get stdgSggCd => throw _privateConstructorUsedError;
   String? get stdgSggCdNm => throw _privateConstructorUsedError;
+  double? get geocodedLat => throw _privateConstructorUsedError;
+  double? get geocodedLng => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -638,7 +640,9 @@ abstract class $CenterYouthcenterItemDtoCopyWith<$Res> {
       String? stdgCtpvCd,
       String? stdgCtpvCdNm,
       String? stdgSggCd,
-      String? stdgSggCdNm});
+      String? stdgSggCdNm,
+      double? geocodedLat,
+      double? geocodedLng});
 }
 
 /// @nodoc
@@ -665,6 +669,8 @@ class _$CenterYouthcenterItemDtoCopyWithImpl<$Res,
     Object? stdgCtpvCdNm = freezed,
     Object? stdgSggCd = freezed,
     Object? stdgSggCdNm = freezed,
+    Object? geocodedLat = freezed,
+    Object? geocodedLng = freezed,
   }) {
     return _then(_value.copyWith(
       cntrSn: freezed == cntrSn
@@ -707,6 +713,14 @@ class _$CenterYouthcenterItemDtoCopyWithImpl<$Res,
           ? _value.stdgSggCdNm
           : stdgSggCdNm // ignore: cast_nullable_to_non_nullable
               as String?,
+      geocodedLat: freezed == geocodedLat
+          ? _value.geocodedLat
+          : geocodedLat // ignore: cast_nullable_to_non_nullable
+              as double?,
+      geocodedLng: freezed == geocodedLng
+          ? _value.geocodedLng
+          : geocodedLng // ignore: cast_nullable_to_non_nullable
+              as double?,
     ) as $Val);
   }
 }
@@ -730,7 +744,9 @@ abstract class _$$CenterYouthcenterItemDtoImplCopyWith<$Res>
       String? stdgCtpvCd,
       String? stdgCtpvCdNm,
       String? stdgSggCd,
-      String? stdgSggCdNm});
+      String? stdgSggCdNm,
+      double? geocodedLat,
+      double? geocodedLng});
 }
 
 /// @nodoc
@@ -756,6 +772,8 @@ class __$$CenterYouthcenterItemDtoImplCopyWithImpl<$Res>
     Object? stdgCtpvCdNm = freezed,
     Object? stdgSggCd = freezed,
     Object? stdgSggCdNm = freezed,
+    Object? geocodedLat = freezed,
+    Object? geocodedLng = freezed,
   }) {
     return _then(_$CenterYouthcenterItemDtoImpl(
       cntrSn: freezed == cntrSn
@@ -798,6 +816,14 @@ class __$$CenterYouthcenterItemDtoImplCopyWithImpl<$Res>
           ? _value.stdgSggCdNm
           : stdgSggCdNm // ignore: cast_nullable_to_non_nullable
               as String?,
+      geocodedLat: freezed == geocodedLat
+          ? _value.geocodedLat
+          : geocodedLat // ignore: cast_nullable_to_non_nullable
+              as double?,
+      geocodedLng: freezed == geocodedLng
+          ? _value.geocodedLng
+          : geocodedLng // ignore: cast_nullable_to_non_nullable
+              as double?,
     ));
   }
 }
@@ -815,7 +841,9 @@ class _$CenterYouthcenterItemDtoImpl implements _CenterYouthcenterItemDto {
       this.stdgCtpvCd,
       this.stdgCtpvCdNm,
       this.stdgSggCd,
-      this.stdgSggCdNm});
+      this.stdgSggCdNm,
+      this.geocodedLat,
+      this.geocodedLng});
 
   factory _$CenterYouthcenterItemDtoImpl.fromJson(Map<String, dynamic> json) =>
       _$$CenterYouthcenterItemDtoImplFromJson(json);
@@ -840,10 +868,14 @@ class _$CenterYouthcenterItemDtoImpl implements _CenterYouthcenterItemDto {
   final String? stdgSggCd;
   @override
   final String? stdgSggCdNm;
+  @override
+  final double? geocodedLat;
+  @override
+  final double? geocodedLng;
 
   @override
   String toString() {
-    return 'CenterYouthcenterItemDto(cntrSn: $cntrSn, cntrNm: $cntrNm, cntrAddr: $cntrAddr, cntrDaddr: $cntrDaddr, cntrTelno: $cntrTelno, cntrUrlAddr: $cntrUrlAddr, stdgCtpvCd: $stdgCtpvCd, stdgCtpvCdNm: $stdgCtpvCdNm, stdgSggCd: $stdgSggCd, stdgSggCdNm: $stdgSggCdNm)';
+    return 'CenterYouthcenterItemDto(cntrSn: $cntrSn, cntrNm: $cntrNm, cntrAddr: $cntrAddr, cntrDaddr: $cntrDaddr, cntrTelno: $cntrTelno, cntrUrlAddr: $cntrUrlAddr, stdgCtpvCd: $stdgCtpvCd, stdgCtpvCdNm: $stdgCtpvCdNm, stdgSggCd: $stdgSggCd, stdgSggCdNm: $stdgSggCdNm, geocodedLat: $geocodedLat, geocodedLng: $geocodedLng)';
   }
 
   @override
@@ -868,7 +900,11 @@ class _$CenterYouthcenterItemDtoImpl implements _CenterYouthcenterItemDto {
             (identical(other.stdgSggCd, stdgSggCd) ||
                 other.stdgSggCd == stdgSggCd) &&
             (identical(other.stdgSggCdNm, stdgSggCdNm) ||
-                other.stdgSggCdNm == stdgSggCdNm));
+                other.stdgSggCdNm == stdgSggCdNm) &&
+            (identical(other.geocodedLat, geocodedLat) ||
+                other.geocodedLat == geocodedLat) &&
+            (identical(other.geocodedLng, geocodedLng) ||
+                other.geocodedLng == geocodedLng));
   }
 
   @JsonKey(ignore: true)
@@ -884,7 +920,9 @@ class _$CenterYouthcenterItemDtoImpl implements _CenterYouthcenterItemDto {
       stdgCtpvCd,
       stdgCtpvCdNm,
       stdgSggCd,
-      stdgSggCdNm);
+      stdgSggCdNm,
+      geocodedLat,
+      geocodedLng);
 
   @JsonKey(ignore: true)
   @override
@@ -912,7 +950,9 @@ abstract class _CenterYouthcenterItemDto implements CenterYouthcenterItemDto {
       final String? stdgCtpvCd,
       final String? stdgCtpvCdNm,
       final String? stdgSggCd,
-      final String? stdgSggCdNm}) = _$CenterYouthcenterItemDtoImpl;
+      final String? stdgSggCdNm,
+      final double? geocodedLat,
+      final double? geocodedLng}) = _$CenterYouthcenterItemDtoImpl;
 
   factory _CenterYouthcenterItemDto.fromJson(Map<String, dynamic> json) =
       _$CenterYouthcenterItemDtoImpl.fromJson;
@@ -937,6 +977,10 @@ abstract class _CenterYouthcenterItemDto implements CenterYouthcenterItemDto {
   String? get stdgSggCd;
   @override
   String? get stdgSggCdNm;
+  @override
+  double? get geocodedLat;
+  @override
+  double? get geocodedLng;
   @override
   @JsonKey(ignore: true)
   _$$CenterYouthcenterItemDtoImplCopyWith<_$CenterYouthcenterItemDtoImpl>

--- a/lib/features/policy_new/data/dto/center_youthcenter_dto.g.dart
+++ b/lib/features/policy_new/data/dto/center_youthcenter_dto.g.dart
@@ -74,6 +74,12 @@ _$CenterYouthcenterItemDtoImpl _$$CenterYouthcenterItemDtoImplFromJson(
       stdgCtpvCdNm: json['stdgCtpvCdNm'] as String?,
       stdgSggCd: json['stdgSggCd'] as String?,
       stdgSggCdNm: json['stdgSggCdNm'] as String?,
+      geocodedLat: json['geocoded_lat'] is String
+          ? double.tryParse(json['geocoded_lat'] as String)
+          : (json['geocoded_lat'] as num?)?.toDouble(),
+      geocodedLng: json['geocoded_lng'] is String
+          ? double.tryParse(json['geocoded_lng'] as String)
+          : (json['geocoded_lng'] as num?)?.toDouble(),
     );
 
 Map<String, dynamic> _$$CenterYouthcenterItemDtoImplToJson(
@@ -89,4 +95,6 @@ Map<String, dynamic> _$$CenterYouthcenterItemDtoImplToJson(
       'stdgCtpvCdNm': instance.stdgCtpvCdNm,
       'stdgSggCd': instance.stdgSggCd,
       'stdgSggCdNm': instance.stdgSggCdNm,
+      'geocoded_lat': instance.geocodedLat,
+      'geocoded_lng': instance.geocodedLng,
     };

--- a/lib/features/policy_new/data/mappers/youth_center_mapper.dart
+++ b/lib/features/policy_new/data/mappers/youth_center_mapper.dart
@@ -4,14 +4,17 @@ import '../dto/center_youthcenter_dto.dart';
 
 extension YouthCenterDtoMapper on CenterYouthcenterItemDto {
   YouthCenterEntity toDomain() {
+    final lat = geocodedLat;
+    final lng = geocodedLng;
+
     return YouthCenterEntity(
       centerName:
           cntrNm?.trim().isNotEmpty == true ? cntrNm!.trim() : 'Unknown Center',
       address: cntrAddr?.trim().isNotEmpty == true
           ? cntrAddr!.trim()
           : 'Unknown Address',
-      lat: null,
-      lng: null,
+      lat: lat,
+      lng: lng,
       detailAddress: cntrDaddr?.trim(),
       sidoName: stdgCtpvCdNm?.trim(),
       sigunguName: stdgSggCdNm?.trim(),

--- a/lib/features/policy_new/presentation/map/youth_center_map_provider.dart
+++ b/lib/features/policy_new/presentation/map/youth_center_map_provider.dart
@@ -10,10 +10,9 @@ import '../../../../application/di.dart' as app_di;
 import '../../../../env/app_env.dart';
 import '../../application/youthcenter_providers.dart';
 import '../../data/mappers/youth_center_mapper.dart';
-import '../../data/remote/youth_center_geocode_remote.dart';
 import '../../domain/youthcenter/youth_center_entity.dart';
 
-const double kCenterRangeKm = 40.0;
+const double kCenterRangeKm = 20.0;
 
 class CenterFetchRequest {
   const CenterFetchRequest({
@@ -39,11 +38,6 @@ class CenterFetchRequest {
   int get hashCode => Object.hash(lat, lng, radiusKm);
 }
 
-final youthCenterGeocodeRemoteProvider =
-    Provider<YouthCenterGeocodeRemote>((ref) {
-  return YouthCenterGeocodeRemote();
-});
-
 // ─────────────────────────────────────────────────────────────────────────────
 // Youth Center Map Provider
 // ─────────────────────────────────────────────────────────────────────────────
@@ -55,12 +49,10 @@ final youthCenterMapProvider = FutureProvider.autoDispose
   debugPrint('[YCMAP] radius=${request.radiusKm}km');
 
   final repo = ref.read(youthCenterRepositoryProvider);
-  final geocoder = ref.read(youthCenterGeocodeRemoteProvider);
   final prefs = ref.read(app_di.sharedPreferencesProvider);
 
   // 앱 시작할 때 API 키가 잘 들어왔는지 체크
-  debugPrint('[YCMAP] Kakao REST API KEY = ${geocoder.runtimeType} '
-      '| env key: ${AppEnv.kakaoRestApiKey}');
+  debugPrint('[YCMAP] Kakao REST API KEY length=${AppEnv.kakaoRestApiKey.length}');
 
   // ───────────────────────────────────────
   // 캐시 로드
@@ -105,7 +97,6 @@ final youthCenterMapProvider = FutureProvider.autoDispose
   debugPrint('[YCMAP] API success, item count=${items.length}');
 
   final result = <CenterMarkerPoint>[];
-  final candidates = <({CenterMarkerPoint point, double distance})>[];
 
   for (final center in items) {
     final addr = center.address.trim();
@@ -122,41 +113,8 @@ final youthCenterMapProvider = FutureProvider.autoDispose
     debugPrint('[YCMAP] FullAddress = "$fullAddress"');
 
     final cacheKey = '${center.centerName}|$fullAddress';
-    double? lat;
-    double? lng;
-
-    // ─────────────────────────────
-    // 캐시 Hit
-    // ─────────────────────────────
-    if (cache.containsKey(cacheKey)) {
-      final entry = cache[cacheKey];
-      lat = entry?['lat']?.toDouble();
-      lng = entry?['lng']?.toDouble();
-      debugPrint('[YCMAP] Cache HIT -> ($lat, $lng)');
-    } else {
-      debugPrint('[YCMAP] Cache MISS → Geocode required');
-    }
-
-    // ─────────────────────────────
-    // Geocode 호출
-    // ─────────────────────────────
-    if (lat == null || lng == null) {
-      debugPrint('[YCMAP][Geocode] Calling geocode for "$fullAddress"...');
-
-      final pos = await geocoder.geocodeAddress(fullAddress);
-
-      if (pos == null) {
-        debugPrint('[YCMAP][Geocode] ❌ FAIL geocoding "$fullAddress"');
-        continue;
-      }
-
-      lat = pos.lat;
-      lng = pos.lng;
-
-      debugPrint('[YCMAP][Geocode] ✔ OK → ($lat, $lng)');
-
-      cache[cacheKey] = {'lat': lat, 'lng': lng};
-    }
+    final lat = center.lat;
+    final lng = center.lng;
 
     // 좌표 없으면 skip
     if (lat == null || lng == null) {
@@ -164,39 +122,28 @@ final youthCenterMapProvider = FutureProvider.autoDispose
       continue;
     }
 
+    if (lat == 0 || lng == 0) {
+      debugPrint('[YCMAP] ❌ Skip: 좌표가 0,0 입니다');
+      continue;
+    }
+
     // 거리 계산
     final dist = _distanceKm(request.lat, request.lng, lat, lng);
     debugPrint('[YCMAP] Distance = ${dist.toStringAsFixed(2)}km');
 
-    final markerPoint = center.toMarkerPoint(lat: lat, lng: lng);
-
-    candidates.add((point: markerPoint, distance: dist));
-
-    if (dist <= request.radiusKm) {
-      result.add(markerPoint);
-      debugPrint('[YCMAP] ✔ Added to result');
-    } else {
+    if (dist > request.radiusKm) {
       debugPrint('[YCMAP] Skip: too far');
+      continue;
     }
-  }
 
-  if (result.isEmpty && candidates.isNotEmpty) {
-    debugPrint('[YCMAP] 🔍 반경 내 결과 없음 → 가장 가까운 센터 3곳 노출');
-
-    candidates.sort((a, b) => a.distance.compareTo(b.distance));
-    final fallbackCenters = candidates.take(3).map((c) => c.point).toList();
-
-    debugPrint('[YCMAP] fallback count=${fallbackCenters.length}');
-    return fallbackCenters;
-  }
-
-  if (result.isEmpty && cachedMarkers.isNotEmpty) {
-    debugPrint('[YCMAP] 새 결과 없음 → 캐시된 마커 사용 (${cachedMarkers.length}개)');
-    return cachedMarkers;
+    final markerPoint = center.toMarkerPoint(lat: lat, lng: lng);
+    result.add(markerPoint);
+    cache[cacheKey] = {'lat': lat, 'lng': lng};
+    debugPrint('[YCMAP] ✔ Added to result (within radius)');
   }
 
   // ─────────────────────────────────────────────
-  // 캐시 저장
+  // 캐시 저장 (마커 + 지오코드)
   // ─────────────────────────────────────────────
   try {
     await prefs.setString('yc_center_geocode_cache_v1', jsonEncode(cache));


### PR DESCRIPTION
## Summary
- embed center marker list in the Kakao map HTML and send only center IDs on click
- look up center details locally in Flutter to show sheets without JS payloads
- filter youth centers strictly by geocoded coordinates within the 20km radius

## Testing
- not run (flutter/dart toolchain unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693668423f808324884f3154b903ebc7)