### PR TITLE
Fix explore filters status and region mapping

### DIFF
--- a/lib/features/policy_new/application/filters/policy_filter_ui_state.dart
+++ b/lib/features/policy_new/application/filters/policy_filter_ui_state.dart
@@ -169,9 +169,13 @@ class PolicyFilterUiStateNotifier extends StateNotifier<PolicyFilterUiState> {
   void toggleOnlineOnly() =>
       state = state.copyWith(showOnlyOnline: !state.showOnlyOnline);
 
-  void setStatus(PolicyStatusFilter status) => state = state.copyWith(
-        status: status,
-      );
+  void setStatus(PolicyStatusFilter status) {
+    if (state.status == status) return;
+
+    state = state.copyWith(
+      status: status,
+    );
+  }
 
   void setInstitution({String? id, String? name}) => state = state.copyWith(
         institutionId: id,

--- a/lib/features/policy_new/data/repositories/policy_repository_impl.dart
+++ b/lib/features/policy_new/data/repositories/policy_repository_impl.dart
@@ -65,10 +65,8 @@ class PolicyRepositoryImpl implements PolicyRepository {
       params['searchRgnSe'] = regionValue;
     }
 
-    final statusValue = normalizedFilter.status == PolicyStatusFilter.includeClosed
-        ? null
-        : normalizedFilter.status.queryValue;
-    if (statusValue != null && statusValue.isNotEmpty) {
+    final statusValue = _mapStatusParam(normalizedFilter.status);
+    if (statusValue != null) {
       params['status'] = statusValue;
     }
 
@@ -104,7 +102,7 @@ class PolicyRepositoryImpl implements PolicyRepository {
 
   void _sanitizeParams(Map<String, dynamic> params) {
     params.removeWhere((key, value) {
-      if (key == 'searchRgnSe') {
+      if (key == 'status' || key == 'searchRgnSe') {
         return value == null;
       }
       if (value == null) return true;
@@ -514,25 +512,57 @@ class PolicyRepositoryImpl implements PolicyRepository {
   PolicyQuery _sanitizeQueryForExplore(PolicyQuery query) {
     if (!_isExploreFeed(query.feedType)) return query;
 
-    final sanitizedFilter = _sanitizeFilterForExplore(query.filter);
+    final sanitizedFilter =
+        _sanitizeFilterForExplore(query.filter, feedType: query.feedType);
     return query.copyWith(filter: sanitizedFilter);
   }
 
-  PolicyFilter _sanitizeFilterForExplore(PolicyFilter filter) {
-    final sanitizedStatus = filter.status == PolicyStatusFilter.includeClosed
-        ? PolicyStatusFilter.inProgressOnly
-        : filter.status;
+  String? _mapStatusParam(PolicyStatusFilter status) {
+    switch (status) {
+      case PolicyStatusFilter.includeClosed:
+        return '';
+      case PolicyStatusFilter.inProgressOnly:
+        return 'inProgress';
+      case PolicyStatusFilter.closedOnly:
+        return 'closed';
+    }
+  }
+
+  PolicyFilter _sanitizeFilterForExplore(
+    PolicyFilter filter, {
+    required PolicyFeedType feedType,
+  }) {
     final sanitizedCategory = _sanitizeCategoryForExplore(filter.category);
-    final mappedSearchRgnSe = _mapSearchRgnSeForExplore(filter);
+    final mappedSearchRgnSe = _mapSearchRgnSeForExplore(filter, feedType);
 
     return filter.copyWith(
-      status: sanitizedStatus,
+      status: filter.status,
       category: sanitizedCategory,
       searchRgnSe: mappedSearchRgnSe,
     );
   }
 
-  String _mapSearchRgnSeForExplore(PolicyFilter filter) {
+  String _mapSearchRgnSeForExplore(
+    PolicyFilter filter,
+    PolicyFeedType feedType,
+  ) {
+    final normalizedExplicit = _normalizeRegionSegment(
+      filter.searchRgnSe,
+      allowEmpty: true,
+    );
+
+    if (normalizedExplicit != null) {
+      return normalizedExplicit;
+    }
+
+    if (feedType == PolicyFeedType.region) {
+      return 'region';
+    }
+
+    if (feedType == PolicyFeedType.all) {
+      return '';
+    }
+
     final city = _normalizeRegionSegment(filter.city);
     final district = _normalizeRegionSegment(filter.district);
 


### PR DESCRIPTION
## Summary
- update explore status and search region parameter mapping to align with API expectations
- ensure status changes do not trigger duplicate fetches when unchanged
- improve sanitized parameter handling and logging for explore queries

## Testing
- Not run (Dart/Flutter toolchain unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939fa3adcd483249cf49a6b084fef1e)