### PR TITLE
Refine explore tab provider interactions

### DIFF
--- a/lib/features/policy_new/application/explore/explore_providers.dart
+++ b/lib/features/policy_new/application/explore/explore_providers.dart
@@ -18,9 +18,19 @@ final exploreStateProvider =
 );
 
 class ExploreController extends StateNotifier<ExploreState> {
-  ExploreController(this.ref) : super(const ExploreState());
+  ExploreController(this.ref) : super(_initialState(ref));
 
   final Ref ref;
+
+  static ExploreState _initialState(Ref ref) {
+    final initialRegion = ref.read(regionProvider);
+    final hasSelection = initialRegion?.isNotEmpty ?? false;
+    final filterRegion = ref.read(globalFilterProvider).region;
+    final isRegional = hasSelection || filterRegion != PolicyRegion.all;
+    return ExploreState(
+      mode: isRegional ? ExploreSubMode.region : ExploreSubMode.all,
+    );
+  }
 
   void setMode(ExploreSubMode mode) {
     debugPrint('[Explore] setMode: $mode');

--- a/lib/features/policy_new/presentation/explore/policy_explore_screen.dart
+++ b/lib/features/policy_new/presentation/explore/policy_explore_screen.dart
@@ -42,22 +42,26 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
     final state = ref.read(exploreStateProvider);
     _searchController = TextEditingController(text: state.keyword);
 
-    final controller = ref.read(exploreStateProvider.notifier);
-    final initialRegion = ref.read(regionProvider);
-    controller.ensureRegionMode(hasSelection: initialRegion?.isNotEmpty ?? false);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final controller = ref.read(exploreStateProvider.notifier);
+      final initialRegion = ref.read(regionProvider);
+      controller.ensureRegionMode(hasSelection: initialRegion?.isNotEmpty ?? false);
+    });
 
     _regionSubscription = ref.listenManual<String?>(
       regionProvider,
       (previous, next) {
         final hasSelection = next?.isNotEmpty ?? false;
-        controller.ensureRegionMode(hasSelection: hasSelection);
+        ref
+            .read(exploreStateProvider.notifier)
+            .ensureRegionMode(hasSelection: hasSelection);
       },
     );
   }
 
   @override
   void dispose() {
-    _regionSubscription?.close();
+    _regionSubscription.close();
     _searchController.dispose();
     super.dispose();
   }
@@ -65,7 +69,6 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(exploreStateProvider);
-    final controller = ref.read(exploreStateProvider.notifier);
     final filterUi = ref.watch(globalFilterProvider);
     ref.watch(regionProvider);
     final regionNotifier = ref.read(regionProvider.notifier);
@@ -106,18 +109,20 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
                   _SearchBarRow(
                     keyword: keyword,
                     sortKind: sortKind,
-                    onKeywordChanged: controller.setKeyword,
-                    onSubmit: controller.setKeyword,
-                    onSortChanged: controller.setSortKind,
-                    onOpenFilterSheet: () =>
-                        _openFilterBottomSheet(context, controller, state),
+                    onKeywordChanged: (value) =>
+                        ref.read(exploreStateProvider.notifier).setKeyword(value),
+                    onSubmit: (value) =>
+                        ref.read(exploreStateProvider.notifier).setKeyword(value),
+                    onSortChanged: (value) =>
+                        ref.read(exploreStateProvider.notifier).setSortKind(value),
+                    onOpenFilterSheet: () => _openFilterBottomSheet(context),
                     textController: _searchController,
                   ),
                   const SizedBox(height: 12),
                   _QuickFilterChips(
                     statusFilter: statusFilter,
                     onToggleStatus: (value) =>
-                        controller.setStatusFilter(value),
+                        ref.read(exploreStateProvider.notifier).setStatusFilter(value),
                   ),
                   const SizedBox(height: 12),
                   _RegionDropdown(
@@ -136,9 +141,9 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
                   PolicyQuerySummary(
                     summary: summary,
                     conditionSummary: queryState.conditionSummary,
-                    onReset: controller.clearFilters,
-                    onTap: () =>
-                        _openFilterBottomSheet(context, controller, state),
+                    onReset: () =>
+                        ref.read(exploreStateProvider.notifier).clearFilters(),
+                    onTap: () => _openFilterBottomSheet(context),
                     showConditionSummary: false,
                   ),
                 ],
@@ -259,11 +264,7 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
     }
   }
 
-  void _openFilterBottomSheet(
-    BuildContext context,
-    ExploreController controller,
-    ExploreState state,
-  ) {
+  void _openFilterBottomSheet(BuildContext context) {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
@@ -366,7 +367,9 @@ class _PolicyExploreScreenState extends ConsumerState<PolicyExploreScreen> {
                         Expanded(
                           child: ElevatedButton(
                             onPressed: () {
-                              controller.setStatusFilter(tempStatus);
+                              ref
+                                  .read(exploreStateProvider.notifier)
+                                  .setStatusFilter(tempStatus);
                               final selectedCategory =
                                   tempCategories.isNotEmpty ? tempCategories.first : null;
                               final categoryEnum =


### PR DESCRIPTION
## Summary
- initialize the explore controller with an initial mode based on existing region selections and filters
- move region mode initialization to a post-frame callback and manage region listener cleanup explicitly
- update explore UI callbacks to read the notifier only in response to user actions and avoid build-time state changes

## Testing
- Not run (flutter/dart SDK unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693918dc8b94832487dfabe9d1274566)