### PR TITLE
정책 상세 CTA/알림 하단 고정 및 오버플로우 방지

### DIFF
--- a/lib/features/policy_new/presentation/detail/policy_detail_bottom_sheet.dart
+++ b/lib/features/policy_new/presentation/detail/policy_detail_bottom_sheet.dart
@@ -151,7 +151,7 @@ class _PolicyDetailBottomSheetState
           clipBehavior: Clip.antiAlias,
           child: SafeArea(
             top: true,
-            bottom: true,
+            bottom: false,
             child: asyncPolicy.when(
               data: (policy) => _Content(
                 policy: policy,
@@ -217,9 +217,7 @@ class _Content extends StatelessWidget {
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),
-                const SizedBox(height: AppSpacing.md),
-                PolicyActionBar(policy: policy),
-                const SizedBox(height: AppSpacing.lg),
+                const SizedBox(height: AppSpacing.xl),
                 const AppDivider(),
                 const SizedBox(height: AppSpacing.lg),
                 _InfoSection(
@@ -258,41 +256,63 @@ class _Content extends StatelessWidget {
             ),
           ),
         ),
-        const AppDivider(),
-        Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSpacing.lg,
-            vertical: AppSpacing.md,
-          ),
-          child: hasSchedule
-              ? Row(
-                  children: [
-                    Expanded(
-                      child: PolicyReminderButton(policy: policy),
-                    ),
-                  ],
-                )
-              : Column(
+        SafeArea(
+          top: false,
+          bottom: true,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const AppDivider(),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(
+                  AppSpacing.lg,
+                  AppSpacing.md,
+                  AppSpacing.lg,
+                  AppSpacing.lg,
+                ),
+                child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
+                  mainAxisSize: MainAxisSize.min,
                   children: [
-                    ElevatedButton(
-                      onPressed: null,
-                      style: ElevatedButton.styleFrom(
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
+                    PolicyActionBar(policy: policy),
+                    const SizedBox(height: AppSpacing.md),
+                    if (hasSchedule)
+                      Row(
+                        children: [
+                          Expanded(
+                            child: PolicyReminderButton(policy: policy),
+                          ),
+                        ],
+                      )
+                    else
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          ElevatedButton(
+                            onPressed: null,
+                            style: ElevatedButton.styleFrom(
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                            ),
+                            child: const Text('알림 설정'),
+                          ),
+                          const SizedBox(height: AppSpacing.sm),
+                          Text(
+                            '일정 업데이트 되면 알려드릴게요',
+                            style: AppText.textTheme.bodyMedium!.copyWith(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onSurfaceVariant,
+                            ),
+                          ),
+                        ],
                       ),
-                      child: const Text('알림 설정'),
-                    ),
-                    const SizedBox(height: AppSpacing.sm),
-                    Text(
-                      '일정 업데이트 되면 알려드릴게요',
-                      style: AppText.textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      ),
-                    ),
                   ],
                 ),
+              ),
+            ],
+          ),
         ),
       ],
     );

--- a/lib/features/policy_new/presentation/detail/widgets/policy_action_bar.dart
+++ b/lib/features/policy_new/presentation/detail/widgets/policy_action_bar.dart
@@ -147,8 +147,8 @@ class PolicyActionButton extends StatelessWidget {
     final background = resolveBackground();
     final foreground = resolveForeground();
 
-    return SizedBox(
-      height: 56,
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minHeight: 56),
       child: Material(
         color: background,
         shape: RoundedRectangleBorder(


### PR DESCRIPTION
## Summary
- 정책 상세 바텀시트의 본문 스크롤 영역과 하단 CTA/알림 영역을 분리해 작은 화면에서도 안전하게 스크롤되도록 조정했습니다.
- SafeArea로 감싼 하단 섹션에 PolicyActionBar와 알림 버튼을 재배치하여 버튼이 항상 화면 하단에 고정되도록 했습니다.
- CTA 버튼에 최소 높이 제약을 적용해 글자 크기 확대 시에도 레이아웃이 깨지지 않도록 보완했습니다.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938f424c7b883249ce3cb780e02e66a)