### PR TITLE
탐색 필터 정합성 개선

### DIFF
--- a/lib/features/policy_new/application/controllers/global_filter_controller.dart
+++ b/lib/features/policy_new/application/controllers/global_filter_controller.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../filters/policy_filter_ui_state.dart';
 import '../filters/policy_search_keyword_provider.dart';
 import '../../domain/values/policy_feed_type.dart';
+import '../../../application/notifiers/region_notifier.dart';
 
 class GlobalFilterController {
   GlobalFilterController(this.ref);
@@ -12,6 +13,7 @@ class GlobalFilterController {
   PolicyFilterUiState get state => ref.read(globalFilterProvider);
 
   void resetAll() {
+    ref.read(regionProvider.notifier).resetCity();
     ref.read(globalFilterProvider.notifier).resetAll();
     for (final type in PolicyFeedType.values) {
       ref.read(policySearchKeywordProvider(type).notifier).clear();

--- a/lib/features/policy_new/application/controllers/policy_query_orchestrator.dart
+++ b/lib/features/policy_new/application/controllers/policy_query_orchestrator.dart
@@ -10,6 +10,7 @@ import '../filters/policy_filter_ui_state.dart';
 import '../providers.dart';
 import '../behavior/policy_behavior_tracker.dart';
 import '../../domain/recommendation/user_profile.dart';
+import '../../../../application/notifiers/region_notifier.dart';
 
 class PolicyQueryOrchestrator {
   PolicyQueryOrchestrator(this.ref);
@@ -65,15 +66,10 @@ class PolicyQueryOrchestrator {
 
     return PolicyQuery(
       feedType: PolicyFeedType.recommend,
-      filter: PolicyFilter(
+      filter: _buildFilterFromUi(
         region: _ui.region == PolicyRegion.all ? _profile.region : _ui.region,
-        category: _ui.category,
-        age: _profile.age,
-        isOnline: _ui.showOnlyOnline ? true : null,
-        institutionId: _ui.institutionId,
-        departmentId: _ui.departmentId,
         tags: baseTags,
-        status: _ui.status,
+        age: _profile.age,
       ),
       tags: combinedTags,
       sort: PolicySortOption.recommendation,
@@ -81,18 +77,7 @@ class PolicyQueryOrchestrator {
   }
 
   PolicyQuery _buildAllQuery(String keyword) {
-    final filter = PolicyFilter(
-      region: _ui.region,
-      province: _ui.province,
-      city: _ui.city,
-      district: _ui.district,
-      category: _ui.category,
-      isOnline: _ui.showOnlyOnline ? true : null,
-      institutionId: _ui.institutionId,
-      departmentId: _ui.departmentId,
-      tags: _ui.tags,
-      status: _ui.status,
-    );
+    final filter = _buildFilterFromUi();
 
     return PolicyQuery(
       feedType: PolicyFeedType.all,
@@ -103,20 +88,8 @@ class PolicyQueryOrchestrator {
   }
 
   PolicyQuery _buildRegionQuery() {
-    final region =
-        _ui.region == PolicyRegion.all ? _profile.region : _ui.region;
-
-    final filter = PolicyFilter(
-      region: region,
-      province: _ui.province,
-      city: _ui.city,
-      district: _ui.district,
-      category: _ui.category,
-      isOnline: _ui.showOnlyOnline ? true : null,
-      institutionId: _ui.institutionId,
-      departmentId: _ui.departmentId,
-      status: _ui.status,
-    );
+    final region = _ui.region == PolicyRegion.all ? _profile.region : _ui.region;
+    final filter = _buildFilterFromUi(region: region);
 
     return PolicyQuery(
       feedType: PolicyFeedType.region,
@@ -126,17 +99,7 @@ class PolicyQueryOrchestrator {
   }
 
   PolicyQuery _buildSearchQuery(String keyword) {
-    final filter = PolicyFilter(
-      region: _ui.region,
-      province: _ui.province,
-      city: _ui.city,
-      district: _ui.district,
-      category: _ui.category,
-      isOnline: _ui.showOnlyOnline ? true : null,
-      institutionId: _ui.institutionId,
-      departmentId: _ui.departmentId,
-      status: _ui.status,
-    );
+    final filter = _buildFilterFromUi();
 
     return PolicyQuery(
       feedType: PolicyFeedType.search,
@@ -172,5 +135,60 @@ class PolicyQueryOrchestrator {
       tags: _compareIds,
       sort: _ui.sort,
     ).normalize(clearRecommendKeyword: false);
+  }
+
+  PolicyFilter _buildFilterFromUi({
+    PolicyRegion? region,
+    List<String>? tags,
+    int? age,
+  }) {
+    final resolvedRegion = region ?? _ui.region;
+    final regionNotifier = ref.read(regionProvider.notifier);
+
+    final resolvedProvince = resolvedRegion == PolicyRegion.gyeongbuk
+        ? regionNotifier.selectedProvince
+        : _provinceName(resolvedRegion, fallback: _ui.province);
+    final resolvedCity =
+        resolvedRegion == PolicyRegion.gyeongbuk ? regionNotifier.selectedCity : null;
+    final resolvedDistrict = resolvedRegion == PolicyRegion.gyeongbuk
+        ? regionNotifier.selectedDistrict
+        : null;
+
+    return PolicyFilter(
+      region: resolvedRegion,
+      province: resolvedProvince,
+      city: resolvedCity,
+      district: resolvedDistrict,
+      category: _ui.category,
+      isOnline: _ui.showOnlyOnline ? true : null,
+      institutionId: _ui.institutionId,
+      departmentId: _ui.departmentId,
+      tags: tags ?? _ui.tags,
+      status: _ui.status,
+      age: age,
+    );
+  }
+
+  String _provinceName(PolicyRegion region, {required String fallback}) {
+    switch (region) {
+      case PolicyRegion.all:
+        return '전국';
+      case PolicyRegion.seoul:
+        return '서울';
+      case PolicyRegion.busan:
+        return '부산';
+      case PolicyRegion.daegu:
+        return '대구';
+      case PolicyRegion.incheon:
+        return '인천';
+      case PolicyRegion.gwangju:
+        return '광주';
+      case PolicyRegion.daejeon:
+        return '대전';
+      case PolicyRegion.ulsan:
+        return '울산';
+      case PolicyRegion.gyeongbuk:
+        return fallback.isEmpty ? '경상북도' : fallback;
+    }
   }
 }

--- a/lib/features/policy_new/application/explore/explore_providers.dart
+++ b/lib/features/policy_new/application/explore/explore_providers.dart
@@ -97,8 +97,8 @@ class ExploreController extends StateNotifier<ExploreState> {
 
   void clearFilters() {
     debugPrint('[Explore] clearFilters');
-    final hasRegionSelection = ref.read(regionProvider)?.isNotEmpty ?? false;
     ref.read(globalFilterControllerProvider).resetAll();
+    final hasRegionSelection = ref.read(regionProvider)?.isNotEmpty ?? false;
     state = state.copyWith(
       mode: hasRegionSelection ? ExploreSubMode.region : ExploreSubMode.all,
       keyword: '',

--- a/lib/features/policy_new/data/repositories/policy_repository_impl.dart
+++ b/lib/features/policy_new/data/repositories/policy_repository_impl.dart
@@ -67,8 +67,8 @@ class PolicyRepositoryImpl implements PolicyRepository {
       params['searchPolicyType'] = _mapCategory(filter.category!);
     }
 
-    if (filter.isOngoing != null) {
-      params['aplyPsbltyYn'] = filter.isOngoing! ? 'Y' : 'N';
+    if (filter.status == PolicyStatusFilter.inProgressOnly) {
+      params['aplyPsbltyYn'] = 'Y';
     }
 
     if (filter.isOnline != null) {
@@ -213,13 +213,16 @@ class PolicyRepositoryImpl implements PolicyRepository {
     required int pageSize,
     required String scopeKey,
   }) async {
+    final normalizedQuery = query.normalize();
+    final filter = normalizedQuery.filter;
+
     try {
       logger.info(
-        'fetchPoliciesByQuery(scope: $scopeKey, page: $page, size: $pageSize)',
+        '[Explore][INFO] fetchPoliciesByQuery(scope: $scopeKey, region: ${filter.region.name}/${filter.province}/${filter.city ?? '-'} (${filter.district ?? '-'}), status: ${filter.status.queryValue}, sort: ${normalizedQuery.sort.name}, keyword: ${normalizedQuery.keyword ?? '-'}, feed: ${normalizedQuery.feedType.name}, page: $page, size: $pageSize)',
       );
 
       final result = await _fetchFromRemote(
-        query: query,
+        query: normalizedQuery,
         page: page,
         pageSize: pageSize,
       );
@@ -462,7 +465,7 @@ class PolicyRepositoryImpl implements PolicyRepository {
     return params.entries.map((e) => '${e.key}=${e.value}').join(', ');
   }
 
-  String _mapRegion(PolicyRegion region) {
+  String? _mapRegion(PolicyRegion region) {
     switch (region) {
       case PolicyRegion.seoul:
         return '서울';
@@ -479,17 +482,28 @@ class PolicyRepositoryImpl implements PolicyRepository {
       case PolicyRegion.ulsan:
         return '울산';
       case PolicyRegion.gyeongbuk:
-        return '경북 전체';
+        return '경상북도';
       case PolicyRegion.all:
-        return '전체';
+        return null;
     }
   }
 
   String? _regionParam(PolicyFilter filter) {
-    // 우선순위: city만 전달. (도 단위는 기본 전체 의미로 생략)
-    if (filter.city != null && filter.city!.isNotEmpty) {
-      return filter.city;
+    final city = filter.city?.trim();
+    if (city != null && city.isNotEmpty) {
+      return city;
     }
+
+    final province = filter.province.trim();
+    if (filter.region == PolicyRegion.gyeongbuk && province.isNotEmpty) {
+      return province;
+    }
+
+    final mappedRegion = _mapRegion(filter.region);
+    if (mappedRegion != null && mappedRegion.isNotEmpty) {
+      return mappedRegion;
+    }
+
     return null;
   }
 


### PR DESCRIPTION
## Summary
- 정책 쿼리를 만들 때 UI에 표시된 지역/시군 선택값을 그대로 사용해 검색 조건과 API 파라미터가 일치하도록 정리했습니다.
- 필터 초기화 시 지역 선택도 함께 리셋해 탐색 탭 요약과 실제 조회 조건이 어긋나지 않도록 했습니다.
- 정책 쿼리 생성 시 경북 시·군 선택을 RegionNotifier의 실제 선택값에서 직접 읽어 UI 표시와 쿼리 파라미터의 불일치를 방지했습니다.

## Testing
- Not run (dart 명령어 부재)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938ef3824a083249f2019c4656f099d)