### PR TITLE
Fix region notifier import path in global filter controller

### DIFF
--- a/lib/features/policy_new/application/controllers/global_filter_controller.dart
+++ b/lib/features/policy_new/application/controllers/global_filter_controller.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../filters/policy_filter_ui_state.dart';
 import '../filters/policy_search_keyword_provider.dart';
 import '../../domain/values/policy_feed_type.dart';
-import '../../../application/notifiers/region_notifier.dart';
+import '../../../../application/notifiers/region_notifier.dart';
 
 class GlobalFilterController {
   GlobalFilterController(this.ref);


### PR DESCRIPTION
## Summary
- fix the relative import to `region_notifier.dart` in the global filter controller

## Testing
- flutter analyze lib/features/policy_new/application/controllers/global_filter_controller.dart *(fails: flutter not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938f650e0d08324a2b516591476157b)