### PR TITLE
Fix compare imports and map console message handling

### DIFF
--- a/lib/features/map_v2/kakao_map_controller.dart
+++ b/lib/features/map_v2/kakao_map_controller.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:webview_flutter_android/webview_flutter_android.dart';
 import 'package:webview_flutter_wkwebview/webview_flutter_wkwebview.dart';
+import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
 
 import 'kakao_map_html_builder.dart';
 

--- a/lib/features/policy_new/presentation/compare/policy_compare_screen.dart
+++ b/lib/features/policy_new/presentation/compare/policy_compare_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../compare/application/providers.dart';
-import '../../compare/domain/values/policy_failure.dart';
+import '../../application/providers.dart';
+import '../../domain/values/policy_failure.dart';
 import '../../compare/presentation/widgets/compare_empty_widget.dart';
 import '../../compare/presentation/widgets/compare_need_more_widget.dart';
 import '../detail/policy_detail_bottom_sheet.dart';

--- a/lib/features/policy_new/presentation/compare/widgets/policy_compare_canvas.dart
+++ b/lib/features/policy_new/presentation/compare/widgets/policy_compare_canvas.dart
@@ -2,14 +2,14 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
-import '../../../../compare/controllers/compare_diff_service.dart';
-import '../../../../compare/models/compare_state.dart';
-import '../../../../compare/presentation/widgets/compare_diff_table_widget.dart';
-import '../../../../compare/presentation/widgets/compare_header_row_widget.dart';
-import '../../../../compare/presentation/widgets/compare_summary_highlight.dart';
-import '../../../../compare/presentation/widgets/policy_compare_zoom_controls.dart';
-import '../../../../ui/components/horizontal_overflow_container.dart';
-import '../../../../ui/theme/app_spacing.dart';
+import 'package:youth_road_app/features/policy_new/compare/controllers/compare_diff_service.dart';
+import 'package:youth_road_app/features/policy_new/compare/models/compare_state.dart';
+import 'package:youth_road_app/features/policy_new/compare/presentation/widgets/compare_diff_table_widget.dart';
+import 'package:youth_road_app/features/policy_new/compare/presentation/widgets/compare_header_row_widget.dart';
+import 'package:youth_road_app/features/policy_new/compare/presentation/widgets/compare_summary_highlight.dart';
+import 'package:youth_road_app/features/policy_new/compare/presentation/widgets/policy_compare_zoom_controls.dart';
+import 'package:youth_road_app/ui/components/horizontal_overflow_container.dart';
+import 'package:youth_road_app/ui/theme/app_spacing.dart';
 
 class PolicyCompareCanvas extends StatefulWidget {
   const PolicyCompareCanvas({


### PR DESCRIPTION
## Summary
- Fix compare screen imports to reference existing providers and failure types
- Update policy compare canvas imports to valid compare widgets and shared UI modules
- Add missing webview console message level import for Kakao map controller

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693913c4afdc8324bf1ec182c0ce62a2)