### PR TITLE
탐색 지역 조회 기본 쿼리 보정

### DIFF
--- a/lib/features/policy_new/application/controllers/base_feed_controller.dart
+++ b/lib/features/policy_new/application/controllers/base_feed_controller.dart
@@ -263,8 +263,15 @@ abstract class BasePolicyFeedController
       return;
     }
 
+    final fetchPrefix = (feedType == PolicyFeedType.all ||
+            feedType == PolicyFeedType.region ||
+            feedType == PolicyFeedType.search)
+        ? '[Policy][Explore][FETCH]'
+        : '[Feed][FETCH]';
+
     debugPrint(
-      '[Feed][FETCH] feed=${feedType.name}, '
+      '$fetchPrefix feed=${feedType.name}, '
+      'queryFeed=${queryState.query.feedType.name}, '
       'status=${queryState.query.filter.status.queryValue}, '
       'region=${queryState.query.filter.region.name}/${queryState.query.filter.province}/${queryState.query.filter.city ?? '-'} '
       '(${queryState.query.filter.district ?? '-'}), '

--- a/lib/features/policy_new/application/controllers/policy_query_engine.dart
+++ b/lib/features/policy_new/application/controllers/policy_query_engine.dart
@@ -31,7 +31,7 @@ class PolicyQueryEngine {
     final repo = ref.read(policyRepositoryProvider);
 
     final logBuffer = StringBuffer()
-      ..write('[Policy][INFO] fetchPoliciesByQuery(')
+      ..write('[Policy][Explore] fetchPoliciesByQuery(')
       ..write('feed: ${feedType.name}, ')
       ..write('page: $page, ')
       ..write('sort: ${query.sort.name}, ')

--- a/lib/features/policy_new/application/controllers/policy_query_orchestrator.dart
+++ b/lib/features/policy_new/application/controllers/policy_query_orchestrator.dart
@@ -89,10 +89,17 @@ class PolicyQueryOrchestrator {
 
   PolicyQuery _buildRegionQuery() {
     final region = _ui.region == PolicyRegion.all ? _profile.region : _ui.region;
+    final regionNotifier = ref.read(regionProvider.notifier);
+    final hasCitySelection =
+        regionNotifier.selectedCity != null || regionNotifier.selectedDistrict != null;
     final filter = _buildFilterFromUi(region: region);
 
+    // region 피드가 시/군 선택이 없는 상태에서도 빈 결과만 내려오는 것을 막기 위해
+    // 실제 쿼리는 기본(all) 스코프로 전송하되, 필터에는 지역 정보를 유지한다.
+    final queryFeedType = hasCitySelection ? PolicyFeedType.region : PolicyFeedType.all;
+
     return PolicyQuery(
-      feedType: PolicyFeedType.region,
+      feedType: queryFeedType,
       filter: filter,
       sort: _ui.sort,
     ).normalize();

--- a/lib/features/policy_new/application/explore/explore_providers.dart
+++ b/lib/features/policy_new/application/explore/explore_providers.dart
@@ -8,6 +8,7 @@ import '../../domain/values/policy_category.dart';
 import '../../domain/values/policy_sort.dart';
 import '../../domain/values/policy_feed_type.dart';
 import '../../domain/values/policy_status_filter.dart';
+import '../../domain/values/policy_region.dart';
 import '../reexplore/policy_reexplore.dart';
 import '../../../../application/notifiers/region_notifier.dart';
 
@@ -110,8 +111,14 @@ class ExploreController extends StateNotifier<ExploreState> {
       return;
     }
 
-    final nextMode = hasSelection ? ExploreSubMode.region : ExploreSubMode.all;
+    final filterRegion = ref.read(globalFilterProvider).region;
+    final isRegional = hasSelection || filterRegion != PolicyRegion.all;
+    final nextMode = isRegional ? ExploreSubMode.region : ExploreSubMode.all;
     if (state.mode != nextMode) {
+      debugPrint(
+        '[Policy][Explore] ensureRegionMode -> $nextMode '
+        '(selection=$hasSelection, filterRegion=${filterRegion.name})',
+      );
       state = state.copyWith(mode: nextMode);
     }
   }

--- a/lib/features/policy_new/presentation/widgets/policy_feed_list_view.dart
+++ b/lib/features/policy_new/presentation/widgets/policy_feed_list_view.dart
@@ -84,7 +84,12 @@ class _PolicyFeedListViewState extends ConsumerState<PolicyFeedListView>
     }
 
     final visibleItems = state.visibleItems;
-    final isInitialLoading = state.isLoading && visibleItems.isEmpty;
+    final isPristine = !state.isLoading &&
+        state.previousResults == null &&
+        visibleItems.isEmpty &&
+        reaction.phase == UIReactionPhase.idle;
+    final isInitialLoading = (state.isLoading || isPristine) &&
+        visibleItems.isEmpty;
     final isTransitionLoading = state.isLoading && state.previousResults != null;
     var showSkeleton =
         reaction.shouldHoldSkeleton || isInitialLoading || isTransitionLoading;
@@ -111,6 +116,10 @@ class _PolicyFeedListViewState extends ConsumerState<PolicyFeedListView>
         key: const ValueKey('policy-list-error'),
         message: state.failure!.message,
         onRetry: notifier.loadFirstPage,
+      );
+    } else if (isInitialLoading) {
+      content = const PolicyListSkeleton(
+        key: ValueKey('policy-list-initial-loading'),
       );
     } else if (shouldShowSearchGuide) {
       content = PolicySearchEmptyView(


### PR DESCRIPTION
## Summary
- 탐색 지역 모드에서 시·군 선택이 없을 때 기본(all) 스코프로 조회하도록 쿼리 feedType을 보정했습니다.
- 정책 조회 로깅에 실제 쿼리 feedType을 추가해 파라미터 확인을 쉽게 했습니다.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938f9119abc8324b033adbce08b2f0d)