### PR TITLE
Improve policy compare zoom viewport

### DIFF
--- a/lib/features/policy_new/presentation/compare/policy_compare_screen.dart
+++ b/lib/features/policy_new/presentation/compare/policy_compare_screen.dart
@@ -1,7 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../compare/presentation/compare_tab.dart';
+import '../../compare/application/providers.dart';
+import '../../compare/domain/values/policy_failure.dart';
+import '../../compare/presentation/widgets/compare_empty_widget.dart';
+import '../../compare/presentation/widgets/compare_need_more_widget.dart';
+import '../detail/policy_detail_bottom_sheet.dart';
+import 'widgets/policy_compare_canvas.dart';
 
 /// 단독 화면으로 비교 UI를 띄울 때 사용하는 래퍼 스크린입니다.
 class PolicyCompareScreen extends ConsumerWidget {
@@ -9,11 +14,83 @@ class PolicyCompareScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final compareIds = ref.watch(compareRepositoryProvider).ids;
+    final state = ref.watch(compareFeedControllerProvider);
+    final controller = ref.read(compareFeedControllerProvider.notifier);
+    final compareController = ref.read(compareRepositoryProvider.notifier);
+
+    Widget body;
+    if (compareIds.isEmpty) {
+      body = const CompareEmptyWidget();
+    } else {
+      body = state.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, st) => _buildError(context, e, controller.load),
+        data: (data) {
+          if (compareIds.length == 1) {
+            return const CompareNeedMoreWidget();
+          }
+
+          if (data.policies.isEmpty) {
+            return const CompareEmptyWidget();
+          }
+
+          return PolicyCompareCanvas(
+            state: data,
+            onRemove: compareController.remove,
+            onClear: compareController.clear,
+            onOpenDetail: (policyId) => _openDetail(context, policyId),
+            onRefresh: controller.load,
+          );
+        },
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('정책 비교'),
       ),
-      body: const CompareTab(),
+      body: SafeArea(child: body),
+    );
+  }
+
+  Widget _buildError(
+    BuildContext context,
+    Object error,
+    VoidCallback onRetry,
+  ) {
+    final message = error is PolicyFailure ? error.message : error.toString();
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              '비교 정보를 불러오지 못했어요',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: onRetry,
+              child: const Text('다시 시도'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _openDetail(BuildContext context, String policyId) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => PolicyDetailBottomSheet(policyId: policyId),
     );
   }
 }

--- a/lib/features/policy_new/presentation/compare/widgets/policy_compare_canvas.dart
+++ b/lib/features/policy_new/presentation/compare/widgets/policy_compare_canvas.dart
@@ -1,0 +1,249 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../../../../compare/controllers/compare_diff_service.dart';
+import '../../../../compare/models/compare_state.dart';
+import '../../../../compare/presentation/widgets/compare_diff_table_widget.dart';
+import '../../../../compare/presentation/widgets/compare_header_row_widget.dart';
+import '../../../../compare/presentation/widgets/compare_summary_highlight.dart';
+import '../../../../compare/presentation/widgets/policy_compare_zoom_controls.dart';
+import '../../../../ui/components/horizontal_overflow_container.dart';
+import '../../../../ui/theme/app_spacing.dart';
+
+class PolicyCompareCanvas extends StatefulWidget {
+  const PolicyCompareCanvas({
+    super.key,
+    required this.state,
+    required this.onRemove,
+    required this.onClear,
+    required this.onOpenDetail,
+    required this.onRefresh,
+  });
+
+  final CompareState state;
+  final void Function(String) onRemove;
+  final VoidCallback onClear;
+  final void Function(String) onOpenDetail;
+  final VoidCallback onRefresh;
+
+  static const double _initialScale = 0.7;
+  static const double _minScale = 0.4;
+  static const double _maxScale = 2.0;
+  static const double _zoomStep = 0.1;
+
+  @override
+  State<PolicyCompareCanvas> createState() => _PolicyCompareCanvasState();
+}
+
+class _PolicyCompareCanvasState extends State<PolicyCompareCanvas> {
+  final HorizontalOverflowController _overflowController =
+      HorizontalOverflowController();
+  final TransformationController _transformationController =
+      TransformationController();
+  final GlobalKey _viewportKey = GlobalKey();
+  double _currentScale = PolicyCompareCanvas._initialScale;
+
+  @override
+  void initState() {
+    super.initState();
+    _resetZoom(useSetState: false);
+  }
+
+  @override
+  void didUpdateWidget(covariant PolicyCompareCanvas oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.state.policies.length != widget.state.policies.length) {
+      _resetZoom();
+    }
+  }
+
+  @override
+  void dispose() {
+    _transformationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = widget.state;
+    final service = CompareDiffService();
+    final labelWidth = service.labelWidth;
+    final mediaHeight = MediaQuery.of(context).size.height;
+    final viewportHeight = math.max(mediaHeight * 0.55, 360.0);
+
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              AppSpacing.lg,
+              AppSpacing.md,
+              AppSpacing.lg,
+              AppSpacing.sm,
+            ),
+            child: Row(
+              children: [
+                Text(
+                  '비교 중인 정책 ${state.policies.length}개',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const Spacer(),
+                IconButton(
+                  tooltip: '새로고침',
+                  onPressed: widget.onRefresh,
+                  icon: const Icon(Icons.refresh),
+                ),
+                TextButton.icon(
+                  onPressed: widget.onClear,
+                  icon: const Icon(Icons.delete_outline),
+                  label: const Text('모두 비우기'),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.lg,
+              vertical: AppSpacing.sm,
+            ),
+            child: CompareHeaderRowWidget(
+              policies: state.policies,
+              insights: state.insights,
+              onRemove: widget.onRemove,
+              onOpenDetail: widget.onOpenDetail,
+              labelWidth: labelWidth,
+              columnWidth: CompareDiffService.columnWidth,
+              overflowController: _overflowController,
+            ),
+          ),
+          const Divider(height: 1),
+          Padding(
+            padding: const EdgeInsets.only(top: AppSpacing.md),
+            child: SizedBox(
+              key: _viewportKey,
+              height: viewportHeight,
+              child: ClipRect(
+                child: Stack(
+                  children: [
+                    Positioned.fill(
+                      child: InteractiveViewer(
+                        transformationController: _transformationController,
+                        minScale: PolicyCompareCanvas._minScale,
+                        maxScale: PolicyCompareCanvas._maxScale,
+                        panEnabled: _currentScale > 1.0,
+                        scaleEnabled: true,
+                        clipBehavior: Clip.none,
+                        onInteractionUpdate: (_) => _syncScale(),
+                        onInteractionEnd: (_) => _syncScale(),
+                        child: SingleChildScrollView(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: AppSpacing.lg,
+                            vertical: AppSpacing.md,
+                          ),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              CompareSummaryHighlight(
+                                insights: state.insights,
+                              ),
+                              const SizedBox(height: AppSpacing.md),
+                              CompareDiffTableWidget(
+                                policies: state.policies,
+                                diffs: state.diffs,
+                                insights: state.insights,
+                                fields: service.fields,
+                                labelWidth: labelWidth,
+                                columnWidth: CompareDiffService.columnWidth,
+                                overflowController: _overflowController,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                    Positioned(
+                      right: AppSpacing.lg,
+                      top: AppSpacing.sm,
+                      child: PolicyCompareZoomControls(
+                        currentScale: _currentScale,
+                        minScale: PolicyCompareCanvas._minScale,
+                        maxScale: PolicyCompareCanvas._maxScale,
+                        onZoomIn: _handleZoomIn,
+                        onZoomOut: _handleZoomOut,
+                        onReset: _resetZoom,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _handleZoomIn() {
+    _updateScale(_currentScale + PolicyCompareCanvas._zoomStep);
+  }
+
+  void _handleZoomOut() {
+    _updateScale(_currentScale - PolicyCompareCanvas._zoomStep);
+  }
+
+  void _resetZoom({bool useSetState = true}) {
+    final apply = () {
+      _currentScale = PolicyCompareCanvas._initialScale;
+      _transformationController.value =
+          Matrix4.identity()..scale(PolicyCompareCanvas._initialScale);
+    };
+
+    if (useSetState) {
+      setState(apply);
+    } else {
+      apply();
+    }
+  }
+
+  void _syncScale() {
+    final scale = _transformationController.value.getMaxScaleOnAxis();
+    final clampedScale =
+        scale.clamp(PolicyCompareCanvas._minScale, PolicyCompareCanvas._maxScale);
+    if ((clampedScale - _currentScale).abs() > 0.001) {
+      setState(() {
+        _currentScale = clampedScale;
+      });
+    }
+  }
+
+  void _updateScale(double targetScale) {
+    final clampedScale = targetScale.clamp(
+      PolicyCompareCanvas._minScale,
+      PolicyCompareCanvas._maxScale,
+    );
+    final matrix = _transformationController.value.clone();
+    final currentScale = matrix.getMaxScaleOnAxis();
+    final baseMatrix = currentScale > 0 ? matrix : Matrix4.identity();
+    final factor = clampedScale / (currentScale > 0 ? currentScale : 1.0);
+
+    final renderBox =
+        _viewportKey.currentContext?.findRenderObject() as RenderBox?;
+    final viewportSize = renderBox?.size ?? context.size;
+    final focalPoint = viewportSize?.center(Offset.zero);
+
+    final updatedMatrix = focalPoint != null
+        ? (Matrix4.identity()
+              ..translate(focalPoint.dx, focalPoint.dy)
+              ..scale(factor)
+              ..translate(-focalPoint.dx, -focalPoint.dy))
+            .multiplied(baseMatrix)
+        : (baseMatrix.clone()..scale(factor));
+
+    setState(() {
+      _currentScale = clampedScale;
+      _transformationController.value = updatedMatrix;
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- replace compare tab wrapper with in-screen compare rendering using PolicyCompareCanvas
- add fixed-height compare canvas with InteractiveViewer-based zoom/pan controls synced with buttons
- clamp zoom scale updates and sync with on-screen controls, pinch gestures, and viewport-centered resets

## Testing
- Not run (environment not provided)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69390fbc7c488324adc5f171f7193eb3)