### PR TITLE
Fix Kakao map current location radius and filtering

### DIFF
--- a/lib/features/map_v2/current_location_provider.dart
+++ b/lib/features/map_v2/current_location_provider.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'kakao_map_html_builder.dart';
+import 'services/gps_service.dart';
+import 'services/location_permission_service.dart';
+
+class CurrentLocationState {
+  const CurrentLocationState({
+    this.location,
+    this.isLoading = false,
+    this.error,
+    this.serviceDisabled = false,
+    this.permissionIssue,
+  });
+
+  final KakaoMapLatLng? location;
+  final bool isLoading;
+  final String? error;
+  final bool serviceDisabled;
+  final LocationPermissionIssue? permissionIssue;
+
+  static const _unset = Object();
+
+  CurrentLocationState copyWith({
+    KakaoMapLatLng? location,
+    bool? isLoading,
+    Object? error = _unset,
+    bool? serviceDisabled,
+    Object? permissionIssue = _unset,
+  }) {
+    return CurrentLocationState(
+      location: location ?? this.location,
+      isLoading: isLoading ?? this.isLoading,
+      error: error == _unset ? this.error : error as String?,
+      serviceDisabled: serviceDisabled ?? this.serviceDisabled,
+      permissionIssue: permissionIssue == _unset
+          ? this.permissionIssue
+          : permissionIssue as LocationPermissionIssue?,
+    );
+  }
+
+  static CurrentLocationState initial() => const CurrentLocationState();
+}
+
+final currentLocationProvider =
+    StateNotifierProvider<CurrentLocationNotifier, CurrentLocationState>(
+  (_) => CurrentLocationNotifier(),
+);
+
+class CurrentLocationNotifier extends StateNotifier<CurrentLocationState> {
+  CurrentLocationNotifier() : super(CurrentLocationState.initial());
+
+  final _gpsService = const GpsService();
+  final _permissionService = const LocationPermissionService();
+
+  Future<void> fetch() async {
+    if (state.isLoading) return;
+
+    state = state.copyWith(
+      isLoading: true,
+      error: null,
+      permissionIssue: null,
+      serviceDisabled: false,
+    );
+
+    try {
+      final serviceEnabled = await _gpsService.isLocationServiceEnabled();
+      if (!serviceEnabled) {
+        state = state.copyWith(
+          isLoading: false,
+          serviceDisabled: true,
+          error: '위치 서비스가 꺼져 있습니다.',
+        );
+        return;
+      }
+
+      final permissionResult = await _permissionService.ensurePermission();
+      if (permissionResult != LocationPermissionIssue.granted) {
+        state = state.copyWith(
+          isLoading: false,
+          permissionIssue: permissionResult,
+          error: _permissionMessage(permissionResult),
+        );
+        return;
+      }
+
+      final position = await _gpsService.getCurrentPosition();
+      state = state.copyWith(
+        isLoading: false,
+        location: KakaoMapLatLng(position.latitude, position.longitude),
+        error: null,
+      );
+    } catch (error, stack) {
+      debugPrint('[CurrentLocation] 위치 로드 실패: $error');
+      if (stack != null) debugPrint(stack.toString());
+      state = state.copyWith(
+        isLoading: false,
+        error: '현재 위치를 가져오지 못했습니다.',
+      );
+    }
+  }
+
+  String _permissionMessage(LocationPermissionIssue issue) {
+    switch (issue) {
+      case LocationPermissionIssue.denied:
+        return '위치 권한이 거부되었습니다.';
+      case LocationPermissionIssue.deniedForever:
+        return '위치 권한이 영구히 거부되었습니다.';
+      case LocationPermissionIssue.granted:
+        return '';
+    }
+  }
+}

--- a/lib/features/map_v2/kakao_map_screen.dart
+++ b/lib/features/map_v2/kakao_map_screen.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:geolocator/geolocator.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 
@@ -18,10 +17,10 @@ import '../../env/app_env.dart';
 import '../center/presentation/center_detail_bottom_sheet.dart';
 import '../policy_new/data/mappers/youth_center_mapper.dart';
 import '../policy_new/presentation/map/youth_center_map_provider.dart';
+import 'current_location_provider.dart';
 import 'kakao_map_html_builder.dart';
 import 'kakao_map_providers.dart';
 import 'kakao_map_webview.dart';
-import 'services/gps_service.dart';
 import 'services/location_permission_service.dart';
 import '../../ui/components/app_common_bottom_sheets.dart';
 import 'widgets/center_list_bottom_sheet.dart';
@@ -46,8 +45,6 @@ class KakaoMapScreen extends ConsumerStatefulWidget {
 class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   static final _defaultCenter = KakaoMapLatLng(36.4919, 128.8889);
   static const _locationZoomLevel = 6;
-  static const _gpsService = GpsService();
-  static const _permissionService = LocationPermissionService();
   static const _locationTimeout = Duration(seconds: 8);
   static const _debounceDuration = Duration(milliseconds: 400);
   static const _centerMarkerFallbackBase64 =
@@ -70,6 +67,9 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   List<CenterMarkerPoint> _cachedCenterPoints = const [];
   bool _showLoadingOverlay = false;
   bool _locationResolved = false;
+  bool _authErrorShown = false;
+  LocationPermissionIssue? _lastPermissionIssue;
+  bool _serviceGuideShown = false;
 
   Timer? _moveDebounce;
   Timer? _tooltipTimer;
@@ -84,6 +84,8 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
       'len=${AppEnv.kakaoRestApiKey.length}',
     );
 
+    _setupLocationListener();
+    _setupCenterErrorListener();
     _prepareCenterMarkerIcon();
     _preloadCachedCenterMarkers();
     _startLocationRequest();
@@ -320,6 +322,80 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     );
   }
 
+  void _setupLocationListener() {
+    ref.listen<CurrentLocationState>(currentLocationProvider,
+        (previous, next) {
+      if (next.location != null && !_locationResolved) {
+        _locationResolved = true;
+        _locationTimer?.cancel();
+        _deviceLocation = next.location;
+        _applyNewCenter(next.location!, animate: true, fromLocation: true);
+        return;
+      }
+
+      if (!next.isLoading && !_locationResolved) {
+        _handleLocationIssues(next);
+        if (next.error != null) {
+          _locationResolved = true;
+          _locationTimer?.cancel();
+          _applyFallbackCenter(locationError: next.error);
+        }
+      }
+    });
+  }
+
+  void _setupCenterErrorListener() {
+    ref.listen<YouthCenterMapState>(youthCenterMapStateProvider,
+        (previous, next) {
+      final message = next.errorMessage;
+      final isAuthError =
+          message != null && message.contains('센터 인증 정보가 올바르지 않습니다');
+      if (next.status == YouthCenterMapStatus.error && isAuthError) {
+        _showAuthErrorOnce(message!);
+      }
+    });
+  }
+
+  void _handleLocationIssues(CurrentLocationState state) {
+    if (!mounted) return;
+    if (state.serviceDisabled && !_serviceGuideShown) {
+      _serviceGuideShown = true;
+      _showLocationPermissionGuide(LocationBottomSheetIssue.serviceDisabled);
+      return;
+    }
+
+    if (state.permissionIssue == null) return;
+    if (_lastPermissionIssue == state.permissionIssue) return;
+    _lastPermissionIssue = state.permissionIssue;
+
+    if (state.permissionIssue == LocationPermissionIssue.denied) {
+      _showLocationPermissionGuide(LocationBottomSheetIssue.permissionDenied);
+    } else if (state.permissionIssue == LocationPermissionIssue.deniedForever) {
+      _showLocationPermissionGuide(
+        LocationBottomSheetIssue.permissionPermanentlyDenied,
+      );
+    }
+  }
+
+  void _showAuthErrorOnce(String message) {
+    if (_authErrorShown) return;
+    _authErrorShown = true;
+    if (!mounted) return;
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('인증 오류'),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('확인'),
+          ),
+        ],
+      ),
+    );
+  }
+
   void _startLocationRequest() {
     _locationTimer?.cancel();
     _locationTimer = Timer(_locationTimeout, () {
@@ -329,60 +405,14 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
       _applyFallbackCenter(locationError: '위치 확인 시간이 초과되었습니다.');
     });
 
+    _lastPermissionIssue = null;
+    _serviceGuideShown = false;
     setState(() {
       _viewStatus = KakaoMapViewStatus.locating;
       _showLoadingOverlay = true;
       _locationResolved = false;
     });
-    _loadInitialPosition();
-  }
-
-  Future<void> _loadInitialPosition() async {
-    if (!mounted) return;
-
-    try {
-      final serviceEnabled = await _gpsService.isLocationServiceEnabled();
-      if (!serviceEnabled) {
-        await _showLocationPermissionGuide(
-          LocationBottomSheetIssue.serviceDisabled,
-        );
-        throw '위치 서비스가 꺼져 있습니다.';
-      }
-
-      final permissionResult = await _permissionService.ensurePermission();
-      if (permissionResult == LocationPermissionIssue.denied) {
-        await _showLocationPermissionGuide(
-          LocationBottomSheetIssue.permissionDenied,
-        );
-        throw '위치 권한이 거부되었습니다.';
-      }
-
-      if (permissionResult == LocationPermissionIssue.deniedForever) {
-        await _showLocationPermissionGuide(
-          LocationBottomSheetIssue.permissionPermanentlyDenied,
-        );
-        throw '위치 권한이 영구히 거부되었습니다.';
-      }
-
-      final position = await _gpsService.getCurrentPosition();
-      if (!mounted) return;
-
-      if (_locationResolved) return;
-      _locationResolved = true;
-
-      final location = KakaoMapLatLng(position.latitude, position.longitude);
-      _locationTimer?.cancel();
-      await _applyNewCenter(location, animate: true, fromLocation: true);
-    } catch (error, stack) {
-      debugPrint('[KakaoMapScreen] 위치 로드 실패: $error');
-      if (stack != null) debugPrint(stack.toString());
-      if (!mounted) return;
-      if (_locationResolved) return;
-      _locationResolved = true;
-      await _applyFallbackCenter(
-        locationError: '현재 위치를 가져오지 못했습니다.',
-      );
-    }
+    ref.read(currentLocationProvider.notifier).fetch();
   }
 
   Future<void> _applyNewCenter(
@@ -405,7 +435,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     });
 
     await _moveMap(center, level: _locationZoomLevel, animate: animate);
-    await _updateSearchCircle(center);
+    await _updateSearchCircle(_effectiveCircleCenter);
   }
 
   Future<void> _retryLoadCenters() async {
@@ -415,10 +445,11 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     });
 
     final notifier = ref.read(youthCenterMapStateProvider.notifier);
-    await notifier.loadCenters(center: _mapCenter, radiusKm: _currentRadius);
+    final searchCenter = _deviceLocation ?? _mapCenter;
+    await notifier.loadCenters(center: searchCenter, radiusKm: _currentRadius);
 
     if (!mounted) return;
-    await _updateSearchCircle(_mapCenter);
+    await _updateSearchCircle(_effectiveCircleCenter);
 
     setState(() {
       _showLoadingOverlay = false;
@@ -500,16 +531,16 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   Future<void> _onMapIdle() async {
     final target = _latestCenterFromMove;
     if (target == null) return;
-    final notifier = ref.read(youthCenterMapStateProvider.notifier);
-    notifier.updateCenter(target, radiusKm: _currentRadius);
-    await _updateSearchCircle(target);
     setState(() {
       _mapCenter = target;
       _viewStatus = _mapReady
           ? KakaoMapViewStatus.markersReady
           : KakaoMapViewStatus.mapReady;
     });
+    _latestCenterFromMove = null;
   }
+
+  KakaoMapLatLng? get _effectiveCircleCenter => _deviceLocation ?? _mapCenter;
 
   Future<void> _moveMap(
     KakaoMapLatLng location, {
@@ -527,7 +558,8 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
       } else {
         await controller.moveMapTo(location, level: level);
       }
-      await controller.showMyPosition(location);
+      final myLocation = _deviceLocation ?? location;
+      await controller.showMyPosition(myLocation);
     } catch (error, stack) {
       debugPrint('[KakaoMapScreen] moveMap error: $error');
       if (stack != null) debugPrint(stack.toString());
@@ -535,10 +567,14 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   }
 
   Future<void> _updateSearchCircle(
-    KakaoMapLatLng center,
+    KakaoMapLatLng? center,
   ) async {
-    if (!_mapReady) return;
+    if (!_mapReady || center == null) return;
     try {
+      debugPrint(
+        '[Map][INFO] drawMyLocationCircle(center: ${center.lat}, ${center.lng}, '
+        'radiusM: ${(_currentRadius * 1000).round()})',
+      );
       final controller = ref.read(kakaoMapControllerProvider);
       await controller.updateCircle(
         center,
@@ -562,7 +598,9 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         _viewStatus = nextStatus;
       }
     });
-    _updateSearchCircle(_mapCenter);
+    if (_locationResolved) {
+      _updateSearchCircle(_effectiveCircleCenter);
+    }
   }
 
   void _onWebViewLoadingChanged(bool isLoading) {

--- a/lib/features/policy_new/presentation/map/youth_center_map_provider.dart
+++ b/lib/features/policy_new/presentation/map/youth_center_map_provider.dart
@@ -274,7 +274,7 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
     const fallback = '센터 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.';
 
     if (error is YouthCenterApiException) {
-      if (error.statusCode == 403) {
+      if (error.statusCode == 403 || error.statusCode == 401) {
         return '센터 인증 정보가 올바르지 않습니다. 잠시 후 다시 시도해주세요.';
       }
       if (!kDebugMode) return error.userMessage;
@@ -298,37 +298,36 @@ List<CenterMarkerPoint> filterCentersWithinRadius(
   double radiusKm,
 ) {
   if (all.isEmpty) return const [];
-  final centersWithDistance = all
-      .map(
-        (point) => _CenterDistance(
-          point: point,
-          distanceKm: _distanceKm(center.lat, center.lng, point.lat, point.lng),
-        ),
+  final radiusMeters = radiusKm * 1000;
+  final filtered = all
+      .where(
+        (point) =>
+            distanceInMeters(
+              center,
+              KakaoMapLatLng(point.lat, point.lng),
+            ) <=
+            radiusMeters,
       )
       .toList();
 
-  final withinRadius = centersWithDistance
-      .where((item) => item.distanceKm <= radiusKm)
-      .map((e) => e.point)
-      .toList();
+  debugPrint('[Map][INFO] filterCentersWithinRadius(before: ${all.length}, '
+      'after: ${filtered.length})');
 
-  return withinRadius;
+  return filtered;
 }
 
-class _CenterDistance {
-  _CenterDistance({required this.point, required this.distanceKm});
+double distanceInMeters(KakaoMapLatLng a, KakaoMapLatLng b) {
+  const earthRadius = 6371000.0;
+  final dLat = _deg(b.lat - a.lat);
+  final dLon = _deg(b.lng - a.lng);
+  final lat1 = _deg(a.lat);
+  final lat2 = _deg(b.lat);
 
-  final CenterMarkerPoint point;
-  final double distanceKm;
-}
-
-double _distanceKm(double lat1, double lon1, double lat2, double lon2) {
-  const R = 6371.0;
-  final dLat = _deg(lat2 - lat1);
-  final dLon = _deg(lon2 - lon1);
-  final a = sin(dLat / 2) * sin(dLat / 2) +
-      cos(_deg(lat1)) * cos(_deg(lat2)) * sin(dLon / 2) * sin(dLon / 2);
-  return R * 2 * atan2(sqrt(a), sqrt(1 - a));
+  final sinLat = sin(dLat / 2);
+  final sinLon = sin(dLon / 2);
+  final aHarv = sinLat * sinLat + cos(lat1) * cos(lat2) * sinLon * sinLon;
+  final c = 2 * atan2(sqrt(aHarv), sqrt(1 - aHarv));
+  return earthRadius * c;
 }
 
 double _deg(double deg) => deg * (pi / 180.0);


### PR DESCRIPTION
## Summary
- preserve current location state fields in copyWith unless explicitly overridden, preventing unintended clearing of errors or permission info

## Testing
- Not run (Flutter/Dart tooling not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938f8fb2f0c832499e099ef115c72bc)