### PR TITLE
센터 마커 클릭 동작 정리

### DIFF
--- a/lib/features/map_v2/kakao_map_html_builder.dart
+++ b/lib/features/map_v2/kakao_map_html_builder.dart
@@ -500,17 +500,11 @@ class KakaoMapHtmlBuilder {
 
         kakao.maps.event.addListener(mk, 'click', function() {
           var isCenter = (m.id && m.id.indexOf('CENTER-') === 0);
-          var centerPayload = {
-            id: m.id,
-            lat: m.lat,
-            lng: m.lng,
-            label: m.title || ''
-          };
 
           _post({
             type: isCenter ? 'centerMarkerClick' : 'marker',
             payload: isCenter
-              ? centerPayload.id
+              ? m.id
               : {
                   id: m.id,
                   lat: m.lat,
@@ -540,11 +534,6 @@ class KakaoMapHtmlBuilder {
             }, 2000);
           }
 
-          if (m.id && m.id.indexOf('CENTER-') === 0 &&
-              window.flutter_inappwebview &&
-              window.flutter_inappwebview.callHandler) {
-            window.flutter_inappwebview.callHandler('onMarkerClicked', centerPayload);
-          }
         });
 
         kakao.maps.event.addListener(mk, 'mouseover', function() {

--- a/lib/features/map_v2/kakao_map_screen.dart
+++ b/lib/features/map_v2/kakao_map_screen.dart
@@ -527,6 +527,25 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
       lng: regionCenter.lng,
       radiusKm: kCenterRangeKm,
     );
+
+    // 마지막으로 확인된 GPS 좌표가 있다면 초기 반경 계산과 지도 중심도 동일 좌표로 맞춰준다.
+    _bootstrapLastKnownLocation();
+  }
+
+  Future<void> _bootstrapLastKnownLocation() async {
+    final cached = await _loadLastKnownPosition();
+    if (!mounted || cached == null) return;
+
+    setState(() {
+      _deviceLocation ??= cached;
+      _latestCenter = cached;
+      _latestZoom = _locationZoomLevel;
+      _currentRequest = CenterFetchRequest(
+        lat: cached.lat,
+        lng: cached.lng,
+        radiusKm: kCenterRangeKm,
+      );
+    });
   }
 
   List<KakaoMapMarker> _policyMarkers(
@@ -562,6 +581,9 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         extra: {
           'id': center.id,
           'name': center.name,
+          'lat': center.lat,
+          'lng': center.lng,
+          'rawAddress': center.rawAddress,
           'fullAddress': center.fullAddress,
           'phone': center.phone,
           'url': center.url,
@@ -1387,26 +1409,19 @@ Future<void> _highlightCenterMarker(
 
   void _handleCenterMarkerClicked(
     String markerId,
-    Map<String, dynamic>? extra,
+    Map<String, dynamic>? _,
   ) {
     debugPrint('[KakaoMap] markerClicked event -> $markerId');
     final normalizedId = markerId.replaceFirst('CENTER-', '');
-    final candidate = _cachedCenterPoints.firstWhere(
-      (c) => c.id == normalizedId || 'CENTER-${c.id}' == markerId,
-      orElse: () => const CenterMarkerPoint(
-        id: '',
-        name: '',
-        rawAddress: '',
-        lat: 0,
-        lng: 0,
-        fullAddress: '',
-        phone: null,
-        url: null,
-        regionLabel: '',
-      ),
-    );
+    CenterMarkerPoint? candidate;
+    for (final center in _cachedCenterPoints) {
+      if (center.id == normalizedId || 'CENTER-${center.id}' == markerId) {
+        candidate = center;
+        break;
+      }
+    }
 
-    if (candidate.id.isEmpty) {
+    if (candidate == null) {
       debugPrint('[KakaoMap] center marker payload missing, ignoring');
       return;
     }

--- a/lib/features/policy_new/data/mappers/youth_center_mapper.dart
+++ b/lib/features/policy_new/data/mappers/youth_center_mapper.dart
@@ -4,8 +4,8 @@ import '../dto/center_youthcenter_dto.dart';
 
 extension YouthCenterDtoMapper on CenterYouthcenterItemDto {
   YouthCenterEntity toDomain() {
-    final lat = geocodedLat;
-    final lng = geocodedLng;
+    final lat = (geocodedLat == null || geocodedLat == 0) ? null : geocodedLat;
+    final lng = (geocodedLng == null || geocodedLng == 0) ? null : geocodedLng;
 
     return YouthCenterEntity(
       centerName:

--- a/lib/features/policy_new/presentation/map/youth_center_map_provider.dart
+++ b/lib/features/policy_new/presentation/map/youth_center_map_provider.dart
@@ -122,7 +122,7 @@ final youthCenterMapProvider = FutureProvider.autoDispose
       continue;
     }
 
-    if (lat == 0 || lng == 0) {
+    if (lat == 0 || lng == 0 || lat.isNaN || lng.isNaN) {
       debugPrint('[YCMAP] ❌ Skip: 좌표가 0,0 입니다');
       continue;
     }


### PR DESCRIPTION
## Summary
- 카카오맵 JS에서 센터 마커 클릭 메시지를 ID 단일 payload로 전송하도록 정리해 WebView 이벤트 흐름을 일관화했습니다.
- WebView에서 받은 센터 마커 클릭을 캐시된 센터 데이터로 처리해 중복 이벤트와 누락된 상세 카드 노출을 방지했습니다.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693672c3bf608324b4c20c7269639adb)