### PR TITLE
Improve Kakao map location timeout and auth handling

### DIFF
--- a/lib/features/map_v2/kakao_map_controller.dart
+++ b/lib/features/map_v2/kakao_map_controller.dart
@@ -108,6 +108,17 @@ class KakaoMapMessage {
   String? get errorCode => payload['code']?.toString();
   String? get errorDetail => payload['detail']?.toString();
   String? get logMessage => payload['message']?.toString();
+
+  @override
+  String toString() {
+    return 'KakaoMapMessage(type: $type, '
+        'code: ${errorCode ?? payload['code']}, '
+        'level: ${logLevel ?? 'n/a'}, '
+        'message: ${logMessage ?? payload['message'] ?? payload['detail']}, '
+        'payload: $payload, '
+        'origin: ${origin ?? 'unknown'}, '
+        'timestamp: ${timestamp?.toIso8601String() ?? 'n/a'})';
+  }
 }
 
 /// ─────────────────────────────────────────────────────────────────────────────

--- a/lib/features/map_v2/kakao_map_screen.dart
+++ b/lib/features/map_v2/kakao_map_screen.dart
@@ -72,6 +72,8 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   bool _serviceGuideShown = false;
   ProviderSubscription<CurrentLocationState>? _locationSubscription;
   ProviderSubscription<YouthCenterMapState>? _centerErrorSubscription;
+  final Map<String, DateTime> _snackTimestamps = {};
+  static const _snackThrottle = Duration(seconds: 5);
 
   Timer? _moveDebounce;
   Timer? _tooltipTimer;
@@ -107,6 +109,10 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   Widget build(BuildContext context) {
     final centerState = ref.watch(youthCenterMapStateProvider);
     final debugPanelEnabled = ref.watch(debugPanelEnabledProvider);
+    final isAuthError = centerState.errorMessage
+            ?.contains('센터 인증 정보가 올바르지 않습니다') ??
+        false;
+    final retryHandler = isAuthError ? null : _retryLoadCenters;
 
     _cachedCenterPoints = centerState.filteredCenters;
 
@@ -147,15 +153,13 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
           ),
           if (_viewStatus == KakaoMapViewStatus.locating)
             _buildLocatingOverlay(),
-          if (_viewStatus == KakaoMapViewStatus.locationError)
-            _buildLocationErrorBanner(),
           if (_showLoadingOverlay && _viewStatus == KakaoMapViewStatus.mapReady)
             _buildLocatingOverlay(),
           if (_activeTooltipName != null)
             CenterMarkerTooltip(name: _activeTooltipName!),
           _buildCenterStatusOverlay(
             centerState,
-            onRetry: _retryLoadCenters,
+            onRetry: retryHandler,
           ),
           Positioned(
             left: 16,
@@ -170,7 +174,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
               onCenterTap: _onCenterCardTap,
               status: centerState.status,
               errorMessage: centerState.errorMessage,
-              onRetry: _retryLoadCenters,
+              onRetry: retryHandler,
             ),
           ),
         ],
@@ -192,62 +196,16 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     );
   }
 
-  Widget _buildLocationErrorBanner() {
-    return Positioned(
-      top: MediaQuery.of(context).padding.top + 12,
-      left: 16,
-      right: 16,
-      child: Material(
-        elevation: 4,
-        borderRadius: BorderRadius.circular(12),
-        color: Colors.red.withOpacity(0.9),
-        child: Padding(
-          padding: const EdgeInsets.all(12),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const Text(
-                '현재 위치를 불러올 수 없습니다.',
-                style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: 4),
-              const Text(
-                '기본 위치(경북 중심) 기준으로 지도를 표시합니다.',
-                style: TextStyle(color: Colors.white70),
-              ),
-              if (_errorCode != null) ...[
-                const SizedBox(height: 4),
-                Text(
-                  '오류 코드: $_errorCode',
-                  style: const TextStyle(color: Colors.white70, fontSize: 12),
-                ),
-              ],
-              if (_lastLog != null) ...[
-                const SizedBox(height: 4),
-                Text(
-                  '최근 로그: $_lastLog',
-                  style: const TextStyle(color: Colors.white70, fontSize: 11),
-                ),
-              ],
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
   Widget _buildCenterStatusOverlay(
     YouthCenterMapState centerState, {
     VoidCallback? onRetry,
   }) {
     final status = centerState.status;
     final shouldShow = status == YouthCenterMapStatus.loading ||
-        status == YouthCenterMapStatus.empty ||
-        status == YouthCenterMapStatus.error;
+        status == YouthCenterMapStatus.empty;
     final allowInteraction = status != YouthCenterMapStatus.loading;
 
-    final hasRetry =
-        status == YouthCenterMapStatus.error && onRetry != null;
+    final hasRetry = status == YouthCenterMapStatus.error && onRetry != null;
 
     String? message;
     switch (status) {
@@ -258,7 +216,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         message = '반경 20km 내 센터가 없습니다.';
         break;
       case YouthCenterMapStatus.error:
-        message = centerState.errorMessage ?? '센터 정보를 불러오지 못했습니다.';
+        message = null;
         break;
       case YouthCenterMapStatus.loaded:
       case YouthCenterMapStatus.initial:
@@ -331,6 +289,9 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
       currentLocationProvider,
       (previous, next) {
         if (next.location != null && !_locationResolved) {
+          debugPrint(
+            '[Map][Location] 위치 획득 성공 lat=${next.location!.lat}, lng=${next.location!.lng}',
+          );
           _locationResolved = true;
           _locationTimer?.cancel();
           _deviceLocation = next.location;
@@ -339,6 +300,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         }
 
         if (!next.isLoading && !_locationResolved) {
+          debugPrint('[Map][Location] 위치 요청 실패: ${next.error ?? 'unknown'}');
           _handleLocationIssues(next);
           if (next.error != null) {
             _locationResolved = true;
@@ -358,6 +320,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         final isAuthError = message != null &&
             message.contains('센터 인증 정보가 올바르지 않습니다');
         if (next.status == YouthCenterMapStatus.error && isAuthError) {
+          debugPrint('[Center][Auth] 인증 오류 감지: $message');
           _showAuthErrorOnce(message!);
         }
       },
@@ -367,6 +330,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   void _handleLocationIssues(CurrentLocationState state) {
     if (!mounted) return;
     if (state.serviceDisabled && !_serviceGuideShown) {
+      debugPrint('[Map][Location] 위치 서비스 비활성화 감지, 안내 표시');
       _serviceGuideShown = true;
       _showLocationPermissionGuide(LocationBottomSheetIssue.serviceDisabled);
       return;
@@ -377,8 +341,10 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     _lastPermissionIssue = state.permissionIssue;
 
     if (state.permissionIssue == LocationPermissionIssue.denied) {
+      debugPrint('[Map][Location] 권한 거부 감지, 안내 표시');
       _showLocationPermissionGuide(LocationBottomSheetIssue.permissionDenied);
     } else if (state.permissionIssue == LocationPermissionIssue.deniedForever) {
+      debugPrint('[Map][Location] 권한 영구 거부 감지, 안내 표시');
       _showLocationPermissionGuide(
         LocationBottomSheetIssue.permissionPermanentlyDenied,
       );
@@ -389,26 +355,23 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     if (_authErrorShown) return;
     _authErrorShown = true;
     if (!mounted) return;
-    showDialog(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('인증 오류'),
-        content: Text(message),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(),
-            child: const Text('확인'),
-          ),
-        ],
+    _showSnackOnce(
+      key: 'center-auth',
+      message: '센터 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.',
+      action: SnackBarAction(
+        label: '다시 시도',
+        onPressed: _retryLoadCenters,
       ),
     );
   }
 
   void _startLocationRequest() {
+    debugPrint('[Map][Location] 위치 요청 시작 (timeout=${_locationTimeout.inSeconds}s)');
     _locationTimer?.cancel();
     _locationTimer = Timer(_locationTimeout, () {
       if (!mounted) return;
       if (_locationResolved) return;
+      debugPrint('[Map][Location] 위치 요청 타임아웃 발생, 기본 위치로 이동');
       _locationResolved = true;
       _applyFallbackCenter(locationError: '위치 확인 시간이 초과되었습니다.');
     });
@@ -475,9 +438,14 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     await _applyNewCenter(fallback, animate: false);
 
     setState(() {
-      _viewStatus = KakaoMapViewStatus.locationError;
+      _viewStatus = _mapReady
+          ? KakaoMapViewStatus.markersReady
+          : KakaoMapViewStatus.mapReady;
       _errorCode = locationError;
+      _showLoadingOverlay = false;
     });
+
+    _showLocationFallbackNotice(locationError);
   }
 
   void _handleMarkerTap(String id) {
@@ -594,6 +562,15 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     }
   }
 
+  void _showLocationFallbackNotice(String? locationError) {
+    final detail = locationError != null ? ' ($locationError)' : '';
+    debugPrint('[Map][Location] 기본 위치로 대체 표시$detail');
+    _showSnackOnce(
+      key: 'location-fallback',
+      message: '현재 위치를 확인할 수 없어 기본 위치(경북 중심)로 표시합니다.',
+    );
+  }
+
   void _onWebViewReady() {
     final centerState = ref.read(youthCenterMapStateProvider);
     final nextStatus = centerState.isLoading
@@ -628,6 +605,31 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         _activeTooltipName = null;
       });
     });
+  }
+
+  void _showSnackOnce({
+    required String key,
+    required String message,
+    SnackBarAction? action,
+  }) {
+    final now = DateTime.now();
+    final lastShown = _snackTimestamps[key];
+    if (lastShown != null && now.difference(lastShown) < _snackThrottle) {
+      return;
+    }
+
+    _snackTimestamps[key] = now;
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+      ..removeCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(message),
+          duration: const Duration(seconds: 3),
+          action: action,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
   }
 
   void _showCenterDetailSheet({

--- a/lib/features/policy_new/presentation/map/youth_center_map_provider.dart
+++ b/lib/features/policy_new/presentation/map/youth_center_map_provider.dart
@@ -93,6 +93,7 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
     try {
       debugPrint('[YCMAP] 요청 시작 → center=(${center.lat}, ${center.lng}), '
           'radiusKm=$radiusKm');
+      debugPrint('[Center][Auth] 센터 목록 API 요청 시작');
       final markers = await _fetchAllCenterMarkers(center);
       final filtered = filterCentersWithinRadius(markers, center, radiusKm);
       final status = filtered.isEmpty
@@ -182,8 +183,10 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
     List<YouthCenterEntity> items;
     try {
       items = await repo.getCentersV2(pageSize: 300);
+      debugPrint('[Center][Auth] 센터 목록 API 응답 성공 count=${items.length}');
     } catch (error) {
       debugPrint('[YCMAP] ❌ API 실패 → 마커 캐시 사용 시도: $error');
+      debugPrint('[Center][Auth] 센터 목록 API 실패: $error');
       if (cachedMarkers.isNotEmpty) {
         debugPrint('[YCMAP] 캐시된 마커 반환 (${cachedMarkers.length}개)');
         return cachedMarkers;
@@ -275,6 +278,9 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
 
     if (error is YouthCenterApiException) {
       if (error.statusCode == 403 || error.statusCode == 401) {
+        debugPrint(
+          '[Center][Auth] 인증 오류 status=${error.statusCode}, message=${error.userMessage}',
+        );
         return '센터 인증 정보가 올바르지 않습니다. 잠시 후 다시 시도해주세요.';
       }
       if (!kDebugMode) return error.userMessage;


### PR DESCRIPTION
## Summary
- add structured KakaoMapMessage logging so code and payload details are visible
- change Kakao map location/auth error handling to use throttled snackbars while keeping the map interactive and falling back to the default center
- log center API auth flow and keep the map usable with cached or empty markers when requests fail

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69390a5beca88324ab64ffcac726d5a0)