### PR TITLE
Fix explore feed searchRgnSe mapping

### DIFF
--- a/lib/features/policy_new/application/controllers/policy_query_orchestrator.dart
+++ b/lib/features/policy_new/application/controllers/policy_query_orchestrator.dart
@@ -170,33 +170,14 @@ class PolicyQueryOrchestrator {
     return category;
   }
 
-  String? _resolveExploreSearchRegion(PolicyRegion region) {
+  String _resolveExploreSearchRegion(PolicyRegion region) {
     final notifier = ref.read(regionProvider.notifier);
-    final city = _normalizeRegionSegment(notifier.selectedCity);
-    final district = _normalizeRegionSegment(notifier.selectedDistrict);
 
-    if (city != null && city.isNotEmpty) {
-      if (district != null && district.isNotEmpty) {
-        return '$city|$district';
-      }
-      return city;
-    }
-
-    if (region == PolicyRegion.all) return null;
-
-    if (region == PolicyRegion.gyeongbuk) {
-      final province = notifier.selectedProvince.trim();
-      if (province.isNotEmpty) return province;
-    }
-
-    return _displayRegionName(region);
-  }
-
-  String? _normalizeRegionSegment(String? value) {
-    if (value == null) return null;
-    final trimmed = value.trim();
-    if (trimmed.isEmpty || trimmed == '전체') return null;
-    return trimmed;
+    return mapSearchRgnSe(
+      region,
+      city: notifier.selectedCity,
+      district: notifier.selectedDistrict,
+    );
   }
 
   String _provinceName(PolicyRegion region, {required String fallback}) {
@@ -222,26 +203,4 @@ class PolicyQueryOrchestrator {
     }
   }
 
-  String _displayRegionName(PolicyRegion region) {
-    switch (region) {
-      case PolicyRegion.all:
-        return '전국';
-      case PolicyRegion.seoul:
-        return '서울';
-      case PolicyRegion.busan:
-        return '부산';
-      case PolicyRegion.daegu:
-        return '대구';
-      case PolicyRegion.incheon:
-        return '인천';
-      case PolicyRegion.gwangju:
-        return '광주';
-      case PolicyRegion.daejeon:
-        return '대전';
-      case PolicyRegion.ulsan:
-        return '울산';
-      case PolicyRegion.gyeongbuk:
-        return '경상북도';
-    }
-  }
 }

--- a/lib/features/policy_new/application/filters/policy_filter_ui_state.dart
+++ b/lib/features/policy_new/application/filters/policy_filter_ui_state.dart
@@ -9,6 +9,33 @@ import '../../domain/values/policy_status_filter.dart';
 import '../reexplore/policy_reexplore.dart';
 import '../../../../application/notifiers/region_notifier.dart';
 
+String mapSearchRgnSe(
+  PolicyRegion region, {
+  String? city,
+  String? district,
+}) {
+  final normalizedCity = _normalizeSearchRegionSegment(city);
+  final normalizedDistrict = _normalizeSearchRegionSegment(district);
+
+  if (normalizedDistrict != null && normalizedDistrict.isNotEmpty) {
+    return normalizedDistrict;
+  }
+
+  if (normalizedCity != null && normalizedCity.isNotEmpty) {
+    return normalizedCity;
+  }
+
+  if (region == PolicyRegion.all) return '';
+  return '';
+}
+
+String? _normalizeSearchRegionSegment(String? value) {
+  if (value == null) return null;
+  final trimmed = value.trim();
+  if (trimmed.isEmpty || trimmed == '전체') return null;
+  return trimmed;
+}
+
 @immutable
 class PolicyFilterUiState {
   final PolicyRegion region;

--- a/lib/features/policy_new/data/repositories/policy_repository_impl.dart
+++ b/lib/features/policy_new/data/repositories/policy_repository_impl.dart
@@ -61,7 +61,7 @@ class PolicyRepositoryImpl implements PolicyRepository {
       normalizedFilter,
       explore: isExploreFeed,
     );
-    if (regionValue != null && regionValue.isNotEmpty) {
+    if (regionValue != null) {
       params['searchRgnSe'] = regionValue;
     }
 
@@ -104,6 +104,9 @@ class PolicyRepositoryImpl implements PolicyRepository {
 
   void _sanitizeParams(Map<String, dynamic> params) {
     params.removeWhere((key, value) {
+      if (key == 'searchRgnSe') {
+        return value == null;
+      }
       if (value == null) return true;
       if (value is String) {
         final trimmed = value.trim();
@@ -520,11 +523,28 @@ class PolicyRepositoryImpl implements PolicyRepository {
         ? PolicyStatusFilter.inProgressOnly
         : filter.status;
     final sanitizedCategory = _sanitizeCategoryForExplore(filter.category);
+    final mappedSearchRgnSe = _mapSearchRgnSeForExplore(filter);
 
     return filter.copyWith(
       status: sanitizedStatus,
       category: sanitizedCategory,
+      searchRgnSe: mappedSearchRgnSe,
     );
+  }
+
+  String _mapSearchRgnSeForExplore(PolicyFilter filter) {
+    final city = _normalizeRegionSegment(filter.city);
+    final district = _normalizeRegionSegment(filter.district);
+
+    if (district != null && district.isNotEmpty) {
+      return district;
+    }
+
+    if (city != null && city.isNotEmpty) {
+      return city;
+    }
+
+    return '';
   }
 
   PolicyCategory? _sanitizeCategoryForExplore(PolicyCategory? category) {
@@ -563,13 +583,16 @@ class PolicyRepositoryImpl implements PolicyRepository {
 
   String? _regionParam(PolicyFilter filter, {bool explore = false}) {
     if (explore) {
-      final explicit = _normalizeRegionSegment(filter.searchRgnSe);
+      final explicit = _normalizeRegionSegment(
+        filter.searchRgnSe,
+        allowEmpty: true,
+      );
       if (explicit != null) {
         return explicit;
       }
     }
-    final city = filter.city?.trim();
-    final district = filter.district?.trim();
+    final city = _normalizeRegionSegment(filter.city);
+    final district = _normalizeRegionSegment(filter.district);
 
     if (city != null && city.isNotEmpty) {
       if (district != null && district.isNotEmpty) {
@@ -589,10 +612,12 @@ class PolicyRepositoryImpl implements PolicyRepository {
     return null;
   }
 
-  String? _normalizeRegionSegment(String? value) {
+  String? _normalizeRegionSegment(String? value, {bool allowEmpty = false}) {
     if (value == null) return null;
     final trimmed = value.trim();
-    if (trimmed.isEmpty || trimmed == '전체') return null;
+    if (trimmed.isEmpty || trimmed == '전체') {
+      return allowEmpty && trimmed.isEmpty ? '' : null;
+    }
     return trimmed;
   }
 


### PR DESCRIPTION
## Summary
- map explore filter regions to searchRgnSe so provinces/all send an empty string while city selections send the city name
- sanitize explore queries in the repository to apply the new mapping and retain searchRgnSe parameters even when empty

## Testing
- dart format lib/features/policy_new/application/filters/policy_filter_ui_state.dart lib/features/policy_new/application/controllers/policy_query_orchestrator.dart lib/features/policy_new/data/repositories/policy_repository_impl.dart (fails: dart command unavailable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939f6948f888324bdfe5785e5b11224)