### PR TITLE
Fix console message level check for Kakao map

### DIFF
--- a/lib/features/map_v2/kakao_map_controller.dart
+++ b/lib/features/map_v2/kakao_map_controller.dart
@@ -486,7 +486,7 @@ class KakaoMapController {
       )
       ..setOnConsoleMessage(
         (message) {
-          final levelTag = message.level == JavaScriptConsoleMessageLevel.error
+          final levelTag = message.level.name == 'error'
               ? '[MapBridge][ERROR]'
               : '[MapBridge][INFO]';
           debugPrint('$levelTag ${message.message}');


### PR DESCRIPTION
## Summary
- update Kakao map controller console logging to avoid missing enum reference

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939159782ec8324a9e10015a1df889a)