### PR TITLE
디버그 패널 토글 연결 및 오버레이 추가

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../core/constants/app_strings.dart';
 import '../theme/app_theme.dart';
 import 'providers/app_providers.dart';
+import '../debug/debug_panel_host.dart';
 
 class YouthRoadApp extends ConsumerWidget {
   const YouthRoadApp({super.key});
@@ -21,7 +22,7 @@ class YouthRoadApp extends ConsumerWidget {
 
       // 🔥 핵심 수정: DevtoolsOverlay 제거
       builder: (context, child) {
-        return child ?? const SizedBox.shrink();
+        return DebugPanelHost(child: child ?? const SizedBox.shrink());
       },
     );
   }

--- a/lib/debug/debug_panel_host.dart
+++ b/lib/debug/debug_panel_host.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'debug_button.dart';
+import 'debug_overlay.dart';
+import 'debug_settings_provider.dart';
+import 'debug_toast.dart';
+
+class DebugPanelHost extends ConsumerStatefulWidget {
+  const DebugPanelHost({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  ConsumerState<DebugPanelHost> createState() => _DebugPanelHostState();
+}
+
+class _DebugPanelHostState extends ConsumerState<DebugPanelHost> {
+  bool _overlayVisible = false;
+  late final ProviderSubscription<bool> _enabledSub;
+
+  @override
+  void initState() {
+    super.initState();
+    _enabledSub = ref.listen<bool>(debugPanelEnabledProvider, (prev, next) {
+      if (!next && _overlayVisible) {
+        setState(() {
+          _overlayVisible = false;
+        });
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _enabledSub.close();
+    super.dispose();
+  }
+
+  void _toggleOverlay(bool visible) {
+    setState(() {
+      _overlayVisible = visible;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!debugPanelFeatureAllowed) {
+      return widget.child;
+    }
+
+    final debugPanelEnabled = ref.watch(debugPanelEnabledProvider);
+
+    if (!debugPanelEnabled) {
+      return widget.child;
+    }
+
+    return Stack(
+      children: [
+        widget.child,
+        const DebugToastOverlay(),
+        if (_overlayVisible)
+          DebugOverlay(
+            onClose: () => _toggleOverlay(false),
+          ),
+        if (!_overlayVisible)
+          DebugButton(
+            onPressed: () => _toggleOverlay(true),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/debug/debug_settings_provider.dart
+++ b/lib/debug/debug_settings_provider.dart
@@ -1,10 +1,11 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../application/di.dart';
 
 const _debugPanelEnabledKey = 'debug_panel_enabled';
+const bool debugPanelFeatureAllowed =
+    bool.fromEnvironment('ENABLE_DEBUG_PANEL', defaultValue: true);
 
 class DebugPanelSettingsNotifier extends StateNotifier<bool> {
   DebugPanelSettingsNotifier(this._prefs) : super(_initialValue(_prefs));
@@ -12,15 +13,16 @@ class DebugPanelSettingsNotifier extends StateNotifier<bool> {
   final SharedPreferences _prefs;
 
   static bool _initialValue(SharedPreferences prefs) {
-    if (!kDebugMode) {
+    if (!debugPanelFeatureAllowed) {
       return false;
     }
     return prefs.getBool(_debugPanelEnabledKey) ?? false;
   }
 
   void setEnabled(bool value) {
-    if (!kDebugMode) {
+    if (!debugPanelFeatureAllowed) {
       state = false;
+      _prefs.setBool(_debugPanelEnabledKey, false);
       return;
     }
     state = value;

--- a/lib/ui/screens/setting/setting_screen.dart
+++ b/lib/ui/screens/setting/setting_screen.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -49,7 +48,7 @@ class SettingScreen extends ConsumerWidget {
               );
             },
           ),
-          if (kDebugMode)
+          if (debugPanelFeatureAllowed)
             SwitchListTile(
               title: const Text('디버그 패널 활성화'),
               subtitle: const Text('디버그 버튼 표시 여부를 전환합니다.'),


### PR DESCRIPTION
## Summary
- 환경 변수로 제어 가능한 디버그 패널 허용 플래그를 추가하고 SharedPreferences 기반 토글 상태를 유지하도록 설정 화면을 갱신했습니다.
- 앱 전역을 감싸는 `DebugPanelHost`를 도입해 탭 이동과 관계없이 플로팅 디버그 버튼과 오버레이가 노출되도록 했습니다.
- 패널이 비활성화될 때 오버레이가 즉시 닫히도록 상태를 동기화하여 토글 즉시 반영을 보장했습니다.

## Testing
- Not run (Flutter/Dart toolchain not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693912306c088324a08179e7705f7729)