### PR TITLE
Handle reminder past-time errors as one-shot

### DIFF
--- a/lib/features/policy_new/application/controllers/policy_reminder_controller.dart
+++ b/lib/features/policy_new/application/controllers/policy_reminder_controller.dart
@@ -20,24 +20,32 @@ class PolicyReminderViewState {
     this.isRefreshing = false,
     this.isMutating = false,
     this.messages = const [],
+    this.errorMessage,
   });
+
+  static const _noValue = Object();
 
   final List<PolicyReminder> reminders;
   final bool isRefreshing;
   final bool isMutating;
   final List<String> messages;
+  final String? errorMessage;
 
   PolicyReminderViewState copyWith({
     List<PolicyReminder>? reminders,
     bool? isRefreshing,
     bool? isMutating,
     List<String>? messages,
+    Object? errorMessage = _noValue,
   }) {
     return PolicyReminderViewState(
       reminders: reminders ?? this.reminders,
       isRefreshing: isRefreshing ?? this.isRefreshing,
       isMutating: isMutating ?? this.isMutating,
       messages: messages ?? this.messages,
+      errorMessage: identical(errorMessage, _noValue)
+          ? this.errorMessage
+          : errorMessage as String?,
     );
   }
 
@@ -94,6 +102,7 @@ class PolicyReminderController
             isRefreshing: false,
             isMutating: false,
             messages: ['알림 정보를 불러오지 못했습니다: $e'],
+            errorMessage: null,
           ),
         );
         print('PolicyReminderController.initialize failed: $e\n$st');
@@ -121,6 +130,7 @@ class PolicyReminderController
             isRefreshing: false,
             isMutating: false,
             messages: preserveMessages ? base.messages : const [],
+            errorMessage: null,
           ),
         );
       } catch (e, st) {
@@ -129,6 +139,7 @@ class PolicyReminderController
             isRefreshing: false,
             isMutating: false,
             messages: ['알림 정보를 불러오지 못했습니다: $e'],
+            errorMessage: null,
           ),
         );
         print('PolicyReminderController.load failed: $e\n$st');
@@ -143,7 +154,13 @@ class PolicyReminderController
     return _silenceEventsWhile(() async {
       final previous = state.value ?? PolicyReminderViewState.initial();
       final previousReminders = await _fetchReminders();
-      state = AsyncData(previous.copyWith(isMutating: true, messages: const []));
+      state = AsyncData(
+        previous.copyWith(
+          isMutating: true,
+          messages: const [],
+          errorMessage: null,
+        ),
+      );
       try {
         final nextKinds = kinds.toSet();
         if (nextKinds.isEmpty) {
@@ -156,7 +173,12 @@ class PolicyReminderController
               isRefreshing: false,
               isMutating: false,
               messages: const [],
+              errorMessage: null,
             ),
+          );
+
+          print(
+            '[Reminder][INFO] 알림 토글 성공 (policyId: $policyId, isActive: ${refreshed.isNotEmpty})',
           );
 
           return const ReminderMutationResult(reminders: [], failures: []);
@@ -173,13 +195,24 @@ class PolicyReminderController
           await _restorePreviousReminders(previousReminders, refreshed);
 
           _pendingEventReload = false;
+          final failureMessages = _messagesForResult(result);
+          final failureMessage = failureMessages.isNotEmpty
+              ? failureMessages.first
+              : '알림을 설정하지 못했어요. 잠시 후 다시 시도해 주세요.';
           state = AsyncData(
             PolicyReminderViewState(
               reminders: previousReminders,
               isRefreshing: false,
               isMutating: false,
-              messages: _messagesForResult(result),
+              messages: const [],
+              errorMessage: failureMessage,
             ),
+          );
+
+          final firstFailure =
+              failureMessages.isNotEmpty ? failureMessages.first : null;
+          print(
+            '[Reminder][WARN] 알림 토글 실패 (policyId: $policyId, error: $firstFailure)',
           );
 
           return ReminderMutationResult(
@@ -208,7 +241,12 @@ class PolicyReminderController
             isRefreshing: false,
             isMutating: false,
             messages: _messagesForResult(result),
+            errorMessage: null,
           ),
+        );
+
+        print(
+          '[Reminder][INFO] 알림 토글 성공 (policyId: $policyId, isActive: ${latestReminders.isNotEmpty})',
         );
 
         return result;
@@ -232,20 +270,24 @@ class PolicyReminderController
                 timeKind: kind,
                 failure: const ScheduleFailure(
                   type: ScheduleFailureType.unknown,
-                  message: '알림을 설정하지 못했어요. 잠시 후 다시 시도해 주세요.',
-                  code: ScheduleFailureCode.internalException,
-                ),
+                message: '알림을 설정하지 못했어요. 잠시 후 다시 시도해 주세요.',
+                code: ScheduleFailureCode.internalException,
               ),
-            )
-            .toList();
+            ),
+          )
+          .toList();
         state = AsyncData(
           PolicyReminderViewState(
             reminders: previousReminders,
             isRefreshing: false,
             isMutating: false,
-            messages: const ['알림을 설정하지 못했어요. 잠시 후 다시 시도해 주세요.'],
+            messages: const [],
+            errorMessage:
+                '알림을 설정하지 못했어요. 잠시 후 다시 시도해 주세요.',
           ),
         );
+        print(
+            '[Reminder][WARN] 알림 토글 실패 (policyId: $policyId, error: $e)');
         print('PolicyReminderController.setReminders failed: $e\n$st');
         return ReminderMutationResult(
           reminders: previousReminders,
@@ -258,7 +300,12 @@ class PolicyReminderController
   Future<void> removeReminder(String reminderId) async {
     await _silenceEventsWhile(() async {
       final previous = state.value ?? PolicyReminderViewState.initial();
-      state = AsyncData(previous.copyWith(isMutating: true));
+      state = AsyncData(
+        previous.copyWith(
+          isMutating: true,
+          errorMessage: null,
+        ),
+      );
       try {
         await _service.cancelReminder(reminderId, deleteFromRepository: true);
         final current = await _fetchReminders();
@@ -267,6 +314,7 @@ class PolicyReminderController
             reminders: current,
             isMutating: false,
             messages: const [],
+            errorMessage: null,
           ),
         );
       } catch (e, st) {
@@ -274,6 +322,7 @@ class PolicyReminderController
           previous.copyWith(
             isMutating: false,
             messages: ['알림을 취소하지 못했어요. 잠시 후 다시 시도해 주세요.'],
+            errorMessage: null,
           ),
         );
         print('PolicyReminderController.removeReminder failed: $e\n$st');
@@ -284,7 +333,12 @@ class PolicyReminderController
   Future<void> cancelAll() async {
     await _silenceEventsWhile(() async {
       final previous = state.value ?? PolicyReminderViewState.initial();
-      state = AsyncData(previous.copyWith(isMutating: true));
+      state = AsyncData(
+        previous.copyWith(
+          isMutating: true,
+          errorMessage: null,
+        ),
+      );
       try {
         await _service.cancelAllByPolicy(
           policyId,
@@ -295,6 +349,7 @@ class PolicyReminderController
             reminders: const [],
             isMutating: false,
             messages: const [],
+            errorMessage: null,
           ),
         );
       } catch (e, st) {
@@ -302,6 +357,7 @@ class PolicyReminderController
           previous.copyWith(
             isMutating: false,
             messages: ['모든 알림을 취소하지 못했어요. 잠시 후 다시 시도해 주세요.'],
+            errorMessage: null,
           ),
         );
         print('PolicyReminderController.cancelAll failed: $e\n$st');
@@ -312,6 +368,12 @@ class PolicyReminderController
   void clearMessages() {
     state = state.whenData(
       (viewState) => viewState.copyWith(messages: const []),
+    );
+  }
+
+  void clearError() {
+    state = state.whenData(
+      (viewState) => viewState.copyWith(errorMessage: null),
     );
   }
 

--- a/lib/features/policy_new/presentation/reminder/policy_reminder_button.dart
+++ b/lib/features/policy_new/presentation/reminder/policy_reminder_button.dart
@@ -23,6 +23,32 @@ class PolicyReminderButton extends ConsumerWidget {
     final controller =
         ref.read(policyReminderControllerProvider(policy.id).notifier);
 
+    ref.listen<AsyncValue<PolicyReminderViewState>>(
+      policyReminderControllerProvider(policy.id),
+      (previous, next) {
+        next.whenData((viewState) {
+          final messenger = ScaffoldMessenger.maybeOf(context);
+          if (messenger == null) return;
+
+          final errorMessage = viewState.errorMessage;
+          if (errorMessage != null) {
+            messenger.showSnackBar(
+              SnackBar(content: Text(errorMessage)),
+            );
+            controller.clearError();
+            return;
+          }
+
+          if (viewState.messages.isNotEmpty) {
+            messenger.showSnackBar(
+              SnackBar(content: Text(viewState.messages.first)),
+            );
+            controller.clearMessages();
+          }
+        });
+      },
+    );
+
     return reminderState.when(
       data: (viewState) {
         final reminders = viewState.reminders;
@@ -33,18 +59,6 @@ class PolicyReminderButton extends ConsumerWidget {
         final activeOptions =
             activeReminders.map((reminder) => reminder.timeKind).toSet();
         final hasActiveReminders = activeReminders.isNotEmpty;
-
-        if (viewState.messages.isNotEmpty) {
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            final messenger = ScaffoldMessenger.maybeOf(context);
-            if (messenger != null) {
-              messenger.showSnackBar(
-                SnackBar(content: Text(viewState.messages.first)),
-              );
-              controller.clearMessages();
-            }
-          });
-        }
 
         return _ReminderSheetButton(
           policy: policy,
@@ -125,18 +139,6 @@ class _ReminderSheet extends ConsumerWidget {
             ? activeOptions
             : initialOptions;
 
-        if (viewState.messages.isNotEmpty) {
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            final messenger = ScaffoldMessenger.maybeOf(context);
-            if (messenger != null) {
-              messenger.showSnackBar(
-                SnackBar(content: Text(viewState.messages.first)),
-              );
-              controller.clearMessages();
-            }
-          });
-        }
-
         return _ReminderSheetScaffold(
           policy: policy,
           viewState: viewState,
@@ -149,15 +151,7 @@ class _ReminderSheet extends ConsumerWidget {
             } else {
               next.remove(option);
             }
-            final result = await controller.setReminders(policy, next.toList());
-            if (result.hasFailure && context.mounted) {
-              final messages = controller.state.value?.messages ?? [];
-              final message =
-                  messages.isNotEmpty ? messages.first : '알림을 설정하지 못했어요.';
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text(message)),
-              );
-            }
+            await controller.setReminders(policy, next.toList());
           },
           onRemove: (reminderId) => controller.removeReminder(reminderId),
           onOpenOptions: () =>


### PR DESCRIPTION
## Summary
- add one-shot error handling to the reminder controller so past-time failures clear after being consumed
- update reminder button UI to listen for errors/messages once and trigger toast with immediate reset
- add logging for reminder toggle successes and failures

## Testing
- flutter analyze *(fails: command not found)*
- flutter test *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938f43ca00483249f75d40009c27928)