### PR TITLE
카카오맵 위치/마커 동기화 및 도메인 설정 수정

### DIFF
--- a/lib/env/app_env.dart
+++ b/lib/env/app_env.dart
@@ -13,4 +13,10 @@ class AppEnv {
   static const kakaoMapApiKey = String.fromEnvironment('KAKAO_MAP_API_KEY');
   static const kakaoRestApiKey = String.fromEnvironment('KAKAO_REST_API_KEY');
   static const chatEndpoint = String.fromEnvironment('CHAT_ENDPOINT');
+
+  /// Kakao Map WebView baseUrl (카카오 콘솔 허용 도메인과 동일하게 설정 필요)
+  static const kakaoMapBaseUrl = String.fromEnvironment(
+    'KAKAO_MAP_BASE_URL',
+    defaultValue: 'https://www.gbyouth.co.kr',
+  );
 }

--- a/lib/features/map_v2/kakao_map_controller.dart
+++ b/lib/features/map_v2/kakao_map_controller.dart
@@ -198,6 +198,9 @@ class KakaoMapController {
   int _reloadAttempts = 0;
   _LoadRequest? _lastLoadRequest;
 
+  bool get hasApiKey => _apiKey.isNotEmpty;
+  String get apiKeyPreview => _maskApiKey(_apiKey);
+
   Stream<KakaoMapEvent> get events => _eventController.stream;
   bool get isReady => _ready;
   int get reloadAttempts => _reloadAttempts;
@@ -415,6 +418,9 @@ class KakaoMapController {
   /// ---------------------------------------------------------------------------
   void _logApiKey() {
     final masked = _maskApiKey(_apiKey);
+    if (_apiKey.isEmpty) {
+      debugPrint('[Map][ERROR] KakaoMap API Key 가 비어 있습니다. --dart-define=KAKAO_MAP_API_KEY 값을 확인하세요.');
+    }
     debugPrint('[KAKAO_MAP_WEBVIEW] Using KakaoMap API Key: $masked');
   }
 
@@ -490,6 +496,17 @@ class KakaoMapController {
               ? '[MapBridge][ERROR]'
               : '[MapBridge][INFO]';
           debugPrint('$levelTag ${message.message}');
+          final log = KakaoMapMessage(
+            type: 'log',
+            payload: {
+              'message': message.message,
+              'level': message.level.name,
+            },
+            logLevel: message.level.name,
+            origin: 'kakao-map-js',
+            timestamp: DateTime.now(),
+          );
+          _eventController.add(KakaoMapEvent(KakaoMapEventType.log, log));
         },
       );
 

--- a/lib/features/map_v2/kakao_map_providers.dart
+++ b/lib/features/map_v2/kakao_map_providers.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../core/constants/env.dart';
+import '../../env/app_env.dart';
 import 'kakao_map_controller.dart';
 import 'kakao_map_html_builder.dart';
 
@@ -23,8 +23,9 @@ final kakaoMapEnableClusteringProvider = Provider<bool>(
 final kakaoMapControllerProvider = Provider.autoDispose<KakaoMapController>((ref) {
   final builder = ref.watch(kakaoMapHtmlBuilderProvider);
   final controller = KakaoMapController(
-    apiKey: Env.kakaoMapApiKey,
+    apiKey: AppEnv.kakaoMapApiKey,
     builder: builder,
+    baseUrl: AppEnv.kakaoMapBaseUrl,
   );
   ref.onDispose(controller.dispose);
   return controller;

--- a/lib/features/map_v2/kakao_map_screen.dart
+++ b/lib/features/map_v2/kakao_map_screen.dart
@@ -213,7 +213,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         message = '주변 센터 정보를 불러오는 중입니다.';
         break;
       case YouthCenterMapStatus.empty:
-        message = '반경 20km 내 센터가 없습니다.';
+        message = '반경 20km 내 센터가 없습니다. 가장 가까운 센터 3곳을 보여드려요.';
         break;
       case YouthCenterMapStatus.error:
         message = null;
@@ -224,7 +224,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     }
 
     return IgnorePointer(
-      ignoring: !allowInteraction,
+      ignoring: allowInteraction,
       child: AnimatedOpacity(
         opacity: shouldShow ? 1 : 0,
         duration: const Duration(milliseconds: 200),
@@ -396,8 +396,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     _latestZoom = _locationZoomLevel;
     _deviceLocation = fromLocation ? center : _deviceLocation;
 
-    final notifier = ref.read(youthCenterMapStateProvider.notifier);
-    await notifier.loadCenters(center: center, radiusKm: _currentRadius);
+    await _refreshCentersFor(center, forceFetch: true);
 
     setState(() {
       _viewStatus = _mapReady
@@ -407,7 +406,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     });
 
     await _moveMap(center, level: _locationZoomLevel, animate: animate);
-    await _updateSearchCircle(_effectiveCircleCenter);
+    await _updateSearchCircle(_mapCenter);
   }
 
   Future<void> _retryLoadCenters() async {
@@ -416,12 +415,11 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
       _showLoadingOverlay = true;
     });
 
-    final notifier = ref.read(youthCenterMapStateProvider.notifier);
     final searchCenter = _deviceLocation ?? _mapCenter;
-    await notifier.loadCenters(center: searchCenter, radiusKm: _currentRadius);
+    await _refreshCentersFor(searchCenter, forceFetch: true);
 
     if (!mounted) return;
-    await _updateSearchCircle(_effectiveCircleCenter);
+    await _updateSearchCircle(_mapCenter);
 
     setState(() {
       _showLoadingOverlay = false;
@@ -448,6 +446,28 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
     });
 
     _showLocationFallbackNotice(locationError);
+  }
+
+  Future<void> _refreshCentersFor(
+    KakaoMapLatLng center, {
+    bool forceFetch = false,
+  }) async {
+    final notifier = ref.read(youthCenterMapStateProvider.notifier);
+    final state = ref.read(youthCenterMapStateProvider);
+    final shouldFetch =
+        forceFetch || state.allCenters.isEmpty || state.status == YouthCenterMapStatus.error;
+
+    debugPrint(
+      '[Map][INFO] 중심 좌표 기준 센터 갱신 요청 center=(${center.lat}, ${center.lng}), '
+      'radiusKm=$_currentRadius, fetch=$shouldFetch',
+    );
+
+    if (shouldFetch) {
+      await notifier.loadCenters(center: center, radiusKm: _currentRadius);
+      return;
+    }
+
+    notifier.updateCenter(center, radiusKm: _currentRadius);
   }
 
   void _handleMarkerTap(String id) {
@@ -500,6 +520,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   }
 
   void _handleMapMoved(KakaoMapLatLng center, int zoom) {
+    debugPrint('[Map][INFO] onMapMoved lat=${center.lat}, lng=${center.lng}, zoom=$zoom');
     _latestCenterFromMove = center;
     _latestZoom = zoom;
     _moveDebounce?.cancel();
@@ -509,6 +530,7 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
   Future<void> _onMapIdle() async {
     final target = _latestCenterFromMove;
     if (target == null) return;
+    debugPrint('[Map][INFO] map idle reached, center=(${target.lat}, ${target.lng}), zoom=$_latestZoom');
     setState(() {
       _mapCenter = target;
       _viewStatus = _mapReady
@@ -516,9 +538,9 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
           : KakaoMapViewStatus.mapReady;
     });
     _latestCenterFromMove = null;
+    await _refreshCentersFor(target);
+    await _updateSearchCircle(target);
   }
-
-  KakaoMapLatLng? get _effectiveCircleCenter => _deviceLocation ?? _mapCenter;
 
   Future<void> _moveMap(
     KakaoMapLatLng location, {
@@ -585,8 +607,15 @@ class _KakaoMapScreenState extends ConsumerState<KakaoMapScreen> {
         _viewStatus = nextStatus;
       }
     });
+    debugPrint('[Map][INFO] WebView ready, updating overlays and position markers');
     if (_locationResolved) {
-      _updateSearchCircle(_effectiveCircleCenter);
+      _updateSearchCircle(_mapCenter);
+    }
+    final controller = ref.read(kakaoMapControllerProvider);
+    if (_deviceLocation != null) {
+      controller.showMyPosition(_deviceLocation!);
+    } else {
+      controller.showMyPosition(_mapCenter);
     }
   }
 

--- a/lib/features/map_v2/kakao_map_webview.dart
+++ b/lib/features/map_v2/kakao_map_webview.dart
@@ -118,7 +118,17 @@ class _KakaoMapWebViewState extends ConsumerState<KakaoMapWebView> {
     _safeSetLoading(true);
 
     _scheduleReadyTimeout();
-    _safeLog('map load start');
+    _safeLog(
+      '[Map][INFO] map load start center=(${widget.center.lat}, ${widget.center.lng}), key=${_controller.apiKeyPreview}',
+    );
+
+    if (!_controller.hasApiKey) {
+      _safeLog('[Map][ERROR] KakaoMap API Key 가 없습니다. --dart-define 설정을 확인하세요.');
+      _safeSetLoading(false);
+      _safeMarkFatalError();
+      _safeCallback(() => widget.onError?.call('API_KEY_EMPTY'));
+      return;
+    }
 
     _controller
         .load(

--- a/lib/features/policy_new/presentation/map/youth_center_map_provider.dart
+++ b/lib/features/policy_new/presentation/map/youth_center_map_provider.dart
@@ -95,13 +95,18 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
       debugPrint('[Center][INFO] 센터 목록 API 요청 시작');
       final markers = await _fetchAllCenterMarkers(center);
       final filtered = filterCentersWithinRadius(markers, center, radiusKm);
+      final nearestFallback = filtered.isEmpty && markers.isNotEmpty
+          ? nearestCenters(markers, center, limit: 3)
+          : filtered;
       final status = filtered.isEmpty
           ? YouthCenterMapStatus.empty
           : YouthCenterMapStatus.loaded;
-      debugPrint('[Center][INFO] 필터링 결과=${filtered.length}개, status=$status');
+      debugPrint(
+        '[Center][INFO] 필터링 결과=${filtered.length}개, fallback=${nearestFallback.length}개, status=$status',
+      );
       state = state.copyWith(
         allCenters: markers,
-        filteredCenters: filtered,
+        filteredCenters: nearestFallback,
         isLoading: false,
         center: center,
         radiusKm: radiusKm,
@@ -135,10 +140,16 @@ class YouthCenterMapNotifier extends StateNotifier<YouthCenterMapState> {
     final effectiveRadius = radiusKm ?? state.radiusKm;
     final filtered =
         filterCentersWithinRadius(state.allCenters, center, effectiveRadius);
+    final nearestFallback = filtered.isEmpty && state.allCenters.isNotEmpty
+        ? nearestCenters(state.allCenters, center, limit: 3)
+        : filtered;
+    if (filtered.isEmpty) {
+      debugPrint('[Center][INFO] 반경 내 센터 없음 → 가장 가까운 3곳 반환');
+    }
     state = state.copyWith(
       center: center,
       radiusKm: effectiveRadius,
-      filteredCenters: filtered,
+      filteredCenters: nearestFallback,
       errorMessage: null,
       status: filtered.isEmpty
           ? YouthCenterMapStatus.empty
@@ -340,6 +351,22 @@ List<CenterMarkerPoint> filterCentersWithinRadius(
       'after: ${filtered.length})');
 
   return filtered;
+}
+
+List<CenterMarkerPoint> nearestCenters(
+  List<CenterMarkerPoint> all,
+  KakaoMapLatLng center, {
+  int limit = 3,
+}) {
+  if (all.isEmpty || limit <= 0) return const [];
+  final sorted = [...all]
+    ..sort(
+      (a, b) => distanceInMeters(center, KakaoMapLatLng(a.lat, a.lng))
+          .compareTo(distanceInMeters(center, KakaoMapLatLng(b.lat, b.lng))),
+    );
+  final candidates = sorted.take(limit).toList();
+  debugPrint('[Map][INFO] 가장 가까운 센터 ${candidates.length}개 반환');
+  return candidates;
 }
 
 double distanceInMeters(KakaoMapLatLng a, KakaoMapLatLng b) {


### PR DESCRIPTION
## Summary
- Kakao Map base URL 환경 변수를 추가하고 WebView에 적용해 키/도메인 설정을 명시했습니다.
- Kakao WebView 로깅을 강화하고 API 키 누락 시 즉시 오류를 보고하도록 수정했습니다.
- 지도 이동·위치 실패 상황에서 20km 반경 서클과 센터 마커를 갱신하고, 반경 내 센터가 없을 때는 가까운 3곳을 보여주도록 보완했습니다.

## Testing
- Not run (Flutter/Dart SDK 미설치 환경)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69391909061883248d6682463007652c)