### PR TITLE
Fix policy query override initialization conflict

### DIFF
--- a/lib/features/policy_new/application/controllers/policy_query_override.dart
+++ b/lib/features/policy_new/application/controllers/policy_query_override.dart
@@ -18,8 +18,6 @@ class PolicyQueryOverrideNotifier
 
   final Ref ref;
 
-  String? _hash;
-
   PolicyFilterUiState applyFromDetail({
     required Policy policy,
     required PolicyReExploreMode mode,
@@ -32,20 +30,11 @@ class PolicyQueryOverrideNotifier
       filter,
       feedType: feedType,
     );
-    _hash = queryState.hash;
     state = PolicyQueryOverride(queryState: queryState);
     return filter;
   }
 
-  void ensureActiveForHash(String hash) {
-    if (_hash != null && _hash != hash) {
-      _hash = null;
-      state = null;
-    }
-  }
-
   void clear() {
-    _hash = null;
     state = null;
   }
 }

--- a/lib/features/policy_new/application/providers.dart
+++ b/lib/features/policy_new/application/providers.dart
@@ -472,10 +472,6 @@ final policyQueryProvider = Provider.family<PolicyQueryState, PolicyFeedType>(
       conditionSummary: conditionSummary,
     );
 
-    ref
-        .read(policyQueryOverrideProvider(feedType).notifier)
-        .ensureActiveForHash(baseState.hash);
-
     final overrideState = ref.watch(policyQueryOverrideProvider(feedType));
     if (overrideState != null &&
         overrideState.queryState.hash == baseState.hash) {

--- a/lib/features/policy_new/presentation/tabs/policy_feed_tab.dart
+++ b/lib/features/policy_new/presentation/tabs/policy_feed_tab.dart
@@ -4,10 +4,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../application/filters/policy_filter_ui_state.dart';
 import '../../application/filters/policy_search_keyword_provider.dart';
 import '../../application/controllers/global_filter_controller.dart';
+import '../../application/controllers/policy_query_state.dart';
 import '../../application/providers.dart';
 import '../../domain/values/policy_feed_type.dart';
 import '../../domain/values/policy_category.dart';
 import '../../domain/values/policy_status_filter.dart';
+import '../../application/controllers/policy_query_override.dart';
 import '../compare/widgets/compare_entry_bar.dart';
 import '../widgets/policy_feed_list_view.dart';
 import '../compare/policy_compare_screen.dart';
@@ -50,6 +52,21 @@ class _PolicyFeedTabState extends ConsumerState<PolicyFeedTab> {
         curve: Curves.easeOut,
       );
     });
+
+    ref.listen<PolicyQueryState>(
+      policyQueryProvider(widget.feedType),
+      (_, next) {
+        final override =
+            ref.read(policyQueryOverrideProvider(widget.feedType));
+        if (override == null) return;
+        if (override.queryState.hash == next.hash) return;
+
+        Future.microtask(() {
+          ref.read(policyQueryOverrideProvider(widget.feedType).notifier)
+              .clear();
+        });
+      },
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary
- remove synchronous clearing of policy query override during provider creation
- add feed tab listener to clear overrides asynchronously when the base query changes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69390a05e0088324b4f03d7c1ac6eda1)