### PR TITLE
카카오맵 센터 로딩 상태 개선

### DIFF
--- a/lib/features/map_v2/kakao_map_screen.dart
+++ b/lib/features/map_v2/kakao_map_screen.dart
@@ -147,6 +147,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
             _buildLocatingOverlay(),
           if (_activeTooltipName != null)
             CenterMarkerTooltip(name: _activeTooltipName!),
+          _buildCenterStatusOverlay(centerState),
           Positioned(
             left: 16,
             top: 16 + MediaQuery.of(context).padding.top,
@@ -158,6 +159,8 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
               centers: centerState.filteredCenters,
               radiusKm: _currentRadius,
               onCenterTap: _onCenterCardTap,
+              status: centerState.status,
+              errorMessage: centerState.errorMessage,
             ),
           ),
         ],
@@ -219,6 +222,60 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
             ],
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildCenterStatusOverlay(YouthCenterMapState centerState) {
+    final status = centerState.status;
+    final shouldShow = status == YouthCenterMapStatus.loading ||
+        status == YouthCenterMapStatus.empty ||
+        status == YouthCenterMapStatus.error;
+
+    String? message;
+    switch (status) {
+      case YouthCenterMapStatus.loading:
+        message = '주변 센터 정보를 불러오는 중입니다.';
+        break;
+      case YouthCenterMapStatus.empty:
+        message = '반경 20km 내 센터가 없습니다.';
+        break;
+      case YouthCenterMapStatus.error:
+        message = centerState.errorMessage ?? '센터 정보를 불러오지 못했습니다.';
+        break;
+      case YouthCenterMapStatus.loaded:
+      case YouthCenterMapStatus.initial:
+        message = null;
+    }
+
+    return IgnorePointer(
+      ignoring: true,
+      child: AnimatedOpacity(
+        opacity: shouldShow ? 1 : 0,
+        duration: const Duration(milliseconds: 200),
+        child: message == null
+            ? const SizedBox.shrink()
+            : SafeArea(
+                minimum: const EdgeInsets.only(bottom: 8),
+                child: Align(
+                  alignment: Alignment.bottomCenter,
+                  child: Container(
+                    margin: const EdgeInsets.all(16),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 12,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Colors.black.withOpacity(0.75),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Text(
+                      message,
+                      style: const TextStyle(color: Colors.white),
+                    ),
+                  ),
+                ),
+              ),
       ),
     );
   }

--- a/lib/features/map_v2/widgets/center_list_bottom_sheet.dart
+++ b/lib/features/map_v2/widgets/center_list_bottom_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../policy_new/data/mappers/youth_center_mapper.dart';
+import '../../policy_new/presentation/map/youth_center_map_provider.dart';
 import 'center_card_item.dart';
 
 class CenterListBottomSheet extends StatelessWidget {
@@ -9,11 +10,15 @@ class CenterListBottomSheet extends StatelessWidget {
     required this.centers,
     required this.radiusKm,
     required this.onCenterTap,
+    required this.status,
+    this.errorMessage,
   });
 
   final List<CenterMarkerPoint> centers;
   final double radiusKm;
   final void Function(CenterMarkerPoint center, int index) onCenterTap;
+  final YouthCenterMapStatus status;
+  final String? errorMessage;
 
   @override
   Widget build(BuildContext context) {
@@ -51,23 +56,7 @@ class CenterListBottomSheet extends StatelessWidget {
                 ),
                 const SizedBox(height: 8),
                 Expanded(
-                  child: centers.isEmpty
-                      ? const Center(
-                          child: Text('주변 센터 정보를 불러오는 중입니다.'),
-                        )
-                      : ListView.separated(
-                          scrollDirection: Axis.horizontal,
-                          padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
-                          itemCount: centers.length,
-                          separatorBuilder: (_, __) => const SizedBox(width: 12),
-                          itemBuilder: (_, index) {
-                            final center = centers[index];
-                            return CenterCardItem(
-                              center: center,
-                              onTap: () => onCenterTap(center, index),
-                            );
-                          },
-                        ),
+                  child: _buildContent(),
                 ),
               ],
             ),
@@ -75,6 +64,41 @@ class CenterListBottomSheet extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Widget _buildContent() {
+    switch (status) {
+      case YouthCenterMapStatus.loading:
+        return const Center(
+          child: Text('주변 센터 정보를 불러오는 중입니다.'),
+        );
+      case YouthCenterMapStatus.empty:
+        return const Center(
+          child: Text('반경 20km 내 센터가 없습니다.'),
+        );
+      case YouthCenterMapStatus.error:
+        return Center(
+          child: Text(errorMessage ?? '센터 정보를 불러오지 못했습니다.'),
+        );
+      case YouthCenterMapStatus.initial:
+        return const Center(
+          child: Text('주변 센터 정보를 불러오는 중입니다.'),
+        );
+      case YouthCenterMapStatus.loaded:
+        return ListView.separated(
+          scrollDirection: Axis.horizontal,
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+          itemCount: centers.length,
+          separatorBuilder: (_, __) => const SizedBox(width: 12),
+          itemBuilder: (_, index) {
+            final center = centers[index];
+            return CenterCardItem(
+              center: center,
+              onTap: () => onCenterTap(center, index),
+            );
+          },
+        );
+    }
   }
 
   Widget _buildRadiusPill(BuildContext context, double radiusKm, Color color) {

--- a/lib/features/policy_new/presentation/map/youth_center_map_provider.dart
+++ b/lib/features/policy_new/presentation/map/youth_center_map_provider.dart
@@ -16,6 +16,8 @@ import '../../domain/youthcenter/youth_center_entity.dart';
 
 const double kCenterRangeKm = 20.0;
 
+enum YouthCenterMapStatus { initial, loading, loaded, empty, error }
+
 class YouthCenterMapState {
   const YouthCenterMapState({
     required this.allCenters,
@@ -24,6 +26,7 @@ class YouthCenterMapState {
     this.center,
     this.isLoading = false,
     this.errorMessage,
+    this.status = YouthCenterMapStatus.initial,
   });
 
   final List<CenterMarkerPoint> allCenters;
@@ -32,6 +35,7 @@ class YouthCenterMapState {
   final double radiusKm;
   final bool isLoading;
   final String? errorMessage;
+  final YouthCenterMapStatus status;
 
   YouthCenterMapState copyWith({
     List<CenterMarkerPoint>? allCenters,
@@ -40,6 +44,7 @@ class YouthCenterMapState {
     double? radiusKm,
     bool? isLoading,
     String? errorMessage,
+    YouthCenterMapStatus? status,
   }) {
     return YouthCenterMapState(
       allCenters: allCenters ?? this.allCenters,
@@ -48,6 +53,7 @@ class YouthCenterMapState {
       radiusKm: radiusKm ?? this.radiusKm,
       isLoading: isLoading ?? this.isLoading,
       errorMessage: errorMessage ?? this.errorMessage,
+      status: status ?? this.status,
     );
   }
 
@@ -57,6 +63,7 @@ class YouthCenterMapState {
         radiusKm: kCenterRangeKm,
         center: null,
         isLoading: false,
+        status: YouthCenterMapStatus.initial,
       );
 }
 
@@ -79,11 +86,15 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
       center: center,
       radiusKm: radiusKm,
       errorMessage: null,
+      status: YouthCenterMapStatus.loading,
     );
 
     try {
       final markers = await _fetchAllCenterMarkers(center);
       final filtered = filterCentersWithinRadius(markers, center, radiusKm);
+      final status = filtered.isEmpty
+          ? YouthCenterMapStatus.empty
+          : YouthCenterMapStatus.loaded;
       state = state.copyWith(
         allCenters: markers,
         filteredCenters: filtered,
@@ -91,6 +102,7 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
         center: center,
         radiusKm: radiusKm,
         errorMessage: null,
+        status: status,
       );
     } catch (error, stack) {
       debugPrint('[YCMAP] loadCenters failed: $error');
@@ -100,6 +112,7 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
       state = state.copyWith(
         isLoading: false,
         errorMessage: '$error',
+        status: YouthCenterMapStatus.error,
       );
     }
   }
@@ -113,6 +126,9 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
       radiusKm: effectiveRadius,
       filteredCenters: filtered,
       errorMessage: null,
+      status: filtered.isEmpty
+          ? YouthCenterMapStatus.empty
+          : YouthCenterMapStatus.loaded,
     );
   }
 
@@ -266,14 +282,7 @@ List<CenterMarkerPoint> filterCentersWithinRadius(
       .map((e) => e.point)
       .toList();
 
-  if (withinRadius.isNotEmpty) {
-    return withinRadius;
-  }
-
-  final ordered = [...centersWithDistance]
-    ..sort((a, b) => a.distanceKm.compareTo(b.distanceKm));
-  final fallbackCandidates = ordered.take(3).map((e) => e.point).toList();
-  return fallbackCandidates;
+  return withinRadius;
 }
 
 class _CenterDistance {


### PR DESCRIPTION
## Summary
- 센터 지도 로딩 상태를 명확히 표시하도록 YouthCenterMap 상태에 로딩/빈/에러 구분을 추가했습니다.
- 카카오맵 화면에 터치 차단 없는 하단 로딩/상태 안내 오버레이를 배치했습니다.
- 센터 리스트 바텀시트가 상태별 안내 문구와 빈 결과를 처리하도록 수정했습니다.
- 상태 오버레이가 로딩/빈/에러 간 전환 시에도 애니메이션으로 자연스럽게 사라지도록 조정했습니다.
- 상태 오버레이에 SafeArea를 적용해 하단 제스처 영역을 침범하지 않도록 조정했습니다.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938ef00a8508324a2455b005a34d21a)