### PR TITLE
Improve Kakao map location fallback and handle empty center responses

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,10 @@
     <!-- 인터넷 접근 권한 -->
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <!-- 위치 권한 (GPS) -->
+    <!-- 위치 권한 (GPS)
+         - ACCESS_FINE_LOCATION: 현재 위치 기반 서비스용 (Android 12 이하 maxSdkVersion 30 지정)
+         - ACCESS_COARSE_LOCATION: 저정확도 위치 허용 시 사용
+         - ACCESS_BACKGROUND_LOCATION: 백그라운드 위치 필요 시(센터 반경 계산 시 포그라운드 위주 사용) 선언 -->
     <uses-permission
         android:name="android.permission.ACCESS_FINE_LOCATION"
         android:maxSdkVersion="30" />

--- a/lib/env/app_env.dart
+++ b/lib/env/app_env.dart
@@ -1,6 +1,14 @@
 class AppEnv {
   // Flutter build 시, --dart-define 으로 전달된 값을 읽어옵니다.
   static const youthCenterApiKey = String.fromEnvironment('YOUTH_CENTER_KEY');
+  static const youthCenterApiBaseUrl = String.fromEnvironment(
+    'YOUTH_CENTER_API_BASE_URL',
+    defaultValue: 'https://www.youthcenter.go.kr/go/ythip',
+  );
+  static const youthCenterApiPath = String.fromEnvironment(
+    'YOUTH_CENTER_API_PATH',
+    defaultValue: '/getSpace',
+  );
   static const youthApiKey = String.fromEnvironment('YOUTH_API_KEY');
   static const kakaoMapApiKey = String.fromEnvironment('KAKAO_MAP_API_KEY');
   static const kakaoRestApiKey = String.fromEnvironment('KAKAO_REST_API_KEY');

--- a/lib/features/map_v2/current_location_provider.dart
+++ b/lib/features/map_v2/current_location_provider.dart
@@ -55,7 +55,10 @@ class CurrentLocationNotifier extends StateNotifier<CurrentLocationState> {
   final _permissionService = const LocationPermissionService();
 
   Future<void> fetch() async {
-    if (state.isLoading) return;
+    if (state.isLoading) {
+      debugPrint('[Location][INFO] 위치 요청이 이미 진행 중입니다. 중복 호출 무시');
+      return;
+    }
 
     state = state.copyWith(
       isLoading: true,
@@ -64,9 +67,12 @@ class CurrentLocationNotifier extends StateNotifier<CurrentLocationState> {
       serviceDisabled: false,
     );
 
+    debugPrint('[Location][INFO] 위치 요청 시작');
+
     try {
       final serviceEnabled = await _gpsService.isLocationServiceEnabled();
       if (!serviceEnabled) {
+        debugPrint('[Location][ERROR] 위치 서비스 비활성화 감지');
         state = state.copyWith(
           isLoading: false,
           serviceDisabled: true,
@@ -77,6 +83,7 @@ class CurrentLocationNotifier extends StateNotifier<CurrentLocationState> {
 
       final permissionResult = await _permissionService.ensurePermission();
       if (permissionResult != LocationPermissionIssue.granted) {
+        debugPrint('[Location][ERROR] 위치 권한 문제: $permissionResult');
         state = state.copyWith(
           isLoading: false,
           permissionIssue: permissionResult,
@@ -86,13 +93,14 @@ class CurrentLocationNotifier extends StateNotifier<CurrentLocationState> {
       }
 
       final position = await _gpsService.getCurrentPosition();
+      debugPrint('[Location][INFO] 위치 획득 성공 lat=${position.latitude}, lng=${position.longitude}');
       state = state.copyWith(
         isLoading: false,
         location: KakaoMapLatLng(position.latitude, position.longitude),
         error: null,
       );
     } catch (error, stack) {
-      debugPrint('[CurrentLocation] 위치 로드 실패: $error');
+      debugPrint('[Location][ERROR] 위치 로드 실패: $error');
       if (stack != null) debugPrint(stack.toString());
       state = state.copyWith(
         isLoading: false,

--- a/lib/features/map_v2/kakao_map_controller.dart
+++ b/lib/features/map_v2/kakao_map_controller.dart
@@ -484,9 +484,12 @@ class KakaoMapController {
         ),
       )
       ..setOnConsoleMessage(
-        (message) => debugPrint(
-          '[KAKAO_MAP_WEBVIEW][${message.level}] ${message.message}',
-        ),
+        (message) {
+          final levelTag = message.level == ConsoleMessageLevel.error
+              ? '[MapBridge][ERROR]'
+              : '[MapBridge][INFO]';
+          debugPrint('$levelTag ${message.message}');
+        },
       );
 
     if (controller.platform is AndroidWebViewController) {

--- a/lib/features/map_v2/kakao_map_html_builder.dart
+++ b/lib/features/map_v2/kakao_map_html_builder.dart
@@ -152,6 +152,12 @@ class KakaoMapHtmlBuilder {
     bool enableClustering = false,
     String? additionalScripts,
   }) {
+    final centerCount = markers.where((m) => m.id.startsWith('CENTER-')).length;
+    if (kDebugMode) {
+      debugPrint(
+        '[MapBridge][INFO] HTML build: center=(${center.lat}, ${center.lng}), radiusKm=${(searchRadiusMeters / 1000).toStringAsFixed(1)}, markers=${markers.length}, centerMarkers=$centerCount',
+      );
+    }
     final payload = {
       'center': center.toJson(),
       'markers': markers.map((e) => e.toJson()).toList(),
@@ -488,6 +494,23 @@ class KakaoMapHtmlBuilder {
       markers.forEach(function(m) { m.setMap(null); });
       markers = [];
       markerLookup = {};
+
+      if (!list || !list.length) {
+        console.log('[KakaoMap][INFO] 센터 0개 마커 렌더 요청: skip');
+        if (clusterer) {
+          try {
+            clusterer.clear();
+          } catch (e) {
+            console.log('[KakaoMap][ERROR] clusterer clear 실패', e);
+          }
+        }
+        return;
+      }
+
+      var centerMarkerCount = list.filter(function(m) {
+        return m.id && m.id.indexOf('CENTER-') === 0;
+      }).length;
+      console.log('[KakaoMap][INFO] 센터 ' + centerMarkerCount + '개 마커 렌더 시작 (total ' + list.length + ')');
 
       list.forEach(function(m) {
         var pos = new kakao.maps.LatLng(m.lat, m.lng);

--- a/lib/features/map_v2/kakao_map_screen.dart
+++ b/lib/features/map_v2/kakao_map_screen.dart
@@ -290,7 +290,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
       (previous, next) {
         if (next.location != null && !_locationResolved) {
           debugPrint(
-            '[Map][Location] 위치 획득 성공 lat=${next.location!.lat}, lng=${next.location!.lng}',
+            '[Location][INFO] 위치 획득 성공 lat=${next.location!.lat}, lng=${next.location!.lng}',
           );
           _locationResolved = true;
           _locationTimer?.cancel();
@@ -300,7 +300,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         }
 
         if (!next.isLoading && !_locationResolved) {
-          debugPrint('[Map][Location] 위치 요청 실패: ${next.error ?? 'unknown'}');
+          debugPrint('[Location][ERROR] 위치 요청 실패: ${next.error ?? 'unknown'}');
           _handleLocationIssues(next);
           if (next.error != null) {
             _locationResolved = true;
@@ -330,7 +330,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   void _handleLocationIssues(CurrentLocationState state) {
     if (!mounted) return;
     if (state.serviceDisabled && !_serviceGuideShown) {
-      debugPrint('[Map][Location] 위치 서비스 비활성화 감지, 안내 표시');
+      debugPrint('[Location][ERROR] 위치 서비스 비활성화 감지, 안내 표시');
       _serviceGuideShown = true;
       _showLocationPermissionGuide(LocationBottomSheetIssue.serviceDisabled);
       return;
@@ -341,10 +341,10 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     _lastPermissionIssue = state.permissionIssue;
 
     if (state.permissionIssue == LocationPermissionIssue.denied) {
-      debugPrint('[Map][Location] 권한 거부 감지, 안내 표시');
+      debugPrint('[Location][ERROR] 권한 거부 감지, 안내 표시');
       _showLocationPermissionGuide(LocationBottomSheetIssue.permissionDenied);
     } else if (state.permissionIssue == LocationPermissionIssue.deniedForever) {
-      debugPrint('[Map][Location] 권한 영구 거부 감지, 안내 표시');
+      debugPrint('[Location][ERROR] 권한 영구 거부 감지, 안내 표시');
       _showLocationPermissionGuide(
         LocationBottomSheetIssue.permissionPermanentlyDenied,
       );
@@ -366,12 +366,12 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   }
 
   void _startLocationRequest() {
-    debugPrint('[Map][Location] 위치 요청 시작 (timeout=${_locationTimeout.inSeconds}s)');
+    debugPrint('[Location][INFO] 위치 요청 시작 (timeout=${_locationTimeout.inSeconds}s)');
     _locationTimer?.cancel();
     _locationTimer = Timer(_locationTimeout, () {
       if (!mounted) return;
       if (_locationResolved) return;
-      debugPrint('[Map][Location] 위치 요청 타임아웃 발생, 기본 위치로 이동');
+      debugPrint('[Location][ERROR] 위치 요청 타임아웃 발생, 기본 위치로 이동');
       _locationResolved = true;
       _applyFallbackCenter(locationError: '위치 확인 시간이 초과되었습니다.');
     });
@@ -391,6 +391,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     bool animate = false,
     bool fromLocation = false,
   }) async {
+    debugPrint('[Location][INFO] 지도 중심 적용 lat=${center.lat}, lng=${center.lng}, fromLocation=$fromLocation');
     _mapCenter = center;
     _latestZoom = _locationZoomLevel;
     _deviceLocation = fromLocation ? center : _deviceLocation;
@@ -434,6 +435,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     if (!mounted) return;
     _locationTimer?.cancel();
     final fallback = _defaultCenter;
+    debugPrint('[Location][INFO] 위치 실패로 기본 좌표 사용: $fallback, error=$locationError');
 
     await _applyNewCenter(fallback, animate: false);
 
@@ -564,7 +566,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
 
   void _showLocationFallbackNotice(String? locationError) {
     final detail = locationError != null ? ' ($locationError)' : '';
-    debugPrint('[Map][Location] 기본 위치로 대체 표시$detail');
+    debugPrint('[Location][INFO] 기본 위치로 대체 표시$detail');
     _showSnackOnce(
       key: 'location-fallback',
       message: '현재 위치를 확인할 수 없어 기본 위치(경북 중심)로 표시합니다.',

--- a/lib/features/policy_new/data/sources/youthcenter/youth_center_remote_source.dart
+++ b/lib/features/policy_new/data/sources/youthcenter/youth_center_remote_source.dart
@@ -83,7 +83,13 @@ class YouthCenterRemoteSource {
       if (sggCd != null) 'sggCd': sggCd,
     };
 
-    const url = 'https://www.youthcenter.go.kr/go/ythip/getSpace';
+    final url = _buildYouthCenterUrl();
+    debugPrint(
+      '[Center][INFO] baseUrl=${AppEnv.youthCenterApiBaseUrl}, path=${AppEnv.youthCenterApiPath}',
+    );
+    debugPrint(
+      '[Center][INFO] query={pageNum:$pageNum,pageSize:$pageSize,ctpvCd:$ctpvCd,sggCd:$sggCd}',
+    );
     _logRequest(
       'GET',
       url,
@@ -110,6 +116,14 @@ class YouthCenterRemoteSource {
     return dto;
   }
 
+  String _buildYouthCenterUrl() {
+    final base = _normalizeBaseUrl(AppEnv.youthCenterApiBaseUrl);
+    final path = AppEnv.youthCenterApiPath.startsWith('/')
+        ? AppEnv.youthCenterApiPath
+        : '/${AppEnv.youthCenterApiPath}';
+    return '$base$path';
+  }
+
   Future<Response<T>> _safeRequest<T>(
     Future<Response<T>> Function() runRequest, {
     required String fallbackMessage,
@@ -122,6 +136,7 @@ class YouthCenterRemoteSource {
       _logDioError(e, stack);
       final status = e.response?.statusCode;
       final reason = e.response?.statusMessage ?? e.message;
+      debugPrint('[Center][ERROR] HTTP 실패 status=$status, message=$reason');
       throw YouthCenterApiException(
         userMessage: fallbackMessage,
         statusCode: status,
@@ -149,13 +164,12 @@ class YouthCenterRemoteSource {
   }
 
   void _logResponse(Response response) {
-    if (!kDebugMode) return;
-    debugPrint(
-      '[YOUTH_CENTER_API][RES] status=${response.statusCode} uri=${response.requestOptions.uri}',
-    );
+    debugPrint('[Center][INFO] 응답 status=${response.statusCode}');
+    debugPrint('[YOUTH_CENTER_API][RES] status=${response.statusCode} uri=${response.requestOptions.uri}');
   }
 
   void _logDioError(DioException e, StackTrace stack) {
+    debugPrint('[Center][ERROR] DioException status=${e.response?.statusCode}, message=${e.message}');
     if (!kDebugMode) return;
     final request = e.requestOptions;
     debugPrint('[YOUTH_CENTER_API][ERR] url=${request.uri}');

--- a/lib/features/policy_new/presentation/map/youth_center_map_provider.dart
+++ b/lib/features/policy_new/presentation/map/youth_center_map_provider.dart
@@ -82,6 +82,7 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
     required KakaoMapLatLng center,
     double radiusKm = kCenterRangeKm,
   }) async {
+    debugPrint('[Location][INFO] loadCenters() 호출 center=(${center.lat}, ${center.lng}), radiusKm=$radiusKm');
     state = state.copyWith(
       isLoading: true,
       center: center,
@@ -91,14 +92,13 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
     );
 
     try {
-      debugPrint('[YCMAP] 요청 시작 → center=(${center.lat}, ${center.lng}), '
-          'radiusKm=$radiusKm');
-      debugPrint('[Center][Auth] 센터 목록 API 요청 시작');
+      debugPrint('[Center][INFO] 센터 목록 API 요청 시작');
       final markers = await _fetchAllCenterMarkers(center);
       final filtered = filterCentersWithinRadius(markers, center, radiusKm);
       final status = filtered.isEmpty
           ? YouthCenterMapStatus.empty
           : YouthCenterMapStatus.loaded;
+      debugPrint('[Center][INFO] 필터링 결과=${filtered.length}개, status=$status');
       state = state.copyWith(
         allCenters: markers,
         filteredCenters: filtered,
@@ -109,10 +109,14 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
         status: status,
       );
     } catch (error, stack) {
-      debugPrint('[YCMAP] loadCenters failed: $error');
-      if (kDebugMode) {
-        debugPrint(stack.toString());
+      debugPrint('[Center][ERROR] 센터 불러오기 실패: $error');
+      if (error is YouthCenterApiException) {
+        debugPrint('[Center][ERROR] status=${error.statusCode}, reason=${error.reason}');
       }
+      if (error is DioException) {
+        debugPrint('[Center][ERROR] dio status=${error.response?.statusCode}, message=${error.message}');
+      }
+      if (kDebugMode) debugPrint(stack.toString());
       state = state.copyWith(
         isLoading: false,
         errorMessage: _buildUserMessage(error),
@@ -149,6 +153,7 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
     debugPrint('[YCMAP] Provider START');
     debugPrint('[YCMAP] center=(${center.lat}, ${center.lng})');
     debugPrint('[YCMAP] radius=${state.radiusKm}km');
+    debugPrint('[Center][INFO] 요청 좌표=(${center.lat}, ${center.lng}), radiusKm=${state.radiusKm}');
 
     final repo = _ref.read(youthCenterRepositoryProvider);
     final prefs = _ref.read(app_di.sharedPreferencesProvider);
@@ -184,6 +189,14 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
     try {
       items = await repo.getCentersV2(pageSize: 300);
       debugPrint('[Center][Auth] 센터 목록 API 응답 성공 count=${items.length}');
+    } on StateError catch (error, stack) {
+      debugPrint('[YCMAP] ⚠️ 빈 응답 → 캐시/빈 리스트 처리: $error');
+      if (kDebugMode) debugPrint(stack.toString());
+      if (cachedMarkers.isNotEmpty) {
+        debugPrint('[YCMAP] 캐시된 마커 반환 (${cachedMarkers.length}개)');
+        return cachedMarkers;
+      }
+      return const [];
     } catch (error) {
       debugPrint('[YCMAP] ❌ API 실패 → 마커 캐시 사용 시도: $error');
       debugPrint('[Center][Auth] 센터 목록 API 실패: $error');
@@ -196,6 +209,7 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
     debugPrint('[YCMAP] API success, item count=${items.length}');
 
     final result = <CenterMarkerPoint>[];
+    var firstLogged = false;
 
     for (final centerEntity in items) {
       final addr = centerEntity.address.trim();
@@ -252,6 +266,12 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
       final markerPoint = centerEntity.toMarkerPoint(lat: lat, lng: lng);
       result.add(markerPoint);
       debugPrint('[YCMAP] ✔ Marker prepared');
+      if (!firstLogged) {
+        debugPrint(
+          '[Center][INFO] 첫 센터 좌표 lat=$lat, lng=$lng, name=${centerEntity.centerName}',
+        );
+        firstLogged = true;
+      }
     }
 
     try {


### PR DESCRIPTION
## Summary
- 보장된 기본 좌표/오버레이 해제 흐름을 위해 위치 요청 로깅과 폴백 적용 로그를 강화했습니다.
- 청년센터 API 설정을 AppEnv 기반으로 명시하고 요청/응답/실패 정보를 [Center] 로그로 세분화했습니다.
- KakaoMap HTML 브리지에서 전달 데이터/마커 렌더링 상태를 로깅하고 빈 배열 처리 시 방어 코드를 추가했습니다.
- 청년센터 API 응답이 비어 있을 때 캐시 또는 빈 리스트로 복구해 지도 상태를 empty로 안전하게 마무리합니다.

## Testing
- Not run (환경에 Dart/Flutter tooling 부재)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69390f4ecfd483248e52da2e4ad1d706)