### PR TITLE
Refine compare zoom layout

### DIFF
--- a/lib/features/policy_new/compare/presentation/widgets/compare_diff_table_widget.dart
+++ b/lib/features/policy_new/compare/presentation/widgets/compare_diff_table_widget.dart
@@ -27,10 +27,9 @@ class CompareDiffTableWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final visibleFields = fields;
     final totalWidth = labelWidth + (columnWidth + 12) * policies.length;
 
-    final content = visibleFields.isEmpty
+    final content = fields.isEmpty
         ? Container(
             width: totalWidth,
             padding: const EdgeInsets.all(12),
@@ -38,7 +37,7 @@ class CompareDiffTableWidget extends StatelessWidget {
             child: const Text('모든 항목이 동일합니다'),
           )
         : Column(
-            children: visibleFields
+            children: fields
                 .map(
                   (field) => Padding(
                     padding: const EdgeInsets.symmetric(vertical: 8),

--- a/lib/features/policy_new/compare/presentation/widgets/compare_screen.dart
+++ b/lib/features/policy_new/compare/presentation/widgets/compare_screen.dart
@@ -64,7 +64,12 @@ class _CompareScreenState extends State<CompareScreen> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Padding(
-          padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+          padding: const EdgeInsets.fromLTRB(
+            AppSpacing.lg,
+            AppSpacing.md,
+            AppSpacing.lg,
+            AppSpacing.sm,
+          ),
           child: Row(
             children: [
               Text(
@@ -87,8 +92,8 @@ class _CompareScreenState extends State<CompareScreen> {
         ),
         Padding(
           padding: const EdgeInsets.symmetric(
-            horizontal: 16,
-            vertical: 8,
+            horizontal: AppSpacing.lg,
+            vertical: AppSpacing.sm,
           ),
           child: ConstrainedBox(
             constraints: const BoxConstraints(minHeight: headerMinHeight),
@@ -246,8 +251,8 @@ class _ZoomableCompareContent extends StatelessWidget {
         ? const NeverScrollableScrollPhysics()
         : const ClampingScrollPhysics();
 
-    return ConstrainedBox(
-      constraints: BoxConstraints(minHeight: minHeight),
+    return SizedBox(
+      height: minHeight,
       child: Stack(
         children: [
           Padding(


### PR DESCRIPTION
## Summary
- 정책 비교 헤더와 줌 영역 여백을 디자인 토큰으로 정리해 상단 레이아웃을 안정화했습니다.
- 줌 가능한 비교 영역 높이를 고정해 스크롤·드래그 제스처 충돌을 줄였습니다.
- 비교 테이블이 항상 모든 항목을 표시하도록 남은 차이 필터링 흔적을 제거했습니다.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938ff0b79e883248306053662195d67)